### PR TITLE
added plot_split_by_param for plotting single trajectories , changed '_' to '-' for Ki dSym observed emodl output

### DIFF
--- a/Rfiles/load_paths.R
+++ b/Rfiles/load_paths.R
@@ -2,6 +2,7 @@
 
 user_path =  Sys.getenv("USERNAME")
 
+if(!exists('Location'))Location="LOCAL"
 
 if(Location=="NUCLUSTER"){
   user_path = '/projects/p30781/covidproject/'

--- a/Rfiles/simulation_plotter/fitted_param_plots.R
+++ b/Rfiles/simulation_plotter/fitted_param_plots.R
@@ -103,15 +103,15 @@ f_plot_param <- function(exp_name, paramname, emsname, timeVarying = TRUE, SAVE 
 
 
 ### Load trajectories Dat
-exp_name <- "20200730_IL_MR_improvedSym_all0.5"
+exp_name <- "20200816_IL_testbaseline"
 
 #simulation_output <-  file.path(simulation_output, "EMS/20200730_increasedSym/")
 
 
 f_plot_param(exp_name = exp_name, paramname = "social_multiplier_4_", emsname="EMS_", timeVarying = FALSE)
 f_plot_param(exp_name = exp_name, paramname = "backtonormal_multiplier_1_", emsname="EMS_", timeVarying = FALSE)
-f_plot_param(exp_name = exp_name, paramname = "Ki_t_", emsname = "EMS_", timeVarying = TRUE)
-f_plot_param(exp_name = exp_name, paramname = "d_Sym_t_", emsname = "EMS_", timeVarying = TRUE)
+f_plot_param(exp_name = exp_name, paramname = "Ki_t_", emsname = "EMS-", timeVarying = TRUE)
+f_plot_param(exp_name = exp_name, paramname = "d_Sym_t_", emsname = "EMS-", timeVarying = TRUE)
 
 
 

--- a/emodl/extendedmodel_EMS.emodl
+++ b/emodl/extendedmodel_EMS.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_changeTD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_dAsP.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsP_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dSym.emodl
+++ b/emodl/extendedmodel_EMS_dSym.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dSym_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_gradual_reopening.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
+++ b/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_interventionStop.emodl
+++ b/emodl/extendedmodel_EMS_interventionStop.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_neverSIP.emodl
+++ b/emodl/extendedmodel_EMS_neverSIP.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )

--- a/emodl/extendedmodel_EMS_reopen_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_changeTD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_reopen_rollback.emodl
+++ b/emodl/extendedmodel_EMS_reopen_rollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl/extendedmodel_EMS_rollback.emodl
+++ b/emodl/extendedmodel_EMS_rollback.emodl
@@ -1668,47 +1668,47 @@
 (param Kr_a_D (/ 1 (- recovery_time_asymp time_D_As )))
 
 (param Ki_EMS_1 @Ki_EMS_1@)
-(observe Ki_t_EMS_1 Ki_EMS_1)
+(observe Ki_t_EMS-1 Ki_EMS_1)
 (time-event time_infection_import @time_infection_import_EMS_1@ ((As::EMS_1 @initialAs_EMS_1@) (S::EMS_1 (- S::EMS_1 @initialAs_EMS_1@))))
 
 (param Ki_EMS_2 @Ki_EMS_2@)
-(observe Ki_t_EMS_2 Ki_EMS_2)
+(observe Ki_t_EMS-2 Ki_EMS_2)
 (time-event time_infection_import @time_infection_import_EMS_2@ ((As::EMS_2 @initialAs_EMS_2@) (S::EMS_2 (- S::EMS_2 @initialAs_EMS_2@))))
 
 (param Ki_EMS_3 @Ki_EMS_3@)
-(observe Ki_t_EMS_3 Ki_EMS_3)
+(observe Ki_t_EMS-3 Ki_EMS_3)
 (time-event time_infection_import @time_infection_import_EMS_3@ ((As::EMS_3 @initialAs_EMS_3@) (S::EMS_3 (- S::EMS_3 @initialAs_EMS_3@))))
 
 (param Ki_EMS_4 @Ki_EMS_4@)
-(observe Ki_t_EMS_4 Ki_EMS_4)
+(observe Ki_t_EMS-4 Ki_EMS_4)
 (time-event time_infection_import @time_infection_import_EMS_4@ ((As::EMS_4 @initialAs_EMS_4@) (S::EMS_4 (- S::EMS_4 @initialAs_EMS_4@))))
 
 (param Ki_EMS_5 @Ki_EMS_5@)
-(observe Ki_t_EMS_5 Ki_EMS_5)
+(observe Ki_t_EMS-5 Ki_EMS_5)
 (time-event time_infection_import @time_infection_import_EMS_5@ ((As::EMS_5 @initialAs_EMS_5@) (S::EMS_5 (- S::EMS_5 @initialAs_EMS_5@))))
 
 (param Ki_EMS_6 @Ki_EMS_6@)
-(observe Ki_t_EMS_6 Ki_EMS_6)
+(observe Ki_t_EMS-6 Ki_EMS_6)
 (time-event time_infection_import @time_infection_import_EMS_6@ ((As::EMS_6 @initialAs_EMS_6@) (S::EMS_6 (- S::EMS_6 @initialAs_EMS_6@))))
 
 (param Ki_EMS_7 @Ki_EMS_7@)
-(observe Ki_t_EMS_7 Ki_EMS_7)
+(observe Ki_t_EMS-7 Ki_EMS_7)
 (time-event time_infection_import @time_infection_import_EMS_7@ ((As::EMS_7 @initialAs_EMS_7@) (S::EMS_7 (- S::EMS_7 @initialAs_EMS_7@))))
 
 (param Ki_EMS_8 @Ki_EMS_8@)
-(observe Ki_t_EMS_8 Ki_EMS_8)
+(observe Ki_t_EMS-8 Ki_EMS_8)
 (time-event time_infection_import @time_infection_import_EMS_8@ ((As::EMS_8 @initialAs_EMS_8@) (S::EMS_8 (- S::EMS_8 @initialAs_EMS_8@))))
 
 (param Ki_EMS_9 @Ki_EMS_9@)
-(observe Ki_t_EMS_9 Ki_EMS_9)
+(observe Ki_t_EMS-9 Ki_EMS_9)
 (time-event time_infection_import @time_infection_import_EMS_9@ ((As::EMS_9 @initialAs_EMS_9@) (S::EMS_9 (- S::EMS_9 @initialAs_EMS_9@))))
 
 (param Ki_EMS_10 @Ki_EMS_10@)
-(observe Ki_t_EMS_10 Ki_EMS_10)
+(observe Ki_t_EMS-10 Ki_EMS_10)
 (time-event time_infection_import @time_infection_import_EMS_10@ ((As::EMS_10 @initialAs_EMS_10@) (S::EMS_10 (- S::EMS_10 @initialAs_EMS_10@))))
 
 (param Ki_EMS_11 @Ki_EMS_11@)
-(observe Ki_t_EMS_11 Ki_EMS_11)
+(observe Ki_t_EMS-11 Ki_EMS_11)
 (time-event time_infection_import @time_infection_import_EMS_11@ ((As::EMS_11 @initialAs_EMS_11@) (S::EMS_11 (- S::EMS_11 @initialAs_EMS_11@))))
 
 (param N_EMS_1 (+ @speciesS_EMS_1@ @initialAs_EMS_1@) )
@@ -1904,7 +1904,7 @@
 (time-event socialDistance_change_2 @socialDistance_time5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
-(observe d_Sym_t_EMS_1 d_Sym_EMS_1)
+(observe d_Sym_t_EMS-1 d_Sym_EMS_1)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_1 @d_Sym_change1_EMS_1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_1 @d_Sym_change2_EMS_1@)))
@@ -1913,7 +1913,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_1 @d_Sym_change5_EMS_1@)))
             
 (param d_Sym_EMS_2 @d_Sym_EMS_2@)
