### PR TITLE
updated base, age, age-locale models,  added public cases to load_ref_df

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The model is updated every week to fit to latest hospitalisation and deaths repo
 - 20201015 updated parameter fit, reset fitting method
 - 20201007 updated parameter fit
 - 20200929 updated parameter fit, changed fitting method
-- 20200922 updated parameter fit
+- 20200922 updated parameter fit, changed d_Sym parameters (generic)
 - 20200915 updated parameter fit, added social multiplier 7 (time event Aug 25)
 - 20200909 updated parameter fit, updated evolution of CFR
 - 20200825 updated parameter fit

--- a/emodl/extendedmodel.emodl
+++ b/emodl/extendedmodel.emodl
@@ -239,6 +239,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki Ki_red3a)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki Ki_red3b)))
@@ -249,6 +250,7 @@
 (time-event ki_multiplier_change8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
             
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_age8.emodl
+++ b/emodl/extendedmodel_age8.emodl
@@ -1566,6 +1566,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -1579,6 +1580,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_age8_2ndWave_contactMatrix.emodl
+++ b/emodl/extendedmodel_age8_2ndWave_contactMatrix.emodl
@@ -1731,6 +1731,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -1744,6 +1745,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_age8_ChangeTD.emodl
+++ b/emodl/extendedmodel_age8_ChangeTD.emodl
@@ -1566,6 +1566,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -1579,6 +1580,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_age8_gradual_reopening.emodl
+++ b/emodl/extendedmodel_age8_gradual_reopening.emodl
@@ -1566,6 +1566,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -1579,6 +1580,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_age8_interventionStop.emodl
+++ b/emodl/extendedmodel_age8_interventionStop.emodl
@@ -1566,6 +1566,7 @@
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -1579,6 +1580,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 
 (time-event d_Sym_change1 @d_Sym_change_time_1@ ((d_Sym @d_Sym_change1@)))
 (time-event d_Sym_change2 @d_Sym_change_time_2@ ((d_Sym @d_Sym_change2@)))

--- a/emodl/extendedmodel_agelocale_migration_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_migration_scen3.emodl
@@ -12224,6 +12224,7 @@
 (param Ki_red8_EMS_1 (* Ki_EMS_1 @ki_multiplier_8_EMS_1@))
 (param Ki_red9_EMS_1 (* Ki_EMS_1 @ki_multiplier_9_EMS_1@))
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
+(param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 
 (param backtonormal_multiplier_1_EMS_1  (/ (- Ki_red6_EMS_1  Ki_red4_EMS_1 ) (- Ki_EMS_1 Ki_red4_EMS_1 ) ) )  
 (observe backtonormal_multiplier_1_EMS_1 backtonormal_multiplier_1_EMS_1)
@@ -12237,6 +12238,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_1 Ki_red8_EMS_1)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_1 Ki_red9_EMS_1)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -12247,6 +12249,7 @@
 (param Ki_red8_EMS_2 (* Ki_EMS_2 @ki_multiplier_8_EMS_2@))
 (param Ki_red9_EMS_2 (* Ki_EMS_2 @ki_multiplier_9_EMS_2@))
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
+(param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 
 (param backtonormal_multiplier_1_EMS_2  (/ (- Ki_red6_EMS_2  Ki_red4_EMS_2 ) (- Ki_EMS_2 Ki_red4_EMS_2 ) ) )  
 (observe backtonormal_multiplier_1_EMS_2 backtonormal_multiplier_1_EMS_2)
@@ -12260,6 +12263,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_2 Ki_red8_EMS_2)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_2 Ki_red9_EMS_2)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -12270,6 +12274,7 @@
 (param Ki_red8_EMS_3 (* Ki_EMS_3 @ki_multiplier_8_EMS_3@))
 (param Ki_red9_EMS_3 (* Ki_EMS_3 @ki_multiplier_9_EMS_3@))
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
+(param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 
 (param backtonormal_multiplier_1_EMS_3  (/ (- Ki_red6_EMS_3  Ki_red4_EMS_3 ) (- Ki_EMS_3 Ki_red4_EMS_3 ) ) )  
 (observe backtonormal_multiplier_1_EMS_3 backtonormal_multiplier_1_EMS_3)
@@ -12283,6 +12288,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_3 Ki_red8_EMS_3)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_3 Ki_red9_EMS_3)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -12293,6 +12299,7 @@
 (param Ki_red8_EMS_4 (* Ki_EMS_4 @ki_multiplier_8_EMS_4@))
 (param Ki_red9_EMS_4 (* Ki_EMS_4 @ki_multiplier_9_EMS_4@))
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
+(param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 
 (param backtonormal_multiplier_1_EMS_4  (/ (- Ki_red6_EMS_4  Ki_red4_EMS_4 ) (- Ki_EMS_4 Ki_red4_EMS_4 ) ) )  
 (observe backtonormal_multiplier_1_EMS_4 backtonormal_multiplier_1_EMS_4)
@@ -12306,6 +12313,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_4 Ki_red8_EMS_4)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_4 Ki_red9_EMS_4)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -12316,6 +12324,7 @@
 (param Ki_red8_EMS_5 (* Ki_EMS_5 @ki_multiplier_8_EMS_5@))
 (param Ki_red9_EMS_5 (* Ki_EMS_5 @ki_multiplier_9_EMS_5@))
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
+(param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 
 (param backtonormal_multiplier_1_EMS_5  (/ (- Ki_red6_EMS_5  Ki_red4_EMS_5 ) (- Ki_EMS_5 Ki_red4_EMS_5 ) ) )  
 (observe backtonormal_multiplier_1_EMS_5 backtonormal_multiplier_1_EMS_5)
@@ -12329,6 +12338,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_5 Ki_red8_EMS_5)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_5 Ki_red9_EMS_5)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -12339,6 +12349,7 @@
 (param Ki_red8_EMS_6 (* Ki_EMS_6 @ki_multiplier_8_EMS_6@))
 (param Ki_red9_EMS_6 (* Ki_EMS_6 @ki_multiplier_9_EMS_6@))
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
+(param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 
 (param backtonormal_multiplier_1_EMS_6  (/ (- Ki_red6_EMS_6  Ki_red4_EMS_6 ) (- Ki_EMS_6 Ki_red4_EMS_6 ) ) )  
 (observe backtonormal_multiplier_1_EMS_6 backtonormal_multiplier_1_EMS_6)
@@ -12352,6 +12363,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_6 Ki_red8_EMS_6)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_6 Ki_red9_EMS_6)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -12362,6 +12374,7 @@
 (param Ki_red8_EMS_7 (* Ki_EMS_7 @ki_multiplier_8_EMS_7@))
 (param Ki_red9_EMS_7 (* Ki_EMS_7 @ki_multiplier_9_EMS_7@))
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
+(param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 
 (param backtonormal_multiplier_1_EMS_7  (/ (- Ki_red6_EMS_7  Ki_red4_EMS_7 ) (- Ki_EMS_7 Ki_red4_EMS_7 ) ) )  
 (observe backtonormal_multiplier_1_EMS_7 backtonormal_multiplier_1_EMS_7)
@@ -12375,6 +12388,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_7 Ki_red8_EMS_7)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_7 Ki_red9_EMS_7)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -12385,6 +12399,7 @@
 (param Ki_red8_EMS_8 (* Ki_EMS_8 @ki_multiplier_8_EMS_8@))
 (param Ki_red9_EMS_8 (* Ki_EMS_8 @ki_multiplier_9_EMS_8@))
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
+(param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 
 (param backtonormal_multiplier_1_EMS_8  (/ (- Ki_red6_EMS_8  Ki_red4_EMS_8 ) (- Ki_EMS_8 Ki_red4_EMS_8 ) ) )  
 (observe backtonormal_multiplier_1_EMS_8 backtonormal_multiplier_1_EMS_8)
@@ -12398,6 +12413,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_8 Ki_red8_EMS_8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_8 Ki_red9_EMS_8)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -12408,6 +12424,7 @@
 (param Ki_red8_EMS_9 (* Ki_EMS_9 @ki_multiplier_8_EMS_9@))
 (param Ki_red9_EMS_9 (* Ki_EMS_9 @ki_multiplier_9_EMS_9@))
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
+(param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 
 (param backtonormal_multiplier_1_EMS_9  (/ (- Ki_red6_EMS_9  Ki_red4_EMS_9 ) (- Ki_EMS_9 Ki_red4_EMS_9 ) ) )  
 (observe backtonormal_multiplier_1_EMS_9 backtonormal_multiplier_1_EMS_9)
@@ -12421,6 +12438,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_9 Ki_red8_EMS_9)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_9 Ki_red9_EMS_9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -12431,6 +12449,7 @@
 (param Ki_red8_EMS_10 (* Ki_EMS_10 @ki_multiplier_8_EMS_10@))
 (param Ki_red9_EMS_10 (* Ki_EMS_10 @ki_multiplier_9_EMS_10@))
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
+(param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 
 (param backtonormal_multiplier_1_EMS_10  (/ (- Ki_red6_EMS_10  Ki_red4_EMS_10 ) (- Ki_EMS_10 Ki_red4_EMS_10 ) ) )  
 (observe backtonormal_multiplier_1_EMS_10 backtonormal_multiplier_1_EMS_10)
@@ -12444,6 +12463,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_10 Ki_red8_EMS_10)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_10 Ki_red9_EMS_10)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -12454,6 +12474,7 @@
 (param Ki_red8_EMS_11 (* Ki_EMS_11 @ki_multiplier_8_EMS_11@))
 (param Ki_red9_EMS_11 (* Ki_EMS_11 @ki_multiplier_9_EMS_11@))
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
+(param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 
 (param backtonormal_multiplier_1_EMS_11  (/ (- Ki_red6_EMS_11  Ki_red4_EMS_11 ) (- Ki_EMS_11 Ki_red4_EMS_11 ) ) )  
 (observe backtonormal_multiplier_1_EMS_11 backtonormal_multiplier_1_EMS_11)
@@ -12467,6 +12488,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_11 Ki_red8_EMS_11)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_11 Ki_red9_EMS_11)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_agelocale_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_scen3.emodl
@@ -12092,6 +12092,7 @@
 (param Ki_red8_EMS_1 (* Ki_EMS_1 @ki_multiplier_8_EMS_1@))
 (param Ki_red9_EMS_1 (* Ki_EMS_1 @ki_multiplier_9_EMS_1@))
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
+(param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 
 (param backtonormal_multiplier_1_EMS_1  (/ (- Ki_red6_EMS_1  Ki_red4_EMS_1 ) (- Ki_EMS_1 Ki_red4_EMS_1 ) ) )  
 (observe backtonormal_multiplier_1_EMS_1 backtonormal_multiplier_1_EMS_1)
@@ -12105,6 +12106,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_1 Ki_red8_EMS_1)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_1 Ki_red9_EMS_1)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -12115,6 +12117,7 @@
 (param Ki_red8_EMS_2 (* Ki_EMS_2 @ki_multiplier_8_EMS_2@))
 (param Ki_red9_EMS_2 (* Ki_EMS_2 @ki_multiplier_9_EMS_2@))
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
+(param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 
 (param backtonormal_multiplier_1_EMS_2  (/ (- Ki_red6_EMS_2  Ki_red4_EMS_2 ) (- Ki_EMS_2 Ki_red4_EMS_2 ) ) )  
 (observe backtonormal_multiplier_1_EMS_2 backtonormal_multiplier_1_EMS_2)
@@ -12128,6 +12131,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_2 Ki_red8_EMS_2)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_2 Ki_red9_EMS_2)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -12138,6 +12142,7 @@
 (param Ki_red8_EMS_3 (* Ki_EMS_3 @ki_multiplier_8_EMS_3@))
 (param Ki_red9_EMS_3 (* Ki_EMS_3 @ki_multiplier_9_EMS_3@))
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
+(param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 
 (param backtonormal_multiplier_1_EMS_3  (/ (- Ki_red6_EMS_3  Ki_red4_EMS_3 ) (- Ki_EMS_3 Ki_red4_EMS_3 ) ) )  
 (observe backtonormal_multiplier_1_EMS_3 backtonormal_multiplier_1_EMS_3)
@@ -12151,6 +12156,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_3 Ki_red8_EMS_3)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_3 Ki_red9_EMS_3)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -12161,6 +12167,7 @@
 (param Ki_red8_EMS_4 (* Ki_EMS_4 @ki_multiplier_8_EMS_4@))
 (param Ki_red9_EMS_4 (* Ki_EMS_4 @ki_multiplier_9_EMS_4@))
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
+(param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 
 (param backtonormal_multiplier_1_EMS_4  (/ (- Ki_red6_EMS_4  Ki_red4_EMS_4 ) (- Ki_EMS_4 Ki_red4_EMS_4 ) ) )  
 (observe backtonormal_multiplier_1_EMS_4 backtonormal_multiplier_1_EMS_4)
@@ -12174,6 +12181,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_4 Ki_red8_EMS_4)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_4 Ki_red9_EMS_4)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -12184,6 +12192,7 @@
 (param Ki_red8_EMS_5 (* Ki_EMS_5 @ki_multiplier_8_EMS_5@))
 (param Ki_red9_EMS_5 (* Ki_EMS_5 @ki_multiplier_9_EMS_5@))
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
+(param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 
 (param backtonormal_multiplier_1_EMS_5  (/ (- Ki_red6_EMS_5  Ki_red4_EMS_5 ) (- Ki_EMS_5 Ki_red4_EMS_5 ) ) )  
 (observe backtonormal_multiplier_1_EMS_5 backtonormal_multiplier_1_EMS_5)
@@ -12197,6 +12206,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_5 Ki_red8_EMS_5)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_5 Ki_red9_EMS_5)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -12207,6 +12217,7 @@
 (param Ki_red8_EMS_6 (* Ki_EMS_6 @ki_multiplier_8_EMS_6@))
 (param Ki_red9_EMS_6 (* Ki_EMS_6 @ki_multiplier_9_EMS_6@))
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
+(param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 
 (param backtonormal_multiplier_1_EMS_6  (/ (- Ki_red6_EMS_6  Ki_red4_EMS_6 ) (- Ki_EMS_6 Ki_red4_EMS_6 ) ) )  
 (observe backtonormal_multiplier_1_EMS_6 backtonormal_multiplier_1_EMS_6)
@@ -12220,6 +12231,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_6 Ki_red8_EMS_6)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_6 Ki_red9_EMS_6)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -12230,6 +12242,7 @@
 (param Ki_red8_EMS_7 (* Ki_EMS_7 @ki_multiplier_8_EMS_7@))
 (param Ki_red9_EMS_7 (* Ki_EMS_7 @ki_multiplier_9_EMS_7@))
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
+(param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 
 (param backtonormal_multiplier_1_EMS_7  (/ (- Ki_red6_EMS_7  Ki_red4_EMS_7 ) (- Ki_EMS_7 Ki_red4_EMS_7 ) ) )  
 (observe backtonormal_multiplier_1_EMS_7 backtonormal_multiplier_1_EMS_7)
@@ -12243,6 +12256,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_7 Ki_red8_EMS_7)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_7 Ki_red9_EMS_7)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -12253,6 +12267,7 @@
 (param Ki_red8_EMS_8 (* Ki_EMS_8 @ki_multiplier_8_EMS_8@))
 (param Ki_red9_EMS_8 (* Ki_EMS_8 @ki_multiplier_9_EMS_8@))
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
+(param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 
 (param backtonormal_multiplier_1_EMS_8  (/ (- Ki_red6_EMS_8  Ki_red4_EMS_8 ) (- Ki_EMS_8 Ki_red4_EMS_8 ) ) )  
 (observe backtonormal_multiplier_1_EMS_8 backtonormal_multiplier_1_EMS_8)
@@ -12266,6 +12281,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_8 Ki_red8_EMS_8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_8 Ki_red9_EMS_8)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -12276,6 +12292,7 @@
 (param Ki_red8_EMS_9 (* Ki_EMS_9 @ki_multiplier_8_EMS_9@))
 (param Ki_red9_EMS_9 (* Ki_EMS_9 @ki_multiplier_9_EMS_9@))
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
+(param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 
 (param backtonormal_multiplier_1_EMS_9  (/ (- Ki_red6_EMS_9  Ki_red4_EMS_9 ) (- Ki_EMS_9 Ki_red4_EMS_9 ) ) )  
 (observe backtonormal_multiplier_1_EMS_9 backtonormal_multiplier_1_EMS_9)
@@ -12289,6 +12306,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_9 Ki_red8_EMS_9)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_9 Ki_red9_EMS_9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -12299,6 +12317,7 @@
 (param Ki_red8_EMS_10 (* Ki_EMS_10 @ki_multiplier_8_EMS_10@))
 (param Ki_red9_EMS_10 (* Ki_EMS_10 @ki_multiplier_9_EMS_10@))
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
+(param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 
 (param backtonormal_multiplier_1_EMS_10  (/ (- Ki_red6_EMS_10  Ki_red4_EMS_10 ) (- Ki_EMS_10 Ki_red4_EMS_10 ) ) )  
 (observe backtonormal_multiplier_1_EMS_10 backtonormal_multiplier_1_EMS_10)
@@ -12312,6 +12331,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_10 Ki_red8_EMS_10)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_10 Ki_red9_EMS_10)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -12322,6 +12342,7 @@
 (param Ki_red8_EMS_11 (* Ki_EMS_11 @ki_multiplier_8_EMS_11@))
 (param Ki_red9_EMS_11 (* Ki_EMS_11 @ki_multiplier_9_EMS_11@))
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
+(param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 
 (param backtonormal_multiplier_1_EMS_11  (/ (- Ki_red6_EMS_11  Ki_red4_EMS_11 ) (- Ki_EMS_11 Ki_red4_EMS_11 ) ) )  
 (observe backtonormal_multiplier_1_EMS_11 backtonormal_multiplier_1_EMS_11)
@@ -12335,6 +12356,7 @@
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_11 Ki_red8_EMS_11)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_11 Ki_red9_EMS_11)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl_generators/emodl_generator_age.py
+++ b/emodl_generators/emodl_generator_age.py
@@ -957,6 +957,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (param backtonormal_multiplier_1  (/ (- Ki_red6  Ki_red4 ) (- Ki Ki_red4 ) ) )  
 (observe backtonormal_multiplier_1 backtonormal_multiplier_1)
