### PR TITLE
Allow to specify masterconfig in run scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Note that the user-supplied configuration file is used to provide
 *additional* or *updated* parameters from the base configutation file.
 
 ## 2.3 Inputs:
+- Master configuration: YAML file that defines the parameter input values for the model (if not specified uses the default `extendedcobey_200428.yaml`)
 - Running location: Where the simulation is being run (either `Local`
   or `NUCLUSTER`)
 - Region: The region of interest. (e.g. `EMS_1`, or `IL` for all EMS 1-11 inclued in the same model)
@@ -171,6 +172,8 @@ Note that the user-supplied configuration file is used to provide
   --running_location NUCLUSTER --region IL --experiment_config sample_experiment.yaml --emodl_template simplemodel_testing.emodl --name_suffix "testrun_userinitials"`
 - Specifiying cms configuration file and solver:`python runScenarios.py
   --running_location Local --region IL  --experiment_config sample_experiment.yaml --emodl_template simplemodel_testing.emodl --cfg_template model_Tau.cfg`
+- Specifiying master configuration file and using short form of arguments:`python runScenarios.py 
+  -mc config_param_delay7.yaml -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl -cfg model_B.cfg
 
 
 ## 3.5 Define age or region specific inputs 

--- a/runScenarios.py
+++ b/runScenarios.py
@@ -407,7 +407,7 @@ def parse_args():
         "--masterconfig",
         type=str,
         help="Master yaml file that includes all model parameters.",