-(observe d_Sym_t_EMS_2 d_Sym_EMS_2)
+(observe d_Sym_t_EMS-2 d_Sym_EMS_2)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_2 @d_Sym_change1_EMS_2@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_2 @d_Sym_change2_EMS_2@)))
@@ -1922,7 +1922,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_2 @d_Sym_change5_EMS_2@)))
             
 (param d_Sym_EMS_3 @d_Sym_EMS_3@)
-(observe d_Sym_t_EMS_3 d_Sym_EMS_3)
+(observe d_Sym_t_EMS-3 d_Sym_EMS_3)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_3 @d_Sym_change1_EMS_3@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_3 @d_Sym_change2_EMS_3@)))
@@ -1931,7 +1931,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_3 @d_Sym_change5_EMS_3@)))
             
 (param d_Sym_EMS_4 @d_Sym_EMS_4@)
-(observe d_Sym_t_EMS_4 d_Sym_EMS_4)
+(observe d_Sym_t_EMS-4 d_Sym_EMS_4)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_4 @d_Sym_change1_EMS_4@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_4 @d_Sym_change2_EMS_4@)))
@@ -1940,7 +1940,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_4 @d_Sym_change5_EMS_4@)))
             
 (param d_Sym_EMS_5 @d_Sym_EMS_5@)
