### PR TITLE
enabled job submission from python on quest and modified sbatch options

### DIFF
--- a/runScenarios.py
+++ b/runScenarios.py
@@ -533,6 +533,9 @@ if __name__ == '__main__':
         nscen, exp_name, trajectories_dir, temp_dir, temp_exp_dir,
         exe_dir=exe_dir, docker_image=docker_image)
 
+    if Location == 'NUCLUSTER':
+        runExp(trajectories_dir=temp_exp_dir, Location='NUCLUSTER')
+
     if Location == 'Local':
         runExp(trajectories_dir=trajectories_dir, Location='Local')
 

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -81,7 +81,9 @@ def runExp(trajectories_dir, Location = 'Local' ):
         p = os.path.join(trajectories_dir,  'runSimulations.bat')
         subprocess.call([p])
     if Location =='NUCLUSTER' :
-        print('please submit sbatch runSimulations.sh in the terminal')
+        #p = os.path.join(trajectories_dir, 'submit_runSimulations.sh')
+        p = os.path.join(trajectories_dir,  'submit_runSimulations_homeDir.sh')
+        subprocess.call(['sh',p])
 
 
 def reprocess(trajectories_dir, temp_exp_dir, input_fname='trajectories.csv', output_fname=None):
@@ -195,7 +197,13 @@ echo end""")
     # Remaining issue:  /projects/p30781/covidproject/binaries/compartments/compartments.exe  cannot be found
     # Instead try to use /make accessible to all  /home/mrm9534/Box/NU-malaria-team/projects/binaries/compartments/compartments.exe   ?
     exp_name_short = exp_name[-20:]
-    header = '#!/bin/bash\n#SBATCH -A p30781\n#SBATCH -p short\n#SBATCH -t 04:00:00\n#SBATCH -N 1\n#SBATCH --ntasks-per-node=1'
+    header = '#!/bin/bash\n' \
+             '#SBATCH -A p30781\n' \
+             '#SBATCH -p short\n' \
+             '#SBATCH -t 02:00:00\n' \
+             '#SBATCH -N 5\n' \
+             '#SBATCH --ntasks-per-node=1\n' \
+             '#SBATCH --mem=18G'
     jobname = '\n#SBATCH	--job-name="' + exp_name_short + '"'
     array = '\n#SBATCH --array=1-' + str(scen_num)
     err = '\n#SBATCH --error=log/arrayJob_%A_%a.err'
@@ -214,7 +222,13 @@ echo end""")
     # Submission script home directory on quest - hardcoded currently for mrm9534 - to do read in from load_path
     # additional parameters , ncores, time, queue...
     exp_name_short = exp_name[-20:]
-    header = '#!/bin/bash\n#SBATCH -A p30781\n#SBATCH -p short\n#SBATCH -t 04:00:00\n#SBATCH -N 1\n#SBATCH --ntasks-per-node=1'
+    header = '#!/bin/bash\n' \
+             '#SBATCH -A p30781\n' \
+             '#SBATCH -p short\n' \
+             '#SBATCH -t 02:00:00\n' \
+             '#SBATCH -N 5\n' \
+             '#SBATCH --ntasks-per-node=1\n' \
+             '#SBATCH --mem=18G'
     jobname = '\n#SBATCH	--job-name="' + exp_name_short + '"'
     array = '\n#SBATCH --array=1-' + str(scen_num)
     err = '\n#SBATCH --error=log/arrayJob_%A_%a.err'

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -81,8 +81,7 @@ def runExp(trajectories_dir, Location = 'Local' ):
         p = os.path.join(trajectories_dir,  'runSimulations.bat')
         subprocess.call([p])
     if Location =='NUCLUSTER' :
-        #p = os.path.join(trajectories_dir, 'submit_runSimulations.sh')
-        p = os.path.join(trajectories_dir,  'submit_runSimulations_homeDir.sh')
+        p = os.path.join(trajectories_dir, 'submit_runSimulations.sh')
         subprocess.call(['sh',p])
 
 
@@ -194,8 +193,6 @@ echo end""")
 
     # Generic shell submission script that should run for all having access to  projects/p30781
     # submit_runSimulations.sh
-    # Remaining issue:  /projects/p30781/covidproject/binaries/compartments/compartments.exe  cannot be found
-    # Instead try to use /make accessible to all  /home/mrm9534/Box/NU-malaria-team/projects/binaries/compartments/compartments.exe   ?
     exp_name_short = exp_name[-20:]
     header = '#!/bin/bash\n' \
              '#SBATCH -A p30781\n' \
@@ -215,32 +212,7 @@ echo end""")
     file.close()
 
     submit_runSimulations = 'cd /projects/p30781/covidproject/covid-chicago/_temp/' + exp_name + '/trajectories/\ndos2unix runSimulations.sh\nsbatch runSimulations.sh'
-    file = open(os.path.join(temp_exp_dir, 'submit_runSimulations.txt'), 'w')
-    file.write(submit_runSimulations)
-    file.close()
-
-    # Submission script home directory on quest - hardcoded currently for mrm9534 - to do read in from load_path
-    # additional parameters , ncores, time, queue...
-    exp_name_short = exp_name[-20:]
-    header = '#!/bin/bash\n' \
-             '#SBATCH -A p30781\n' \
-             '#SBATCH -p short\n' \
-             '#SBATCH -t 02:00:00\n' \
-             '#SBATCH -N 5\n' \
-             '#SBATCH --ntasks-per-node=1\n' \
-             '#SBATCH --mem=18G'
-    jobname = '\n#SBATCH	--job-name="' + exp_name_short + '"'
-    array = '\n#SBATCH --array=1-' + str(scen_num)
-    err = '\n#SBATCH --error=log/arrayJob_%A_%a.err'
-    out = '\n#SBATCH --output=log/arrayJob_%A_%a.out'
-    module = '\n\nmodule load singularity'
-    singularity = '\n\nsingularity exec /software/singularity/images/singwine-v1.img wine /home/mrm9534/Box/NU-malaria-team/projects/binaries/compartments/compartments.exe  -c /home/mrm9534/gitrepos/covid-chicago/_temp/' + exp_name + '/simulations/model_${SLURM_ARRAY_TASK_ID}.cfg  -m /home/mrm9534/gitrepos/covid-chicago/_temp/' + exp_name + '/simulations/simulation_${SLURM_ARRAY_TASK_ID}.emodl'
-    file = open(os.path.join(trajectories_dir, 'runSimulations_homeDir.sh'), 'w')
-    file.write(header + jobname + array + err + out + module + singularity)
-    file.close()
-
-    submit_runSimulations = 'cd /home/mrm9534/gitrepos/covid-chicago/_temp/' + exp_name + '/trajectories/\ndos2unix runSimulations_homeDir.sh\nsbatch runSimulations_homeDir.sh'
-    file = open(os.path.join(temp_exp_dir, 'submit_runSimulations_homeDir.sh'), 'w')
+    file = open(os.path.join(temp_exp_dir, 'submit_runSimulations.sh'), 'w')
     file.write(submit_runSimulations)
     file.close()
 


### PR DESCRIPTION
- single scenario should not run longer than 2 hours, then are cancelled (previously 4 hours), change made to 'save resources' as those not finishing after 1 hrs rarely if even finish at all
- running on 5 instead of  1 node and added memory specification 
- jobs are automatically submitted when running py command on the NUCLUSTER,, running simulations from project rather than custom user directory