### PR TITLE
added 'triggertime' to state event

### DIFF
--- a/emodl/README.md
+++ b/emodl/README.md
@@ -15,30 +15,34 @@ Naming conventions
 
 Emodl examples:
 
-| structure      | type                            | cms modifications        | intervention          | emodl name                                             |
-|----------------|---------------------------------|--------------------------|-----------------------|--------------------------------------------------------|
-| base           | master                          | none                     | continued SIP         | extendedmodel_cobey.emodl                              |                       |
-| base           | added intervention              | none                     | never SIP             | extendedmodel_cobey_noSIP.emodl                        |
-| base           | added intervention              | none                     | immediate stop of SIP | extendedmodel_cobey_interventionStopy.emodl            |
-| base           | added intervention              | none                     | gradual reopen        | extendedmodel_cobey_gradual_reopening.emodl            |
-|                |                                 |                          |                       |                                                        |
-| age-8          | all location contact matrix     | age specific parameters   | continued SIP         | extendedmodel_age8.emodl                               |
-| age-8          | all location contact matrix     | age specific parameters   | never SIP             | extendedmodel_age8_neverSIP.emodl                      |
-| age-8          | all location contact matrix     | age specific parameters   | ...                  | optionally add interventions as required            |
-|                |                                 |                          |                       |                                                        |
-|                |                                 |                          |                       |                                                        |
-| spatial        | no migration                    | none                     | continued SIP         | extendedmodel_EMS.emodl                   |
-| spatial        | no migration                    | none                     | never SIP             | extendedmodel_EMS_neverSIP.emodl          |
-| spatial        | no migration                    | none                     | immediate stop of SIP | extendedmodel_EMS_interventionStopadj.emodl  |
-| spatial        | no migration                    | none                     | gradual reopen        | extendedmodel_EMS_gradual_reopening.emodl |
-|                |                                 |                          |                       |                                                        |
-| spatial        | migration                       | none                     | continued SIP         | extendedmodel_migration_EMS.emodl                   |
-| spatial        | migration                       | none                     | never SIP             | extendedmodel_migration_EMS_neverSIP.emodl          |
-| spatial        | migration                       | none                     | immediate stop of SIP | extendedmodel_migration_EMS_interventionStopadj.emodl  |
-| spatial        | migration                       | none                     | ...       | analougous to the model without migration    |
-|                |                                 |                          |                       |                                                        |
-| locale_age     | migration and contact matrix    | none                     | continued SIP         | extendedmodel_agelocale_migration_scen3.emodl          |
-|                |                                 |                          |                       |                                                        |
-| ltcf           | no contact matrix               | group specific parameters| continued SIP         | extendedmodel_ltcf_age.emodl                           |
-| ltcf           | no contact matrix               | group specific parameters| continued SIP         | extendedmodel_ltcf_homogeneous.emodl                   |
-| ltcf           | contact matrix                  | group specific parameters| continued SIP         | extendedmodel_ltcf_age_testDelay.emodl                   |
+| structure      			| type                            | cms modifications        | intervention          | emodl name                                             |
+|---------------------------|---------------------------------|--------------------------|-----------------------|--------------------------------------------------------|
+| 1. BASE          			|                                 |                          |                       |                                                        |
+| base             			| master                          | none                     | continued SIP         | extendedmodel_cobey.emodl                              |                     
+| base             			| added intervention              | none                     | never SIP             | extendedmodel_cobey_noSIP.emodl                        |
+| base             			| added intervention              | none                     | immediate stop of SIP | extendedmodel_cobey_interventionStopy.emodl            |
+| base             			| added intervention              | none                     | gradual reopen        | extendedmodel_cobey_gradual_reopening.emodl            |
+| 2. AGE           			|                                 |                          |                       |                                                        |
+| age-8            			| all location contact matrix     | age specific parameters  | continued SIP         | extendedmodel_age8.emodl                               |
+| age-8            			| all location contact matrix     | age specific parameters  | never SIP             | extendedmodel_age8_neverSIP.emodl                      |
+| age-8            			| all location contact matrix     | age specific parameters  | ...                   | optionally add interventions as required            	 |
+| 3. SPATIAL       			|                                 |                          |                       |                                                        |
+| spatial          			| no migration                    | none                     | continued SIP         | extendedmodel_EMS.emodl                   			 |
+| spatial          			| no migration                    | none                     | never SIP             | extendedmodel_EMS_neverSIP.emodl          			 |
+| spatial          			| no migration                    | none                     | immediate stop of SIP | extendedmodel_EMS_interventionStopadj.emodl  			 |
+| spatial          			| no migration                    | none                     | gradual reopen        | extendedmodel_EMS_gradual_reopening.emodl 			 |
+| base             			| added intervention              | none                     | immediate 'rollback'  | extendedmodel_EMS_rollback.emodl            			 |
+| base             			| added intervention              | none                     | triggered 'rollback'  | extendedmodel_EMS_critical_triggeredrollback.emodl     |
+| base             			| added intervention              | none                     | triggered 'rollback'  | extendedmodel_EMS_hosp_triggeredrollback.emodl         |
+| 4. SPATIAL+MIGRATION  	|                          		  |                          |                       |                                                        |
+| spatial        			| migration                       | none                     | continued SIP         | extendedmodel_migration_EMS.emodl                      |
+| spatial        			| migration                       | none                     | never SIP             | extendedmodel_migration_EMS_neverSIP.emodl             |
+| spatial        			| migration                       | none                     | immediate stop of SIP | extendedmodel_migration_EMS_interventionStopadj.emodl  |
+| spatial        			| migration                       | none                     | ...       			 | analougous to the model without migration              |
+| 5. AGE+SPATIAL+MIGRATION  |                       		  |               			 |                       |                                                        |
+| locale_age     			| migration and contact matrix    | none                     | continued SIP         | extendedmodel_agelocale_migration_scen3.emodl          |
+| 6. LONG TERM CARE FACILITY|                    			  |                          |                       |                                                        |
+| ltcf           			| no contact matrix               | group specific parameters| continued SIP         | extendedmodel_ltcf_age.emodl                           |
+| ltcf           			| no contact matrix               | group specific parameters| continued SIP         | extendedmodel_ltcf_homogeneous.emodl                   |
+| ltcf           			| contact matrix                  | group specific parameters| continued SIP         | extendedmodel_ltcf_age_testDelay.emodl                 |
+	