-(observe d_Sym_t_EMS_5 d_Sym_EMS_5)
+(observe d_Sym_t_EMS-5 d_Sym_EMS_5)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_5 @d_Sym_change1_EMS_5@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_5 @d_Sym_change2_EMS_5@)))
@@ -1949,7 +1949,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_5 @d_Sym_change5_EMS_5@)))
             
 (param d_Sym_EMS_6 @d_Sym_EMS_6@)
-(observe d_Sym_t_EMS_6 d_Sym_EMS_6)
+(observe d_Sym_t_EMS-6 d_Sym_EMS_6)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_6 @d_Sym_change1_EMS_6@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_6 @d_Sym_change2_EMS_6@)))
@@ -1958,7 +1958,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_6 @d_Sym_change5_EMS_6@)))
             
 (param d_Sym_EMS_7 @d_Sym_EMS_7@)
-(observe d_Sym_t_EMS_7 d_Sym_EMS_7)
+(observe d_Sym_t_EMS-7 d_Sym_EMS_7)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_7 @d_Sym_change1_EMS_7@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_7 @d_Sym_change2_EMS_7@)))
@@ -1967,7 +1967,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_7 @d_Sym_change5_EMS_7@)))
             
 (param d_Sym_EMS_8 @d_Sym_EMS_8@)
-(observe d_Sym_t_EMS_8 d_Sym_EMS_8)
+(observe d_Sym_t_EMS-8 d_Sym_EMS_8)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_8 @d_Sym_change1_EMS_8@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_8 @d_Sym_change2_EMS_8@)))
@@ -1976,7 +1976,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_8 @d_Sym_change5_EMS_8@)))
             
 (param d_Sym_EMS_9 @d_Sym_EMS_9@)
-(observe d_Sym_t_EMS_9 d_Sym_EMS_9)
+(observe d_Sym_t_EMS-9 d_Sym_EMS_9)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_9 @d_Sym_change1_EMS_9@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_9 @d_Sym_change2_EMS_9@)))
@@ -1985,7 +1985,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_9 @d_Sym_change5_EMS_9@)))
             
 (param d_Sym_EMS_10 @d_Sym_EMS_10@)
-(observe d_Sym_t_EMS_10 d_Sym_EMS_10)
+(observe d_Sym_t_EMS-10 d_Sym_EMS_10)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_10 @d_Sym_change1_EMS_10@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_10 @d_Sym_change2_EMS_10@)))
@@ -1994,7 +1994,7 @@
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_10 @d_Sym_change5_EMS_10@)))
             
 (param d_Sym_EMS_11 @d_Sym_EMS_11@)
-(observe d_Sym_t_EMS_11 d_Sym_EMS_11)
+(observe d_Sym_t_EMS-11 d_Sym_EMS_11)
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_EMS_11 @d_Sym_change1_EMS_11@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_EMS_11 @d_Sym_change2_EMS_11@)))

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -368,11 +368,12 @@ def write_travel_reaction(grp, travelspeciesList=None):
 
 def write_Ki_timevents(grp):
     grp = str(grp)
+    grpout = sub(grp)
     params_str = """
 (param Ki_{grp} @Ki_{grp}@)
-(observe Ki_t_{grp} Ki_{grp})
+(observe Ki_t_{grpout} Ki_{grp})
 (time-event time_infection_import @time_infection_import_{grp}@ ((As::{grp} @initialAs_{grp}@) (S::{grp} (- S::{grp} @initialAs_{grp}@))))
-""".format(grp=grp)
+""".format(grpout=grpout,grp=grp)
     params_str = params_str.replace("  ", " ")
 
     return (params_str)
@@ -803,9 +804,10 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 
     d_Sym_change_str = ""
     for grp in grpList:
+        grpout = sub(grp)
         temp_str = """
 (param d_Sym_{grp} @d_Sym_{grp}@)
