### PR TITLE
integrated Reese's gen_combo function in  sample_parameters.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,17 @@ As described in 2.1. and 2.2 parameters are sampled from the base configuration 
 The [sample_parameters.py](sample_parameters.py) script handles only the sampled_parameters.csv, it allows to: 
 (1) generate csv file from configuration files without running simulations
 (2) load and modify an existing sampled_parameters.csv (change or add single or multiple parameter) (default location `experiment_configs\input_csv`)
-(3) it currently does not allow for generating new parameter combination (in process).
+(3) replace single values for one or more parameter use python dictionary  `--param_dic  {\"capacity_multiplier\":\"0.5\"}`
+(4) combine with multiple values for one or more parameters define additional csv file   `--csv_name_combo startdate_Ki_sets.csv`
 
 Running examples: 
 - nsamples: optional, if specified if overwrites the nsamples in the base configuration, if loading an existing csv the first n samples will be selected (i.e. when selecting samples from an excisting csv file, could be modified to be random if needed)
 - emodl_template: the emodl template is required to test whether the parameter csv table includes all required parameters defined in the desired emodl file to run
-- example1: `python sample_parameters.py -rl Local -r 'IL' --experiment_config 'spatial_EMS_experiment.yaml' --emodl_template 'extendedmodel_EMS.emodl'  -save "sampled_parameters.csv"`
-- example2: `python sample_parameters.py -rl Local -save "sampled_parameters_1000.csv" --nsamples "1000"`
-- example3: `python sample_parameters.py -rl Local -load "sampled_parameters_1000.csv" -save "sampled_parameters_1000_v2.csv"  --param_dic  {\"capacity_multiplier\":\"0.5\"} `
+- example 1: `python sample_parameters.py -rl Local -r IL --experiment_config spatial_EMS_experiment.yaml --emodl_template extendedmodel_EMS.emodl  -save sampled_parameters2.csv`
+- example 2: `python sample_parameters.py -rl Local -save sampled_parameters_1000.csv --nsamples 1000`
+- example 3: `python sample_parameters.py -rl Local -load sampled_parameters_1000.csv -save sampled_parameters_1000_v2.csv  --param_dic  {\"capacity_multiplier\":\"0.5\"} `
+- example 4: `python sample_parameters.py   --csv_name_combo  sampled_parameters_sm7.csv   -save sampled_parameters_sm7_combo.csv`
+   -(sampled_parameters_sm7.csv not under version control, but would for example include 10 values for social multiplier 7 for all 11 regions, the base sample parameters are repeated for each of the 10 rows of the additional csv)
 
 When running simulations with an pre-existing csv file, specify 
 - `--load_sample_parameters` (boolean) and 


### PR DESCRIPTION
The `gen_combo `function combines a full factorial combination of two sample parameter csv files.
`csv_base `is the standard sample_parameter.csv file
`csv_add `contains additional parameter sets to add i.e. startdate+Ki combinations, or region specific sampled parameters that should be repeated for each transmission sample

Example:
currently tested for fitting sm7 parameter:
1) add sampled sm7 parameter (per region) to sample_parameters.csv
`python sample_parameters.py   --csv_name_combo  "sampled_parameters_sm7.csv"   -save "sampled_parameters_sm7_combo.csv"`
 2) Run simulations with varying transmission parameters samples as well as samples on region specific sm7 for fitting, that are repeated for the transmission parameter samples
` python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS.emodl -n "test3_fitsm7"  --load_sample_parameters  --sample_csv  "sampled_parameters_sm7_combo.csv"`
Here one would take the median across transmission parameter samples and explore unique sm7 scenarios to fit

Example:
also currently being tested for simulating fixed startdate+Ki parameters, once these were determined from fitting
(note startdate actually meaning infection import date, as startdate is fixed in locale emodl)
1) run varying startdate+ki fitting simulation 
2) have a csv file with startdate+ki values in wide format (rows = unique startdate+Ki pairs, columns=startdate+Ki  names per region)
3) add startdate+ki and transmission parameters
`python sample_parameters.py   --csv_name_combo  "startdate_Ki.csv"   -save "sampled_parameters_startdateKi.csv"`
4) run simulations
` python runScenarios.py -rl Local -r IL -c spatial_EMS_experiment.yaml -e extendedmodel_EMS.emodl -n "test3_fitsm7"  --load_sample_parameters  --sample_csv  "sampled_parameters_startdateKi.csv"`
Here the overall median would be taken, startdate+Ki pairs were not included in yaml, as this would per default create a full factorial between startdate and Ki, which is not desired in this case

Note, ideally startdate and Ki would be sampled from a parameter space, instead of using fixed pairs.