### PR TITLE
Restore requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+python-dotenv>=0.12
+PyYAML>=5.3
+yamlordereddictloader>0.4
+
+matplotlib==3.1.3
+more-itertools==8.2.0
+numpy==1.18.1
+pandas==1.0.1
+seaborn==0.10.0


### PR DESCRIPTION
The requirements file was accidentally overwritten. Restore the previous version (without the standard library modules listed).

This should be the state before 8fe8d4a20013c757a4c9fe2d7024c3c8c093bfc0.