-(observe d_Sym_t_{grp} d_Sym_{grp})
+(observe d_Sym_t_{grpout} d_Sym_{grp})
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym_{grp} @d_Sym_change1_{grp}@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym_{grp} @d_Sym_change2_{grp}@)))

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -814,7 +814,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 (time-event d_Sym_change3 @d_Sym_change_time_3@ ((d_Sym_{grp} @d_Sym_change3_{grp}@)))
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_{grp} @d_Sym_change4_{grp}@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_{grp} @d_Sym_change5_{grp}@)))
-            """.format(grp=grp)
+            """.format(grpout=grpout,grp=grp)
         d_Sym_change_str = d_Sym_change_str + temp_str
         
     interventionSTOP_str = ""

--- a/plotters/data_comparison.py
+++ b/plotters/data_comparison.py
@@ -18,12 +18,12 @@ datetoday = date(today.year, today.month, today.day)
 
 datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
 
-def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, input_sim_output_path =None) :
+def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None,fname='trajectoriesDat.csv', input_sim_output_path =None) :
     input_wdir = input_wdir or wdir
     sim_output_path_base = os.path.join(input_wdir, 'simulation_output', exp_name)
     sim_output_path = input_sim_output_path or sim_output_path_base
 
-    df = pd.read_csv(os.path.join(sim_output_path, 'trajectoriesDat.csv'))
+    df = pd.read_csv(os.path.join(sim_output_path, fname))
     if 'Ki' not in df.columns.values :
         scen_df = pd.read_csv(os.path.join(sim_output_path, 'sampled_parameters.csv'))
         df = pd.merge(left=df, right=scen_df[['scen_num', 'Ki']], on='scen_num', how='left')

--- a/plotters/plot_split_by_channel.py
+++ b/plotters/plot_split_by_channel.py
@@ -25,7 +25,9 @@ first_day = date(2020, 2, 13) # NMH
 def plot_on_fig(df, channels, axes, color, label) :
 
     for c, channel in enumerate(channels) :
-        channeltitle = re.sub('_det','', str(channel), count=1)
+        channeltitle = re.sub('_detected', '', str(channel), count=1)
+        channeltitle = re.sub('_det','', str(channeltitle), count=1)
+
         ax = axes[c]
         mdf = df.groupby('time')[channel].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
 
@@ -44,16 +46,18 @@ def plot_on_fig(df, channels, axes, color, label) :
 
 if __name__ == '__main__' :
 
-    exp_name = '20200707_IL_EMS_MR4_scen3'
+    exp_name = '20200816_IL_testbaseline'
 
-    fig = plt.figure(figsize=(8, 8))
+    fig = plt.figure(figsize=(12, 8))
     fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
 
     nchannels = {'channels1': ['symptomatic_mild', 'infectious_undet', 'prevalence', 'seroprevalence', 'hospitalized'],
                  'channels2': ['symptomatic_mild_det',  'infectious_det', 'prevalence_det', 'seroprevalence_det', 'hospitalized_det'] }
+    #nchannels = {'channels1': ['hospitalized', 'new_hospitalized', 'hosp_cumul', 'critical', 'new_critical', 'crit_cumul'],
+    #             'channels2': ['hospitalized_det',  'new_detected_hospitalized', 'hosp_det_cumul','critical_det',  'new_detected_critical', 'crit_det_cumul'] }
 
     palette = sns.color_palette('Set1', len(nchannels))
-    axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(nchannels['channels1']))]
+    axes = [fig.add_subplot(2, 3, x + 1) for x in range(len(nchannels['channels1']))]
 
     for d, key in enumerate(nchannels.keys()) :
         sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
@@ -68,7 +72,7 @@ if __name__ == '__main__' :
         plot_on_fig(df, channels, axes, color=palette[d], label=label)
     axes[-1].legend()
 
