### PR TITLE
updated and commented 'today' parameter in master config file

### DIFF
--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -275,7 +275,7 @@ time_parameters:
   ### should be set to after reopening time events are completed
   'today' :
     custom_function: DateToTimestep
-    function_kwargs: {'dates': 2020-09-20}
+    function_kwargs: {'dates': 2020-09-14}
   ### Increased testing - increased detectioon of severe symptomatic infections
   ### (only used if corresponding emodl is defined)
   ### Use fixed dates or define detection time relative to  socialDistance_time3

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -271,6 +271,11 @@ time_parameters:
   'gradual_reopening_time4':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-09-13}  
+  ### 'today' parameter used to constrain after when state events can be activated
+  ### should be set to after reopening time events are completed
+  'today' :
+    custom_function: DateToTimestep
+    function_kwargs: {'dates': 2020-09-20}
   ### Increased testing - increased detectioon of severe symptomatic infections
   ### (only used if corresponding emodl is defined)
   ### Use fixed dates or define detection time relative to  socialDistance_time3
@@ -333,9 +338,6 @@ time_parameters:
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-08-30}
     #function_kwargs: {'dates': [2020-04-15, 2020-05-15, 2020-06-15, 2020-07-15, 2020-08-15, 2020-09-15]}
-  'today' :
-    custom_function: DateToTimestep
-    function_kwargs: {'dates': 2020-08-30}
 fitted_parameters:
   Kis:
     'NMH_catchment':

--- a/experiment_configs/spatial_EMS_experiment.yaml
+++ b/experiment_configs/spatial_EMS_experiment.yaml
@@ -231,7 +231,7 @@ sampled_parameters:
         - {'low': 0.08, 'high': 0.08}
         - {'low': 0.10, 'high': 0.10}
         - {'low': 0.09, 'high': 0.09}
-        - {'low': 0.07, 'high': 0.07}
+        - {'low': 0.08, 'high': 0.08}
   reopening_multiplier_4: #such that 50% exceed by Jan 1
     IL:
       expand_by_age: True


### PR DESCRIPTION
- The  _today_ parameter should be after reopening ends, in the simulation that use a combination of reopening and state events for triggered rollback.  
   - The  _today_ parameter is also needed in state events needed that do not include reopening.
   - Alternatively in the specific reopening - stateevent simulations, the today parameter can be directly included in the emodl, relative to the last reopening time event date. 
- Updated regions 11 specific reopening value from 7 to 8%. 