@@ -970,6 +971,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
 """
 
     rollback_str = """

--- a/emodl_generators/emodl_generator_age_locale.py
+++ b/emodl_generators/emodl_generator_age_locale.py
@@ -945,6 +945,7 @@ def write_interventions(regionList, ageList,total_string, scenarioName, expandMo
 (param Ki_red8_{region} (* Ki_{region} @ki_multiplier_8_{region}@))
 (param Ki_red9_{region} (* Ki_{region} @ki_multiplier_9_{region}@))
 (param Ki_red10_{region} (* Ki_{region} @ki_multiplier_10_{region}@))
+(param Ki_red11_{region} (* Ki_{region} @ki_multiplier_11_{region}@))
 
 (param backtonormal_multiplier_1_{region}  (/ (- Ki_red6_{region}  Ki_red4_{region} ) (- Ki_{region} Ki_red4_{region} ) ) )  
 (observe backtonormal_multiplier_1_{region} backtonormal_multiplier_1_{region})
@@ -958,6 +959,7 @@ def write_interventions(regionList, ageList,total_string, scenarioName, expandMo
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_{region} Ki_red8_{region})))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_{region} Ki_red9_{region})))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_{region} Ki_red10_{region})))
+(time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_{region} Ki_red11_{region})))
             """.format(region=region)
         ki_multiplier_change_str = ki_multiplier_change_str + temp_str
 

--- a/emodl_generators/emodl_generator_base.py
+++ b/emodl_generators/emodl_generator_base.py
@@ -613,6 +613,7 @@ def write_interventions( total_string, scenarioName, change_testDelay=None, trig
 (param Ki_red8 (* Ki @ki_multiplier_8@))
 (param Ki_red9 (* Ki @ki_multiplier_9@))
 (param Ki_red10 (* Ki @ki_multiplier_10@))
+(param Ki_red11 (* Ki @ki_multiplier_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki Ki_red3a)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki Ki_red3b)))
@@ -623,6 +624,7 @@ def write_interventions( total_string, scenarioName, change_testDelay=None, trig
 (time-event ki_multiplier_change8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
 (time-event ki_multiplier_change9 @ki_multiplier_time_9@ ((Ki Ki_red9)))
 (time-event ki_multiplier_change10 @ki_multiplier_time_10@ ((Ki Ki_red10)))
+(time-event ki_multiplier_change11 @ki_multiplier_time_11@ ((Ki Ki_red11)))
             """
     rollback_str ="""
 (time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki Ki_red4)))

--- a/experiment_configs/EMSspecific_sample_parameters.yaml
+++ b/experiment_configs/EMSspecific_sample_parameters.yaml
@@ -250,10 +250,10 @@ sampled_parameters:
       function_kwargs: {'low':  0.205, 'high': 0.205}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.180, 'high': 0.180}
+      function_kwargs: {'low': 0.120, 'high': 0.120}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.215, 'high': 0.215}
+      function_kwargs: {'low': 0.155, 'high': 0.155}
     EMS_6:
       np.random: uniform
       function_kwargs: {'low': 0.240, 'high': 0.240}
@@ -281,13 +281,13 @@ sampled_parameters:
       function_kwargs: {'low': 0.172, 'high': 0.172}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':  0.391, 'high': 0.391}
+      function_kwargs: {'low':  0.410, 'high': 0.410}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.162, 'high': 0.162}
+      function_kwargs: {'low': 0.250, 'high': 0.250}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.215, 'high': 0.215}
+      function_kwargs: {'low':0.175, 'high': 0.175}
     EMS_6:
       np.random: uniform
       function_kwargs: {'low': 0.210, 'high': 0.210}
@@ -309,37 +309,71 @@ sampled_parameters:
   'ki_multiplier_10':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low': 0.250, 'high': 0.250}
+      function_kwargs: {'low': 0.234, 'high': 0.234}
     EMS_2:
       np.random: uniform
       function_kwargs: {'low': 0.222, 'high': 0.222}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low': 0.391, 'high': 0.391}
+      function_kwargs: {'low': 0.420, 'high': 0.420}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.212, 'high': 0.212}
+      function_kwargs: {'low': 0.225, 'high': 0.225}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low': 0.245, 'high': 0.245}
+      function_kwargs: {'low': 0.325, 'high': 0.325}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low': 0.423, 'high': 0.423}
+      function_kwargs: {'low': 0.323, 'high': 0.323}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low': 0.218, 'high': 0.218}
+      function_kwargs: {'low': 0.221, 'high': 0.221}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low': 0.230, 'high': 0.230}
+      function_kwargs: {'low': 0.220, 'high': 0.220}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low': 0.195, 'high': 0.195}
+      function_kwargs: {'low': 0.230, 'high': 0.230}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low': 0.219, 'high': 0.219}
+      function_kwargs: {'low': 0.240, 'high': 0.240}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low': 0.169, 'high': 0.169}
+      function_kwargs: {'low': 0.195, 'high': 0.195}
+  'ki_multiplier_11':
+    EMS_1:
+      np.random: uniform
+      function_kwargs: {'low': 0.270, 'high': 0.270}
+    EMS_2:
+      np.random: uniform
+      function_kwargs: {'low': 0.295, 'high': 0.295}
+    EMS_3:
+      np.random: uniform
+      function_kwargs: {'low': 0.430, 'high': 0.430}
+    EMS_4:
+      np.random: uniform
+      function_kwargs: {'low': 0.375, 'high': 0.375}
+    EMS_5:
+      np.random: uniform
+      function_kwargs: {'low': 0.450, 'high': 0.450}
+    EMS_6:
+      np.random: uniform
+      function_kwargs: {'low': 0.330, 'high': 0.330}
+    EMS_7:
+      np.random: uniform
+      function_kwargs: {'low': 0.340, 'high': 0.340}
+    EMS_8:
+      np.random: uniform
+      function_kwargs: {'low': 0.160, 'high': 0.160}
+    EMS_9:
+      np.random: uniform
+      function_kwargs: {'low': 0.245, 'high': 0.245}
+    EMS_10:
+      np.random: uniform
+      function_kwargs: {'low': 0.240, 'high': 0.240}
+    EMS_11:
+      np.random: uniform
+      function_kwargs: {'low': 0.180, 'high': 0.180}
   'd_Sym_change1':
     EMS_1:
       np.random: uniform

--- a/experiment_configs/EMSspecific_sample_parameters.yaml
+++ b/experiment_configs/EMSspecific_sample_parameters.yaml
@@ -1,39 +1,5 @@
 fixed_parameters_global:
 sampled_parameters:
-  'd_Sym':
-    EMS_1:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_2:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_3:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_4:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_5:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_6:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_7:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_8:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_9:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_10:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_11:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
   'ki_multiplier_3a':
     EMS_1:
       np.random: uniform
@@ -374,74 +340,108 @@ sampled_parameters:
     EMS_11:
       np.random: uniform
       function_kwargs: {'low': 0.180, 'high': 0.180}
+  'd_Sym':
+    EMS_1:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_2:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_3:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_4:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_5:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_6:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_7:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_8:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_9:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_10:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_11:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
   'd_Sym_change1':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.04}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.04}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
   'd_Sym_change2':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.03, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.02, 'high': 0.05}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.02, 'high': 0.05}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.03, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
   'd_Sym_change3':
     EMS_1:
       np.random: uniform
@@ -451,98 +451,98 @@ sampled_parameters:
       function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.10}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.10}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.20}
   'd_Sym_change4':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_3:
       np.random: uniform
       function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.30}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
   'd_Sym_change5':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.40}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.40}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.50}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.50}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}          
+      function_kwargs: {'low':0.10, 'high': 0.40}       
       
       

--- a/experiment_configs/age8grp_experiment.yaml
+++ b/experiment_configs/age8grp_experiment.yaml
@@ -71,40 +71,6 @@ fixed_parameters_global:
 #    - [2.03848504291307e-06, 0.00512975957240923, 0.0230425829403064, 0.0305663224371847, 0.0348303096842973, 0.0268836599567761, 0.0034875849717547, 1.49795910089621e-05] 
 #    - [2.03848504291307e-06, 0.00512975957240923, 0.0230425829403064, 0.0305663224371847, 0.0348303096842973, 0.0268836599567761, 1.33116561888771e-05, 1.0683428383127e-05]
 sampled_parameters:
-  'd_Sym':
-    EMS_1:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_2:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_3:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_4:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_5:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_6:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_7:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_8:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_9:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_10:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_11:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
   'ki_multiplier_3a':
     EMS_1:
       np.random: uniform
@@ -445,74 +411,108 @@ sampled_parameters:
     EMS_11:
       np.random: uniform
       function_kwargs: {'low': 0.180, 'high': 0.180}
+  'd_Sym':
+    EMS_1:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_2:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_3:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_4:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_5:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_6:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_7:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_8:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_9:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_10:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
+    EMS_11:
+      np.random: uniform
+      function_kwargs: {'low':0.0, 'high': 0.01}
   'd_Sym_change1':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.04}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.04}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.01, 'high': 0.05}
+      function_kwargs: {'low':0.01, 'high': 0.08}
   'd_Sym_change2':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.03, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.02, 'high': 0.05}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.02, 'high': 0.05}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.03, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.08}
+      function_kwargs: {'low':0.05, 'high': 0.10}
   'd_Sym_change3':
     EMS_1:
       np.random: uniform
@@ -522,99 +522,99 @@ sampled_parameters:
       function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.10}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.10}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.08, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.20}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.20}
   'd_Sym_change4':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_3:
       np.random: uniform
       function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.15}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.05, 'high': 0.30}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.10, 'high': 0.25}
+      function_kwargs: {'low':0.10, 'high': 0.30}
   'd_Sym_change5':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.40}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.40}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.50}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low':0.15, 'high': 0.50}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}
+      function_kwargs: {'low':0.10, 'high': 0.40}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low':0.20, 'high': 0.35}          
+      function_kwargs: {'low':0.10, 'high': 0.40}           
   #####  fraction_severe
   fraction_severe_age0to9:
     np.random: uniform

--- a/experiment_configs/age8grp_experiment.yaml
+++ b/experiment_configs/age8grp_experiment.yaml
@@ -321,10 +321,10 @@ sampled_parameters:
       function_kwargs: {'low':  0.205, 'high': 0.205}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.180, 'high': 0.180}
+      function_kwargs: {'low': 0.120, 'high': 0.120}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.215, 'high': 0.215}
+      function_kwargs: {'low': 0.155, 'high': 0.155}
     EMS_6:
       np.random: uniform
       function_kwargs: {'low': 0.240, 'high': 0.240}
@@ -352,13 +352,13 @@ sampled_parameters:
       function_kwargs: {'low': 0.172, 'high': 0.172}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low':  0.391, 'high': 0.391}
+      function_kwargs: {'low':  0.410, 'high': 0.410}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.162, 'high': 0.162}
+      function_kwargs: {'low': 0.250, 'high': 0.250}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.215, 'high': 0.215}
+      function_kwargs: {'low':0.175, 'high': 0.175}
     EMS_6:
       np.random: uniform
       function_kwargs: {'low': 0.210, 'high': 0.210}
@@ -380,37 +380,71 @@ sampled_parameters:
   'ki_multiplier_10':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low': 0.250, 'high': 0.250}
+      function_kwargs: {'low': 0.234, 'high': 0.234}
     EMS_2:
       np.random: uniform
       function_kwargs: {'low': 0.222, 'high': 0.222}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low': 0.391, 'high': 0.391}
+      function_kwargs: {'low': 0.420, 'high': 0.420}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.212, 'high': 0.212}
+      function_kwargs: {'low': 0.225, 'high': 0.225}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low': 0.245, 'high': 0.245}
+      function_kwargs: {'low': 0.325, 'high': 0.325}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low': 0.423, 'high': 0.423}
+      function_kwargs: {'low': 0.323, 'high': 0.323}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low': 0.218, 'high': 0.218}
+      function_kwargs: {'low': 0.221, 'high': 0.221}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low': 0.230, 'high': 0.230}
+      function_kwargs: {'low': 0.220, 'high': 0.220}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low': 0.195, 'high': 0.195}
+      function_kwargs: {'low': 0.230, 'high': 0.230}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low': 0.219, 'high': 0.219}
+      function_kwargs: {'low': 0.240, 'high': 0.240}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low': 0.169, 'high': 0.169}
+      function_kwargs: {'low': 0.195, 'high': 0.195}
+  'ki_multiplier_11':
+    EMS_1:
+      np.random: uniform
+      function_kwargs: {'low': 0.270, 'high': 0.270}
+    EMS_2:
+      np.random: uniform
+      function_kwargs: {'low': 0.295, 'high': 0.295}
+    EMS_3:
+      np.random: uniform
+      function_kwargs: {'low': 0.430, 'high': 0.430}
+    EMS_4:
+      np.random: uniform
+      function_kwargs: {'low': 0.375, 'high': 0.375}
+    EMS_5:
+      np.random: uniform
+      function_kwargs: {'low': 0.450, 'high': 0.450}
+    EMS_6:
+      np.random: uniform
+      function_kwargs: {'low': 0.330, 'high': 0.330}
+    EMS_7:
+      np.random: uniform
+      function_kwargs: {'low': 0.340, 'high': 0.340}
+    EMS_8:
+      np.random: uniform
+      function_kwargs: {'low': 0.160, 'high': 0.160}
+    EMS_9:
+      np.random: uniform
+      function_kwargs: {'low': 0.245, 'high': 0.245}
+    EMS_10:
+      np.random: uniform
+      function_kwargs: {'low': 0.240, 'high': 0.240}
+    EMS_11:
+      np.random: uniform
+      function_kwargs: {'low': 0.180, 'high': 0.180}
   'd_Sym_change1':
     EMS_1:
       np.random: uniform

--- a/experiment_configs/age_locale_experiment.yaml
+++ b/experiment_configs/age_locale_experiment.yaml
@@ -89,6 +89,22 @@ sampled_parameters:
         - {'low': 0.080, 'high': 0.080}
         - {'low': 0.100, 'high': 0.100}
         - {'low': 0.070, 'high': 0.070}
+  ki_multiplier_5:
+    IL:
+      expand_by_age: True
+      np.random: uniform
+      function_kwargs:
+        - {'low': 0.125, 'high': 0.125}
+        - {'low': 0.110, 'high': 0.110}
+        - {'low': 0.200, 'high': 0.200}
+        - {'low': 0.135, 'high': 0.135}
+        - {'low': 0.135, 'high': 0.135}
+        - {'low': 0.180, 'high': 0.180}
+        - {'low': 0.095, 'high': 0.095}
+        - {'low': 0.085, 'high': 0.085}
+        - {'low': 0.080, 'high': 0.080}
+        - {'low': 0.100, 'high': 0.100}
+        - {'low': 0.070, 'high': 0.070}
   ki_multiplier_6:
     IL:
       expand_by_age: True
@@ -129,8 +145,8 @@ sampled_parameters:
         - {'low': 0.192, 'high': 0.192}
         - {'low': 0.162, 'high': 0.162}
         - {'low': 0.205, 'high': 0.205}
-        - {'low': 0.180, 'high': 0.180}
-        - {'low': 0.215, 'high': 0.215}
+        - {'low': 0.120, 'high': 0.120}
+        - {'low': 0.155, 'high': 0.155}
         - {'low': 0.240, 'high': 0.240}
         - {'low': 0.170, 'high': 0.170}
         - {'low': 0.120, 'high': 0.120}
@@ -144,9 +160,9 @@ sampled_parameters:
       function_kwargs:
         - {'low': 0.255, 'high': 0.255}
         - {'low': 0.172, 'high': 0.172}
-        - {'low': 0.391, 'high': 0.391}
-        - {'low': 0.162, 'high': 0.162}
-        - {'low': 0.215, 'high': 0.215}
+        - {'low': 0.410, 'high': 0.410}
+        - {'low': 0.250, 'high': 0.250}
+        - {'low': 0.175, 'high': 0.175}
         - {'low': 0.210, 'high': 0.210}
         - {'low': 0.170, 'high': 0.170}
         - {'low': 0.143, 'high': 0.143}
@@ -158,18 +174,34 @@ sampled_parameters:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.250, 'high': 0.250}
+        - {'low': 0.234, 'high': 0.234}
         - {'low': 0.222, 'high': 0.222}
-        - {'low': 0.391, 'high': 0.391}
-        - {'low': 0.212, 'high': 0.212}
-        - {'low': 0.245, 'high': 0.245}
-        - {'low': 0.423, 'high': 0.423}
-        - {'low': 0.218, 'high': 0.218}
+        - {'low': 0.420, 'high': 0.420}
+        - {'low': 0.225, 'high': 0.225}
+        - {'low': 0.325, 'high': 0.325}
+        - {'low': 0.323, 'high': 0.323}
+        - {'low': 0.221, 'high': 0.221}
+        - {'low': 0.220, 'high': 0.220}
         - {'low': 0.230, 'high': 0.230}
+        - {'low': 0.240, 'high': 0.240}
         - {'low': 0.195, 'high': 0.195}
-        - {'low': 0.219, 'high': 0.219}
-        - {'low': 0.169, 'high': 0.169}
-  d_Sym:  
+  ki_multiplier_11:
+    IL:
+      expand_by_age: True
+      np.random: uniform
+      function_kwargs:
+        - {'low': 0.270, 'high': 0.270}
+        - {'low': 0.295, 'high': 0.295}
+        - {'low': 0.430, 'high': 0.430}
+        - {'low': 0.375, 'high': 0.375}
+        - {'low': 0.450, 'high': 0.450}
+        - {'low': 0.330, 'high': 0.330}
+        - {'low': 0.340, 'high': 0.340}
+        - {'low': 0.160, 'high': 0.160}
+        - {'low': 0.245, 'high': 0.245}
+        - {'low': 0.240, 'high': 0.240}
+        - {'low': 0.180, 'high': 0.180}
+  d_Sym:
     IL:
       expand_by_age: True
       np.random: uniform

--- a/experiment_configs/age_locale_experiment.yaml
+++ b/experiment_configs/age_locale_experiment.yaml
@@ -222,33 +222,33 @@ sampled_parameters:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.0, 'high': 0.05}
-        - {'low': 0.0, 'high': 0.05}
-        - {'low': 0.0, 'high': 0.05}
-        - {'low': 0.0, 'high': 0.04}
-        - {'low': 0.0, 'high': 0.04}
-        - {'low': 0.0, 'high': 0.05}
-        - {'low': 0.01, 'high': 0.05}
-        - {'low': 0.01, 'high': 0.05}
-        - {'low': 0.01, 'high': 0.05}
-        - {'low': 0.01, 'high': 0.05}
-        - {'low': 0.01, 'high': 0.05}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
+        - {'low': 0.01, 'high': 0.08}
   d_Sym_change2:
     IL:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.05, 'high': 0.15}
-        - {'low': 0.05, 'high': 0.15}
-        - {'low': 0.03, 'high': 0.08}
-        - {'low': 0.02, 'high': 0.05}
-        - {'low': 0.02, 'high': 0.05}
-        - {'low': 0.03, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.08}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
+        - {'low': 0.05, 'high': 0.10}
   d_Sym_change3:
     IL:
       expand_by_age: True
@@ -256,79 +256,79 @@ sampled_parameters:
       function_kwargs:
         - {'low': 0.10, 'high': 0.20}
         - {'low': 0.10, 'high': 0.20}
-        - {'low': 0.05, 'high': 0.15}
-        - {'low': 0.05, 'high': 0.10}
-        - {'low': 0.05, 'high': 0.10}
-        - {'low': 0.05, 'high': 0.15}
-        - {'low': 0.08, 'high': 0.15}
-        - {'low': 0.08, 'high': 0.15}
-        - {'low': 0.08, 'high': 0.15}
-        - {'low': 0.08, 'high': 0.15}
-        - {'low': 0.08, 'high': 0.15}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
+        - {'low': 0.10, 'high': 0.20}
   d_Sym_change4:
     IL:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.10, 'high': 0.25}
-        - {'low': 0.10, 'high': 0.25}
         - {'low': 0.10, 'high': 0.30}
-        - {'low': 0.05, 'high': 0.15}
-        - {'low': 0.05, 'high': 0.15}
         - {'low': 0.10, 'high': 0.30}
-        - {'low': 0.1, 'high': 0.25}
-        - {'low': 0.1, 'high': 0.25}
-        - {'low': 0.1, 'high': 0.25}
-        - {'low': 0.1, 'high': 0.25}
-        - {'low': 0.1, 'high': 0.25}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
+        - {'low': 0.10, 'high': 0.30}
   d_Sym_change5:
     IL:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.15, 'high': 0.40}
-        - {'low': 0.15, 'high': 0.40}
-        - {'low': 0.15, 'high': 0.50}
-        - {'low': 0.15, 'high': 0.35}
-        - {'low': 0.15, 'high': 0.35}
-        - {'low': 0.15, 'high': 0.50}
-        - {'low': 0.20, 'high': 0.35}
-        - {'low': 0.20, 'high': 0.35}
-        - {'low': 0.20, 'high': 0.35}
-        - {'low': 0.20, 'high': 0.35}
-        - {'low': 0.20, 'high': 0.35}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
+        - {'low': 0.10, 'high': 0.40}
   reopening_multiplier_4_not_used: #such that 100% exceed by Jan 1
     IL:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.16, 'high': 0.16}
-        - {'low': 0.08, 'high': 0.08}
-        - {'low': 0.19, 'high': 0.19}
-        - {'low': 0.12, 'high': 0.12}
-        - {'low': 0.15, 'high': 0.15}
-        - {'low': 0.13, 'high': 0.13}
-        - {'low': 0.07, 'high': 0.07}
-        - {'low': 0.08, 'high': 0.08}
-        - {'low': 0.10, 'high': 0.10}
-        - {'low': 0.09, 'high': 0.09}
-        - {'low': 0.08, 'high': 0.08}
+        - {'low': 0.183, 'high': 0.183}
+        - {'low': 0.114, 'high': 0.114}
+        - {'low': 0.23 , 'high': 0.23 }
+        - {'low': 0.109, 'high': 0.109}
+        - {'low': 0.088, 'high': 0.088}
+        - {'low': 0.163, 'high': 0.163}
+        - {'low': 0.079, 'high': 0.079}
+        - {'low': 0.095, 'high': 0.095}
+        - {'low': 0.126, 'high': 0.126}
+        - {'low': 0.111, 'high': 0.111}
+        - {'low': 0.113, 'high': 0.113}
   reopening_multiplier_4: #such that 50% exceed by Jan 1
     IL:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.09, 'high': 0.09}
-        - {'low': 0.04, 'high': 0.04}
-        - {'low': 0.05, 'high': 0.05}
-        - {'low': 0.04, 'high': 0.04}
-        - {'low': 0.05, 'high': 0.05}
-        - {'low': 0.04, 'high': 0.04}
-        - {'low': 0.04, 'high': 0.04}
-        - {'low': 0.04, 'high': 0.04}
-        - {'low': 0.08, 'high': 0.08}
-        - {'low': 0.05, 'high': 0.05}
-        - {'low': 0.05, 'high': 0.05}
+        - {'low': 0.122, 'high': 0.122}
+        - {'low': 0.056, 'high': 0.056}
+        - {'low': 0.104, 'high': 0.104}
+        - {'low': 0.045, 'high': 0.045}
+        - {'low': 0.001 ,'high': 0.001}
+        - {'low': 0.043, 'high': 0.043}
+        - {'low': 0.034, 'high': 0.034}
+        - {'low': 0.062, 'high': 0.062}
+        - {'low': 0.085, 'high': 0.085}
+        - {'low': 0.069, 'high': 0.069}
+        - {'low': 0.074, 'high': 0.074}
   d_Sym_ct1:
     IL:
       expand_by_age: True
@@ -350,11 +350,11 @@ sampled_parameters:
       expand_by_age: True
       np.random: uniform
       function_kwargs:
-        - {'low': 0.592, 'high': 0.592}
+        - {'low': 0.628, 'high': 0.628}
         - {'low': 0.654, 'high': 0.654}
         - {'low': 0.381, 'high': 0.381}
         - {'low': 0.571, 'high': 0.571}
-        - {'low': 0.501, 'high': 0.501}
+        - {'low': 0.498, 'high': 0.498}
         - {'low': 0.501, 'high': 0.501}
         - {'low': 0.716, 'high': 0.716}
         - {'low': 0.897, 'high': 0.897}

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -102,7 +102,10 @@ def plot_prevalences(exp_name, channels = ['prevalence'], fname='trajectoriesDat
                             color=palette[k], linewidth=0, alpha=0.4)
         if ems_num == 'EMS-1' :
             ax.legend()
-        ax.set_title(ems_num)
+        plotsubtitle = ems_num.replace('EMS-', 'COVID-19 region ')
+        if ems_num == 'All' :
+            plotsubtitle = ems_num.replace('All', 'Illinois')
+        ax.set_title(plotsubtitle)
         ax.xaxis.set_major_formatter(formatter)
         ax.xaxis.set_major_locator(mdates.MonthLocator())
 

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -111,20 +111,45 @@ def load_ref_df(ems_nr):
     ref_df_cli = ref_df_cli.rename(columns={'new_restore_region': 'covid_region'})
     ref_df_cli['date'] = pd.to_datetime(ref_df_cli['date'])
 
-    if ems_nr > 0:
-        ref_df_emr = ref_df_emr[ref_df_emr['covid_region'] == ems_nr]
-        ref_df_ll = ref_df_ll[ref_df_ll['covid_region'] == ems_nr]
-        ref_df_cli = ref_df_cli[ref_df_cli['covid_region'] == ems_nr]
-    else:
-        ref_df_emr = ref_df_emr.groupby('date_of_extract').agg(np.sum).reset_index()
-        ref_df_ll = ref_df_ll.groupby('date').agg(np.sum).reset_index()
-        ref_df_cli = ref_df_cli.groupby('date').agg(np.sum).reset_index()
+    ref_df_public = pd.read_csv(os.path.join(datapath, 'covid_IDPH', 'Corona virus reports', 'IDPH_public_county.csv'))
+    ref_df_public = merge_county_covidregions(df_x=ref_df_public, key_x='county', key_y='County')
+    ref_df_public = ref_df_public.groupby(['test_date','new_restore_region'])['confirmed_cases'].agg(np.sum).reset_index()
+    ref_df_public = ref_df_public.rename(columns={'new_restore_region': 'covid_region'})
+    ref_df_public['test_date'] = pd.to_datetime(ref_df_public['test_date'])
+    ref_df_public.rename(columns={"test_date" : "date"}, inplace=True)
+
+    if not isinstance(ems_nr, list):
+        if ems_nr > 0:
+            ref_df_emr = ref_df_emr[ref_df_emr['covid_region'] == ems_nr]
+            ref_df_ll = ref_df_ll[ref_df_ll['covid_region'] == ems_nr]
+            ref_df_cli = ref_df_cli[ref_df_cli['covid_region'] == ems_nr]
+            ref_df_public = ref_df_public[ref_df_public['covid_region'] == ems_nr]
+        else:
+            ref_df_emr = ref_df_emr.groupby('date_of_extract').agg(np.sum).reset_index()
+            ref_df_ll = ref_df_ll.groupby('date').agg(np.sum).reset_index()
+            ref_df_cli = ref_df_cli.groupby('date').agg(np.sum).reset_index()
+            ref_df_public = ref_df_public.groupby('date').agg(np.sum).reset_index()
+
+        ref_df_public = ref_df_public.sort_values('date')
+        ref_df_public['new_confirmed_cases'] = count_new(ref_df_public, 'confirmed_cases')
+
+    if isinstance(ems_nr, list):
+        inc_df = pd.DataFrame()
+        for region, df in ref_df_public.groupby('covid_region'):
+            df = df.sort_values('date')
+            sdf = pd.DataFrame({'date': df['date'], 'new_confirmed_cases': count_new(df, 'confirmed_cases')})
+            sdf['covid_region'] = region
+            inc_df = pd.concat([inc_df, sdf])
+        ref_df_public_ext = pd.merge(left=ref_df_public, right=inc_df, on=['date', 'covid_region'])
+        ref_df_public = ref_df_public_ext
 
     merge_keys = ['date', 'covid_region']
     ref_df = pd.merge(how='outer', left=ref_df_ll,  right=ref_df_emr, on=merge_keys)
     ref_df = pd.merge(how='outer', left=ref_df, right=ref_df_cli, on=merge_keys)
+    ref_df = pd.merge(how='outer', left=ref_df, right=ref_df_public, on=merge_keys)
 
-    ref_df = ref_df.sort_values('date')
+    if isinstance(ems_nr, list):
+        ref_df[ref_df['covid_region'].isin(ems_nr)]
 
     return ref_df
 

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -151,6 +151,7 @@ def load_ref_df(ems_nr):
     if isinstance(ems_nr, list):
         ref_df[ref_df['covid_region'].isin(ems_nr)]
 
+    ref_df = ref_df.sort_values(['covid_region', 'date'])
     return ref_df
 
 


### PR DESCRIPTION
- plotter edited for Friday slide: [emresource_cli_per_covidregion.py ](https://github.com/numalariamodeling/covid-chicago/blob/master/data_processing/emresource_cli_per_covidregion.py), added '`runInBatchMode`' flag to either produce standard plots for region 10 and 11, or if false allows to be used for all regions and optionally include public case data
- edited labels in prevalence plotter from EMS to COVID-19 regions, issue created for other plotters [#535 ](https://app.zenhub.com/workspaces/covid-19-modeling-5e8b85bb090561fddfdc48ec/issues/numalariamodeling/covid-chicago/535)
- updated emodl and yamls for the other model types 
- load_red_df  loads public data and also allows a list for the `ems_nr` argument to load for all covid regions and keep all (other options single region or aggregate all remain).