-    plt.savefig(os.path.join(sim_output_path, '_channel.png'))
-    plt.savefig(os.path.join(sim_output_path, '_channel.pdf'), format='PDF')
+    plt.savefig(os.path.join(sim_output_path, 'channel_comparison.png'))
+    plt.savefig(os.path.join(sim_output_path, 'channel_comparison.pdf'), format='PDF')
     plt.show()
 

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -1,0 +1,181 @@
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import sys
+sys.path.append('../')
+from load_paths import load_box_paths
+import matplotlib as mpl
+import matplotlib.dates as mdates
+from datetime import date, timedelta
+import seaborn as sns
+from processing_helpers import *
+from data_comparison import load_sim_data
+from copy import copy
+
+mpl.rcParams['pdf.fonttype'] = 42
+
+datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
+
+first_day = date(2020, 2, 13) # IL
+first_plot_day = date(2020, 7, 1)
+last_plot_day = date(2020, 12, 1)
+
+def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
+
+    for c, channel in enumerate(channels) :
+        ax = axes[c]
+        mdf=df
+
+        mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
+        mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
+        if addgrid :
+            ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
+        ax.plot(mdf['date'], mdf[channel], color=color, label=label)
+        ax.set_title(' '.join(channel.split('_')), y=0.85)
+        formatter = mdates.DateFormatter("%m-%d")
+        ax.xaxis.set_major_formatter(formatter)
+        ax.xaxis.set_major_locator(mdates.MonthLocator())
+        #ax.set_ylim(0, max(mdf[channel])+10)
+
+
+def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) :
+    ax = axes[c]
+    mdf = df
+    mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
+    mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
+    if addgrid:
+        ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
+    ax.plot(mdf['date'], mdf['CI_50'], color=color, label=label)
+    ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
+                color=color, linewidth=0, alpha=0.4)
+    ax.set_title(panel_heading, y=0.85)
+    formatter = mdates.DateFormatter("%m-%d")
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.set_major_locator(mdates.MonthLocator())
+    ax.set_ylim(0, max(mdf['CI_75']))
+
+def plot_main() :
+    fig = plt.figure(figsize=(8, 8))
+    fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+    palette = sns.color_palette('GnBu_d', len(exp_names))
+
+    channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+    axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
+
+    for d, exp_name in enumerate(exp_names) :
+        sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+        df = load_sim_data(exp_name, fname='trajectoriesDat_trim.csv')
+
+        df['symptomatic_census'] = df['symptomatic_mild'] + df['symptomatic_severe']
+        df['ventilators'] = get_vents(df['crit_det'].values)
+
+        plot_on_fig(df, channels, axes, color=palette[d], label=exp_name)
+    axes[-1].legend()
+
+    plt.savefig(os.path.join(sim_output_path, 'trajectories_IL.png'))
+    #plt.savefig(os.path.join(sim_output_path, 'trajectories_IL.pdf'), format='PDF')
+    #plt.show()
+
+def plot_covidregions() :
+
+    subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
+                 '_EMS-10', '_EMS-11']
+
+    for region_suffix in subgroups :
+
+        region_label= region_suffix.replace('_EMS-', 'covid region ')
+        region_label2 = region_label.replace(' ', '_')
+
+        fig = plt.figure(figsize=(8, 8))
+        fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+        palette = sns.color_palette('GnBu_d', len(exp_names))
+        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+        axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
+
+
+        for d, exp_name in enumerate(exp_names) :
+            sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
+
+            df['symptomatic_census'] = df['symptomatic_mild'] + df['symptomatic_severe']
+            df['ventilators'] = get_vents(df['crit_det'].values)
+
+            plot_on_fig(df, channels, axes, color=palette[d], label=exp_name)
+
+        axes[-1].legend()
+        fig.suptitle(region_label)
+        plt.savefig(os.path.join(sim_output_path, 'trajectories_%s.png' % region_label2))
+        #plt.savefig(os.path.join(sim_output_path, 'trajectories_%s.pdf' % region_label2))
+        #plt.show()
+
+
+def plot_covidregions_inone(channel='hospitalized') :
+
+    subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
+                 '_EMS-10', '_EMS-11']
+
+    fig = plt.figure(figsize=(12, 8))
+    fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+    palette = sns.color_palette('GnBu_d', len(exp_names))
+    axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
+
+    for c, region_suffix in enumerate(subgroups) :
+
+        region_label= region_suffix.replace('_EMS-', 'covid region ')
+
+        for d, exp_name in enumerate(exp_names) :
+            sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
+
+            plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label=exp_name)
+
+        axes[-1].legend()
+        fig.suptitle(x=0.5, y=0.999,t=channel)
+        plt.tight_layout()
+    plt.savefig(os.path.join(sim_output_path, 'trajectories_covidregion_%s.png' % channel))
+    #plt.savefig(os.path.join(sim_output_path, 'trajectories_covidregion_%s.pdf' % channel))
+        #plt.show()
+
+def plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths']) :
+
+    subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
+                 '_EMS-10', '_EMS-11']
+
+    for channel in channels :
+        fig = plt.figure(figsize=(12, 8))
+        fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+        palette = sns.color_palette('GnBu_d', len(exp_names))
+        axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
+
+        for c, region_suffix in enumerate(subgroups) :
+
+            region_label= region_suffix.replace('_EMS-', 'covid region ')
+
+            for d, exp_name in enumerate(exp_names) :
+                sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+                df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
+
+                plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label="")
+
+            axes[-1].legend()
+            fig.suptitle(x=0.5, y=0.999,t=channel)
+            plt.tight_layout()
+        if os.path.isdir(os.path.join(sim_output_path,'_plots_covid_region_by_indicator')) ==False  :
+            os.mkdir(os.path.join(sim_output_path,'_plots_covid_region_by_indicator'))
+        plt.savefig(os.path.join(sim_output_path,'_plots_covid_region_by_indicator', 'covidregion_%s.png' % channel))
+        #plt.savefig(os.path.join(sim_output_path,'_plots_covid_region_by_indicator', 'covidregion_%s.pdf' % channel))
+        #plt.show()
+
+
+if __name__ == '__main__' :
+
+    exp_names = [ '20200812_IL_MR_baseline',
+                  '20200812_IL_MR_critical75_triggeredrollback']
+
+    plot_main()
+    #plot_covidregions()
+    #plot_covidregions_inone(channel='hospitalized')
+    #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
+    #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
+    #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild','hospitalized_det','deaths_det','infectious_det'])
+

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -24,7 +24,7 @@ def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
 
     for c, channel in enumerate(channels) :
         ax = axes[c]
