### PR TITLE
fixed time to detection and recovery time for mild symptomatic cases

### DIFF
--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -67,7 +67,8 @@ sampled_parameters:
     function_kwargs: {'low':1.0, 'high':6.0}
   'time_to_detection_Sym':
     np.random: uniform
-    function_kwargs: {'low':2.0, 'high':5.0}
+    function_kwargs: {'low':7.0, 'high':7.0}
+    #function_kwargs: {'low':2.0, 'high':5.0}
   'time_to_detection_Sys':
     np.random: uniform
     function_kwargs: {'low':2.0, 'high':2.0}
@@ -77,7 +78,8 @@ sampled_parameters:
     function_kwargs: {'low':7, 'high':10}
   'recovery_time_mild':
     np.random: uniform
-    function_kwargs: {'low':7, 'high':10}
+    function_kwargs: {'low':9, 'high':9}
+    #function_kwargs: {'low':7, 'high':10}
   'recovery_time_hosp':
     np.random: uniform
     function_kwargs: {'low':4, 'high':6}


### PR DESCRIPTION
-  fitting and simulation scenarios that include changing test delay will be easier if the test delay values for mild symptomatics are fixed  
- test delay for As is kept unchanged as no detection of asymptomatics in baseline scenarios, but might need adjustment in contact tracing simulations (currently varying between 1 to 6 )