--- a/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> critical_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (> time @triggertime@) (> critical_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> critical_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (> time @triggertime@) (> critical_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> critical_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (> time @triggertime@) (> critical_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> critical_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (> time @triggertime@) (> critical_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> critical_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (> time @triggertime@) (> critical_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> critical_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (> time @triggertime@) (> critical_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> critical_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (> time @triggertime@) (> critical_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> critical_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (> time @triggertime@) (> critical_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> critical_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (> time @triggertime@) (> critical_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> critical_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (> time @triggertime@) (> critical_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> critical_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (> time @triggertime@) (> critical_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_critical_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (> critical_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> critical_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (> critical_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> critical_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (> critical_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> critical_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (> critical_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> critical_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (> critical_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> critical_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (> critical_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> critical_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (> critical_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> critical_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (> critical_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> critical_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (> critical_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> critical_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (> critical_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> critical_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (> critical_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> critical_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> critical_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (> time @triggertime@) (> critical_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> critical_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (> time @triggertime@) (> critical_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> critical_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (> time @triggertime@) (> critical_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> critical_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (> time @triggertime@) (> critical_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> critical_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (> time @triggertime@) (> critical_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> critical_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (> time @triggertime@) (> critical_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> critical_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (> time @triggertime@) (> critical_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> critical_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (> time @triggertime@) (> critical_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> critical_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (> time @triggertime@) (> critical_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> critical_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (> time @triggertime@) (> critical_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> critical_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (> time @triggertime@) (> critical_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (> critical_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> critical_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (> critical_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> critical_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (> critical_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> critical_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (> critical_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> critical_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (> critical_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> critical_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (> critical_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> critical_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (> critical_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> critical_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (> critical_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> critical_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (> critical_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> critical_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (> critical_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> critical_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (> critical_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> critical_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> hospitalized_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (> time @triggertime@) (> hospitalized_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> hospitalized_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (> time @triggertime@) (> hospitalized_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> hospitalized_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (> time @triggertime@) (> hospitalized_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> hospitalized_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (> time @triggertime@) (> hospitalized_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> hospitalized_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (> time @triggertime@) (> hospitalized_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> hospitalized_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (> time @triggertime@) (> hospitalized_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> hospitalized_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (> time @triggertime@) (> hospitalized_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> hospitalized_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (> time @triggertime@) (> hospitalized_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> hospitalized_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (> time @triggertime@) (> hospitalized_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> hospitalized_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (> time @triggertime@) (> hospitalized_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> hospitalized_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (> time @triggertime@) (> hospitalized_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hosp_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (> hospitalized_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> hospitalized_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (> hospitalized_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> hospitalized_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (> hospitalized_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> hospitalized_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (> hospitalized_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> hospitalized_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (> hospitalized_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> hospitalized_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (> hospitalized_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> hospitalized_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (> hospitalized_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> hospitalized_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (> hospitalized_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> hospitalized_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (> hospitalized_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> hospitalized_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (> hospitalized_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> hospitalized_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (> hospitalized_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> hospitalized_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (> hospitalized_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> hospitalized_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (> hospitalized_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> hospitalized_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (> hospitalized_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> hospitalized_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (> hospitalized_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> hospitalized_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (> hospitalized_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> hospitalized_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (> hospitalized_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> hospitalized_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (> hospitalized_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> hospitalized_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (> hospitalized_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> hospitalized_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (> hospitalized_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> hospitalized_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (> hospitalized_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> hospitalized_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (> hospitalized_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> hospitalized_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -2002,27 +2002,27 @@
 (time-event d_Sym_change4 @d_Sym_change_time_4@ ((d_Sym_EMS_11 @d_Sym_change4_EMS_11@)))
 (time-event d_Sym_change5 @d_Sym_change_time_5@ ((d_Sym_EMS_11 @d_Sym_change5_EMS_11@)))
             
-(state-event rollbacktrigger_EMS_1 (and (time > @triggertime@) (> hospitalized_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
+(state-event rollbacktrigger_EMS_1 (and (> time @triggertime@) (> hospitalized_det_EMS_1 (* @trigger_EMS_1@ @capacity_multiplier@)) ) ((Ki_EMS_1 Ki_red4_EMS_1)))
                     
-(state-event rollbacktrigger_EMS_2 (and (time > @triggertime@) (> hospitalized_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
+(state-event rollbacktrigger_EMS_2 (and (> time @triggertime@) (> hospitalized_det_EMS_2 (* @trigger_EMS_2@ @capacity_multiplier@)) ) ((Ki_EMS_2 Ki_red4_EMS_2)))
                     
-(state-event rollbacktrigger_EMS_3 (and (time > @triggertime@) (> hospitalized_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
+(state-event rollbacktrigger_EMS_3 (and (> time @triggertime@) (> hospitalized_det_EMS_3 (* @trigger_EMS_3@ @capacity_multiplier@)) ) ((Ki_EMS_3 Ki_red4_EMS_3)))
                     
-(state-event rollbacktrigger_EMS_4 (and (time > @triggertime@) (> hospitalized_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
+(state-event rollbacktrigger_EMS_4 (and (> time @triggertime@) (> hospitalized_det_EMS_4 (* @trigger_EMS_4@ @capacity_multiplier@)) ) ((Ki_EMS_4 Ki_red4_EMS_4)))
                     
-(state-event rollbacktrigger_EMS_5 (and (time > @triggertime@) (> hospitalized_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
+(state-event rollbacktrigger_EMS_5 (and (> time @triggertime@) (> hospitalized_det_EMS_5 (* @trigger_EMS_5@ @capacity_multiplier@)) ) ((Ki_EMS_5 Ki_red4_EMS_5)))
                     
-(state-event rollbacktrigger_EMS_6 (and (time > @triggertime@) (> hospitalized_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
+(state-event rollbacktrigger_EMS_6 (and (> time @triggertime@) (> hospitalized_det_EMS_6 (* @trigger_EMS_6@ @capacity_multiplier@)) ) ((Ki_EMS_6 Ki_red4_EMS_6)))
                     
-(state-event rollbacktrigger_EMS_7 (and (time > @triggertime@) (> hospitalized_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
+(state-event rollbacktrigger_EMS_7 (and (> time @triggertime@) (> hospitalized_det_EMS_7 (* @trigger_EMS_7@ @capacity_multiplier@)) ) ((Ki_EMS_7 Ki_red4_EMS_7)))
                     
-(state-event rollbacktrigger_EMS_8 (and (time > @triggertime@) (> hospitalized_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
+(state-event rollbacktrigger_EMS_8 (and (> time @triggertime@) (> hospitalized_det_EMS_8 (* @trigger_EMS_8@ @capacity_multiplier@)) ) ((Ki_EMS_8 Ki_red4_EMS_8)))
                     
-(state-event rollbacktrigger_EMS_9 (and (time > @triggertime@) (> hospitalized_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
+(state-event rollbacktrigger_EMS_9 (and (> time @triggertime@) (> hospitalized_det_EMS_9 (* @trigger_EMS_9@ @capacity_multiplier@)) ) ((Ki_EMS_9 Ki_red4_EMS_9)))
                     
-(state-event rollbacktrigger_EMS_10 (and (time > @triggertime@) (> hospitalized_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
+(state-event rollbacktrigger_EMS_10 (and (> time @triggertime@) (> hospitalized_det_EMS_10 (* @trigger_EMS_10@ @capacity_multiplier@)) ) ((Ki_EMS_10 Ki_red4_EMS_10)))
                     
-(state-event rollbacktrigger_EMS_11 (and (time > @triggertime@) (> hospitalized_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
+(state-event rollbacktrigger_EMS_11 (and (> time @triggertime@) (> hospitalized_det_EMS_11 (* @trigger_EMS_11@ @capacity_multiplier@)) ) ((Ki_EMS_11 Ki_red4_EMS_11)))
                     
 ;[ADDITIONAL_TIMEEVENTS]
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -798,7 +798,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
     rollbacktriggered_str = ""
     for grp in grpList:
         temp_str = """
-(state-event rollbacktrigger_{grp} (and (time > @triggertime@) (> {channel}_{grp} (* @trigger_{grp}@ @capacity_multiplier@)) ) ((Ki_{grp} Ki_red4_{grp})))
+(state-event rollbacktrigger_{grp} (and (> time @triggertime@) (> {channel}_{grp} (* @trigger_{grp}@ @capacity_multiplier@)) ) ((Ki_{grp} Ki_red4_{grp})))
                     """.format(channel=trigger_channel,grp=grp)
         rollbacktriggered_str = rollbacktriggered_str + temp_str
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -798,7 +798,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
     rollbacktriggered_str = ""
     for grp in grpList:
         temp_str = """
-(state-event rollbacktrigger_{grp} (> {channel}_{grp} (* @trigger_{grp}@ @capacity_multiplier@)) ((Ki_{grp} Ki_red4_{grp})))
+(state-event rollbacktrigger_{grp} (and (time > @triggertime@) (> {channel}_{grp} (* @trigger_{grp}@ @capacity_multiplier@)) ) ((Ki_{grp} Ki_red4_{grp})))
                     """.format(channel=trigger_channel,grp=grp)
         rollbacktriggered_str = rollbacktriggered_str + temp_str
 

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -321,6 +321,9 @@ time_parameters:
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-08-05}
     #function_kwargs: {'dates': [2020-04-15, 2020-05-15, 2020-06-15, 2020-07-15, 2020-08-15, 2020-09-15]}
+  'triggertime' :
+    custom_function: DateToTimestep
+    function_kwargs: {'dates': 2020-08-17}
 fitted_parameters:
   Kis:
     'NMH_catchment':


### PR DESCRIPTION
The time constraint ensures the trigger is only pulled after _today_ in the simulations.
In this version the state event is simply added within the write interventions function and only works for either critical or hospitalized (not for either or), and does not include additional options such as triggered reopening.