-        mdf= df.groupby(['time','scen_num'])[channel].agg(CI_50).reset_index()
+        mdf= df #df.groupby(['time','scen_num'])[channel].agg(CI_50).reset_index()
         mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
         mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
 
@@ -44,7 +44,7 @@ def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
 
 def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True, ymax=50) :
     ax = axes[c]
-    mdf = df.groupby(['time', 'scen_num'])[channel].agg(CI_50).reset_index()
+    mdf = df #df.groupby(['time', 'scen_num'])[channel].agg(CI_50).reset_index()
     mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
     mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
 

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -18,7 +18,7 @@ datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
 
 first_day = date(2020, 2, 13) # IL
 first_plot_day = date(2020, 7, 1)
-last_plot_day = date(2020, 12, 1)
+last_plot_day = date(2021, 6, 1)
 
 def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
 

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -17,20 +17,24 @@ mpl.rcParams['pdf.fonttype'] = 42
 datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
 
 first_day = date(2020, 2, 13) # IL
-first_plot_day = date(2020, 7, 1)
-last_plot_day = date(2021, 6, 1)
+first_plot_day = date(2020, 3, 1)
+last_plot_day = date(2020, 9, 1)
 
 def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
 
     for c, channel in enumerate(channels) :
         ax = axes[c]
-        mdf=df
-
+        mdf= df.groupby(['time','scen_num'])[channel].agg(CI_50).reset_index()
         mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
         mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
+
+        for scen in  mdf['scen_num'].unique():
+            pdf = mdf[mdf['scen_num']==scen]
+            ax.plot(pdf['date'], pdf[channel], color=color, label=label)
+
         if addgrid :
             ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
-        ax.plot(mdf['date'], mdf[channel], color=color, label=label)
+
         ax.set_title(' '.join(channel.split('_')), y=0.85)
         formatter = mdates.DateFormatter("%m-%d")
         ax.xaxis.set_major_formatter(formatter)
@@ -38,24 +42,26 @@ def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
         #ax.set_ylim(0, max(mdf[channel])+10)
 
 
-def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) :
+def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True, ymax=50) :
     ax = axes[c]
-    mdf = df
+    mdf = df.groupby(['time', 'scen_num'])[channel].agg(CI_50).reset_index()
     mdf['date'] = mdf['time'].apply(lambda x: first_day + timedelta(days=int(x)))
     mdf = mdf[(mdf['date'] >= first_plot_day) & (mdf['date'] <= last_plot_day)]
