### PR TITLE
Allow np.linspace in _parse_config_parameter

### DIFF
--- a/runScenarios.py
+++ b/runScenarios.py
@@ -43,6 +43,11 @@ def _parse_config_parameter(df, parameter, parameter_function, column_name):
         params = getattr(np.random, parameter_function['np.random'])(**{"size": 1, **function_kwargs})
         result = _get_full_factorial_df(df, column_name, params)
         return result
+    elif 'np' in parameter_function:
+        function_kwargs = parameter_function['function_kwargs']
+        params = getattr(np, parameter_function['np'])(**{"num": 1, **function_kwargs})
+        result = _get_full_factorial_df(df, column_name, params)
+        return result
     elif 'custom_function' in parameter_function:
         function_name = parameter_function['custom_function']
         function_kwargs = parameter_function['function_kwargs']


### PR DESCRIPTION
With this pull request, you can use `np.linspace` to generate the parameter values.

To get just one value, you can put in something like this (using `backtonormal_multiplier` as an example):

```yaml
  'backtonormal_multiplier':
    np: linspace
    function_kwargs: {'start': 0.1, 'stop': 0.3}
```

For multiple values, add `num` in the kwargs:

```yaml
  'backtonormal_multiplier':
    np: linspace
    function_kwargs: {'start': 0.1, 'stop': 0.3, 'num': 3}
```

@ManuelaRunge Please verify if this works on your end.