-        default='model_param_CT.yaml',
+        default='extendedcobey_200428.yaml',
     )
 
     parser.add_argument(

--- a/runScenarios.py
+++ b/runScenarios.py
@@ -21,8 +21,6 @@ log = logging.getLogger(__name__)
 mpl.rcParams['pdf.fonttype'] = 42
 
 today = datetime.datetime.today()
-DEFAULT_CONFIG = 'extendedcobey_200428.yaml'
-
 
 def _get_full_factorial_df(df, column_name, values):
     dfs = []
@@ -357,7 +355,7 @@ def generateScenarios(simulation_population, Kivalues, duration, monitoring_samp
 
 
 def get_experiment_config(experiment_config_file):
-    config = yaml.load(open(os.path.join('./experiment_configs', DEFAULT_CONFIG)), Loader=yamlordereddictloader.Loader)
+    config = yaml.load(open(os.path.join('./experiment_configs', args.masterconfig)), Loader=yamlordereddictloader.Loader)
     yaml_file = open(os.path.join('./experiment_configs',experiment_config_file))
     expt_config = yaml.safe_load(yaml_file)
     for param_type, updated_params in expt_config.items():
@@ -403,6 +401,14 @@ def get_start_dates(start_date):
 def parse_args():
     description = "Simulation run for modeling Covid-19"
     parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument(
+        "-mc",
+        "--masterconfig",
+        type=str,
+        help="Master yaml file that includes all model parameters.",
+        default='model_param_CT.yaml',
+    )
 
     parser.add_argument(
         "-rl",
@@ -508,7 +514,7 @@ if __name__ == '__main__':
     # Generate folders and copy required files
     # GE 04/10/20 added exp_name,emodl_dir,emodlname,cfg_dir here to fix exp_name not defined error
     temp_dir, temp_exp_dir, trajectories_dir, sim_output_path, plot_path = makeExperimentFolder(
-        exp_name, emodl_dir, args.emodl_template, cfg_dir, args.cfg_template,  yaml_dir, DEFAULT_CONFIG, args.experiment_config, wdir=wdir,
+        exp_name, emodl_dir, args.emodl_template, cfg_dir, args.cfg_template,  yaml_dir,  args.masterconfig, args.experiment_config, wdir=wdir,
         git_dir=git_dir)
     log.debug(f"temp_dir = {temp_dir}\n"
               f"temp_exp_dir = {temp_exp_dir}\n"

--- a/simulation_submission_template.txt
+++ b/simulation_submission_template.txt
@@ -1,5 +1,5 @@
 
-#### Some submission line examples for running simulations using the CMS-Python framework
+## Some submission line examples for running simulations using the CMS-Python framework
 
 - specify running_location either Local or NUCLUSTER
 - the region name is automatically added to the experiment name
@@ -14,16 +14,16 @@ Abbreviated
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS.emodl -cfg model_B.cfg -n "scen3"						  
 
 
-#### Current and past scenarios to submit for weekly updates
+## Current and past scenarios to submit for weekly updates
 
- - Baseline and reopening scenarios
+###  Baseline and reopening scenarios
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS.emodl -cfg model_B.cfg -n "baseline"
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_gradual_reopening.emodl -cfg model_B.cfg -n "gradual_reopening"
 
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_rollback.emodl -cfg model_B.cfg -n "rollback"	
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_reopen_rollback.emodl -cfg model_B.cfg -n "reopenRollback"	
 
- - Improved detection and 'speed' scenarios (increase in detection of Sym)
+### Improved detection and 'speed' scenarios (increase in detection of Sym)
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_changeTD.emodl -cfg model_B.cfg -n "baseline_changeTD"						  
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_dSym.emodl -cfg model_B.cfg -n "baseline_dSym"
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_dSym_changeTD.emodl -cfg model_B.cfg -n "baseline_dSym_changeTD"
@@ -32,18 +32,29 @@ python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extende
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_reopen_dSym.emodl -cfg model_B.cfg -n "reopen_dSym"
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_reopen_dSym_changeTD.emodl -cfg model_B.cfg -n "reopen_dSym_changeTD"
 
- - triggered rollback (returns to Ki value before reopening once defined thresholds are reached per region and sample)
-Note to change between critical and hospitalizations, the spatial_EMS_experiment.yaml needs to be edited (see file)
-Additional parameter to change: capacity_multiplier
+### triggered rollback (returns to Ki value before reopening once defined thresholds are reached per region and sample)
+Note to change between critical and hospitalizations, the spatial_EMS_experiment.yaml needs to be edited (see file), alternatively copied version can be generated and used in the submission
+Additional parameter to change: 
+- capacity_multiplier (at what % of the total capacity is the rollback triggered?),
+- today (only after this date can the trigger be pulled)
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollback.emodl -cfg model_B.cfg -n "critical_triggeredrollback"	
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_hospdet_triggeredrollback.emodl -cfg model_B.cfg -n "hosp_triggeredrollback"	
-Additional parameter to change: capacity_multiplier, triggerdelay (number of days between trigger is activated and action is taken )
+
+Additional parameter to change: 
+- capacity_multiplier (at what % of the total capacity is the rollback triggered?),
+- today (only after this date can the trigger be pulled)
+- triggerdelay (number of days between trigger is activated and action is taken )
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl -cfg model_B.cfg -n "critical_triggeredrollbackdelay"	
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl -cfg model_B.cfg -n "hosp_triggeredrollbackdelay"	
 
+### triggere rollback with specified yaml
+- the master config was copied to config_param_delay7, config_param_delay3, and config_param_delay0 to submit all three experiments at once without editing the yaml in between.
+python runScenarios.py -mc config_param_delay7.yaml -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl -cfg model_B.cfg -n "test"	
+python runScenarios.py -mc config_param_delay3.yaml -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl -cfg model_B.cfg -n "regreopen100perc_3daysdelay_sm6"	
+python runScenarios.py -mc config_param_delay0.yaml -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl -cfg model_B.cfg -n "regreopen100perc_0daysdelay_sm6"	
 
 
- - Contact tracing scenarios (detection of As and P, optionally also increase in dSym)
+## Contact tracing scenarios (detection of As and P, optionally also increase in dSym)
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_dAsP.emodl -cfg model_B.cfg -n "baseline_dAsP"						  
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_dAsP_TD.emodl -cfg model_B.cfg -n "baseline_dAsP_TD"
 python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS_dAsPSym.emodl -cfg model_B.cfg -n "baseline_dAsPSym"
@@ -56,7 +67,7 @@ python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extende
 
 
 
-#### When not using the locale model, each group needs to run separately
+## When not using the locale model, each group needs to run separately
 python runScenarios.py -rl Local -r EMS_1 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "baseline"
 python runScenarios.py -rl Local -r EMS_2 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "baseline"
 python runScenarios.py -rl Local -r EMS_3 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "baseline"
@@ -70,22 +81,22 @@ python runScenarios.py -rl Local -r EMS_10 -c EMSspecific_sample_parameters.yaml
 python runScenarios.py -rl Local -r EMS_11 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl -n "baseline"
 
 
-#### For fitting
+## For fitting
 python runScenarios.py -rl Local -r EMS_1 -c extendedmodel_forFitting.yaml -e extendedmodel_forFitting.emodl  -n "fit_test1"
 python runScenarios.py -rl Local -r EMS_2 -c extendedmodel_forFitting.yaml -e extendedmodel_forFitting.emodl  -n "fit_test1"
 ...
 
-#### For startdate-Ki combinations
+## For startdate-Ki combinations
 Note: the runScenarios.py will need editing of the default yaml file form DEFAULT_CONFIG = 'extendedcobey_200428.yaml' to 'extendedcobey_200428_startdateKipair.yaml'
 python runScenarios.py -rl Local -r EMS_1 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "_startdateKi"
 python runScenarios.py -rl Local -r EMS_2 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "_startdateKi"
 python runScenarios.py -rl Local -r EMS_3 -c EMSspecific_sample_parameters.yaml -e extendedmodel.emodl  -n "_startdateKi"
 ...
 
-#### Age model with age specific parameter -not using locale model  (testing)
+## Age model with age specific parameter -not using locale model  (testing)
 python runScenarios.py -rl Local -r EMS_11 -c age8grp_experiment.yaml -e extendedmodel_age8_param.emodl -cfg model_B.cfg -n "age8_ageparam_test"
 
-#### Age model with age specific parameter and migration using locale emodl  (testing)
+## Age model with age specific parameter and migration using locale emodl  (testing)
 python runScenarios.py -rl Local -r IL -c age_locale_experiment.yaml -e extendedmodel_agelocale_scen3.emodl -cfg model_B.cfg -n "agelocale_test2"
 python runScenarios.py -rl Local -r IL -c age_locale_experiment.yaml -e extendedmodel_agelocale_migration_scen3.emodl -cfg model_B.cfg -n "agelocale_migration_test2"
 


### PR DESCRIPTION
Adding parser argument for master config (master yaml) file, this allows to prepare different yamls beforehand and submit all at once without having to chance the master yaml file between submissions.
The copied yaml files should be temporary and copied from the latest master yaml file (and/or spatial yaml file if needed) to ensure all parameters are up to date. 

If nothing is specified current master yaml file will be used automatically (as before)

```
    parser.add_argument(
        "-mc",
        "--masterconfig",
        type=str,
        help="Master yaml file that includes all model parameters.",
        default='extendedcobey_200428.yaml',
    )
```