+
+    for scen in mdf['scen_num'].unique():
+        pdf = mdf[mdf['scen_num'] == scen]
+        ax.plot(pdf['date'], pdf[channel], color=color, label=label)
+
     if addgrid:
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
-    ax.plot(mdf['date'], mdf['CI_50'], color=color, label=label)
-    ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
-                color=color, linewidth=0, alpha=0.4)
     ax.set_title(panel_heading, y=0.85)
     formatter = mdates.DateFormatter("%m-%d")
     ax.xaxis.set_major_formatter(formatter)
     ax.xaxis.set_major_locator(mdates.MonthLocator())
-    ax.set_ylim(0, max(mdf['CI_75']))
+    ax.set_ylim(0, ymax)
 
-def plot_main() :
-    fig = plt.figure(figsize=(12, 8))
+def plot_main(nscen=None, showLegend =True) :
+    fig = plt.figure(figsize=(15, 8))
     fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
     palette = sns.color_palette('GnBu_d', len(exp_names))
 
@@ -64,19 +70,24 @@ def plot_main() :
 
     for d, exp_name in enumerate(exp_names) :
         sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
-        df = load_sim_data(exp_name, fname='trajectoriesDat_trim.csv')
+        df = load_sim_data(exp_name, fname='trajectoriesDat.csv')
+
+        if nscen != None :
+            df = df[df['scen_num'].isin(nscen)]
 
         df['symptomatic_census'] = df['symptomatic_mild'] + df['symptomatic_severe']
         df['ventilators'] = get_vents(df['crit_det'].values)
 
         plot_on_fig(df, channels, axes, color=palette[d], label=exp_name)
-    axes[-1].legend()
+
+    if showLegend:
+        axes[-1].legend()
 
     plt.savefig(os.path.join(sim_output_path, 'trajectories_IL.png'))
     #plt.savefig(os.path.join(sim_output_path, 'trajectories_IL.pdf'), format='PDF')
     #plt.show()
 
-def plot_covidregions() :
+def plot_covidregions(nscen=None, showLegend=True) :
 
     subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
                  '_EMS-10', '_EMS-11']
@@ -95,21 +106,26 @@ def plot_covidregions() :
 
         for d, exp_name in enumerate(exp_names) :
             sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
-            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
+            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat.csv')
+
+            if nscen != None:
+                df = df[df['scen_num'].isin(nscen)]
 
             df['symptomatic_census'] = df['symptomatic_mild'] + df['symptomatic_severe']
             df['ventilators'] = get_vents(df['crit_det'].values)
 
             plot_on_fig(df, channels, axes, color=palette[d], label=exp_name)
 
-        axes[-1].legend()
+        if showLegend :
+            axes[-1].legend()
+
         fig.suptitle(region_label)
         plt.savefig(os.path.join(sim_output_path, 'trajectories_%s.png' % region_label2))
         #plt.savefig(os.path.join(sim_output_path, 'trajectories_%s.pdf' % region_label2))
         #plt.show()
 
 
-def plot_covidregions_inone(channel='hospitalized') :
+def plot_covidregions_inone(channel='hospitalized',nscen=None,showLegend = True, ymax=50) :
 
     subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
                  '_EMS-10', '_EMS-11']
@@ -125,57 +141,31 @@ def plot_covidregions_inone(channel='hospitalized') :
 
         for d, exp_name in enumerate(exp_names) :
             sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
-            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
+            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat.csv')
 
-            plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label=exp_name)
+            if nscen != None:
+                df = df[df['scen_num'].isin(nscen)]
 
-        axes[-1].legend()
+            plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label=exp_name, ymax=ymax)
+
+        if showLegend :
+            axes[-1].legend()
+
         fig.suptitle(x=0.5, y=0.999,t=channel)
         plt.tight_layout()
     plt.savefig(os.path.join(sim_output_path, 'trajectories_covidregion_%s.png' % channel))
     #plt.savefig(os.path.join(sim_output_path, 'trajectories_covidregion_%s.pdf' % channel))
         #plt.show()
 
-def plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths']) :
-
-    subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
-                 '_EMS-10', '_EMS-11']
-
-    for channel in channels :
-        fig = plt.figure(figsize=(16, 8))
-        fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
-        palette = sns.color_palette('GnBu_d', len(exp_names))
-        axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
-
-        for c, region_suffix in enumerate(subgroups) :
-
-            region_label= region_suffix.replace('_EMS-', 'covid region ')
-
-            for d, exp_name in enumerate(exp_names) :
-                sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
-                df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat_trim.csv')
-
-                plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label="")
-
-            axes[-1].legend()
-            fig.suptitle(x=0.5, y=0.999,t=channel)
-            plt.tight_layout()
-        if os.path.isdir(os.path.join(sim_output_path,'_plots_covid_region_by_indicator')) ==False  :
-            os.mkdir(os.path.join(sim_output_path,'_plots_covid_region_by_indicator'))
-        plt.savefig(os.path.join(sim_output_path,'_plots_covid_region_by_indicator', 'covidregion_%s.png' % channel))
-        #plt.savefig(os.path.join(sim_output_path,'_plots_covid_region_by_indicator', 'covidregion_%s.pdf' % channel))
-        #plt.show()
-
 
 if __name__ == '__main__' :
 
-    exp_names = [ '20200812_IL_MR_baseline',
-                  '20200812_IL_MR_critical75_triggeredrollback']
+    exp_names = [ '20200816_IL_testbaseline']
+    showLegend = False
+    if len(exp_names) >1 :
+        showLegend = True
 
-    plot_main()
-    plot_covidregions()
-    #plot_covidregions_inone(channel='hospitalized')
-    #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
-    #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
-    #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild','hospitalized_det','deaths_det','infectious_det'])
-
+    plot_main(nscen=None, showLegend =showLegend)
+    plot_covidregions(nscen=None, showLegend =showLegend)
+    plot_covidregions_inone(channel='Ki_t',nscen=None, showLegend =showLegend,ymax=1.5)
+    plot_covidregions_inone(channel='d_Sym_t',nscen=None, showLegend =showLegend,ymax=1)

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -89,7 +89,7 @@ def plot_covidregions() :
         fig = plt.figure(figsize=(8, 8))
         fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
         palette = sns.color_palette('GnBu_d', len(exp_names))
-        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+        channels = ['infected', 'd_Sym_t', 'new_deaths', 'hospitalized', 'critical', 'Ki_t']
         axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
 
 

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -55,7 +55,7 @@ def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) 
     ax.set_ylim(0, max(mdf['CI_75']))
 
 def plot_main() :
-    fig = plt.figure(figsize=(8, 8))
+    fig = plt.figure(figsize=(12, 8))
     fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
     palette = sns.color_palette('GnBu_d', len(exp_names))
 
@@ -86,10 +86,10 @@ def plot_covidregions() :
         region_label= region_suffix.replace('_EMS-', 'covid region ')
         region_label2 = region_label.replace(' ', '_')
 
-        fig = plt.figure(figsize=(8, 8))
+        fig = plt.figure(figsize=(12, 8))
         fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
         palette = sns.color_palette('GnBu_d', len(exp_names))
-        channels = ['infected', 'd_Sym_t', 'new_deaths', 'hospitalized', 'critical', 'Ki_t']
+        channels = ['infected', 'new_deaths', 'hospitalized', 'critical', 'd_Sym_t','Ki_t']
         axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
 
 
@@ -114,7 +114,7 @@ def plot_covidregions_inone(channel='hospitalized') :
     subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
                  '_EMS-10', '_EMS-11']
 
-    fig = plt.figure(figsize=(12, 8))
+    fig = plt.figure(figsize=(16, 8))
     fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
     palette = sns.color_palette('GnBu_d', len(exp_names))
     axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
@@ -142,7 +142,7 @@ def plot_covidregions_inone2(channels=['infected','new_detected','hospitalized',
                  '_EMS-10', '_EMS-11']
 
     for channel in channels :
-        fig = plt.figure(figsize=(12, 8))
+        fig = plt.figure(figsize=(16, 8))
         fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
         palette = sns.color_palette('GnBu_d', len(exp_names))
         axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
@@ -173,7 +173,7 @@ if __name__ == '__main__' :
                   '20200812_IL_MR_critical75_triggeredrollback']
 
     plot_main()
-    #plot_covidregions()
+    plot_covidregions()
     #plot_covidregions_inone(channel='hospitalized')
     #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
     #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])


### PR DESCRIPTION
changed '_' to '-' for Ki dSym observed emodl output for simpler filtering in postprocessing and plotting ( all variables with EMS_1 are input, all variables with EMS-1 are tracked via time in the model).



