### PR TITLE
Corrected README, experiment_configs/extendedcobey_200428.yaml, experiment_configs/spatial_EMS_experiment.yaml, and experiment_configs/EMSspecific_sample_parameters.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The model is updated every week to fit to latest hospitalisation and deaths repo
 - 20201015 updated parameter fit, reset fitting method
 - 20201007 updated parameter fit
 - 20200929 updated parameter fit, changed fitting method
-- 20200922 updated parameter fit
+- 20200922 updated parameter fit, changed d_Sym parameters (generic)
 - 20200915 updated parameter fit, added social multiplier 7 (time event Aug 25)
 - 20200909 updated parameter fit, updated evolution of CFR
 - 20200825 updated parameter fit

--- a/experiment_configs/EMSspecific_sample_parameters.yaml
+++ b/experiment_configs/EMSspecific_sample_parameters.yaml
@@ -1,39 +1,5 @@
 fixed_parameters_global:
 sampled_parameters:
-  'd_Sym':
-    EMS_1:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_2:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_3:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_4:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_5:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_6:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_7:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_8:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_9:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_10:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
-    EMS_11:
-      np.random: uniform
-      function_kwargs: {'low':0.0, 'high': 0.02}
   'ki_multiplier_3a':
     EMS_1:
       np.random: uniform
@@ -250,10 +216,10 @@ sampled_parameters:
       function_kwargs: {'low':  0.205, 'high': 0.205}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.120, 'high': 0.120}
+      function_kwargs: {'low': 0.180, 'high': 0.180}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low':0.180, 'high': 0.180}
+      function_kwargs: {'low':0.150, 'high': 0.150}
     EMS_6:
       np.random: uniform
       function_kwargs: {'low': 0.240, 'high': 0.240}
@@ -284,13 +250,13 @@ sampled_parameters:
       function_kwargs: {'low':  0.410, 'high': 0.410}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.250, 'high': 0.250}
+      function_kwargs: {'low': 0.162, 'high': 0.162}
     EMS_5:
       np.random: uniform
       function_kwargs: {'low':0.215, 'high': 0.215}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low': 0.210, 'high': 0.210}
+      function_kwargs: {'low': 0.215, 'high': 0.215}
     EMS_7:
       np.random: uniform
       function_kwargs: {'low': 0.170, 'high': 0.170}
@@ -309,16 +275,16 @@ sampled_parameters:
   'ki_multiplier_10':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low': 0.234, 'high': 0.234}
+      function_kwargs: {'low': 0.243, 'high': 0.243}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low': 0.222, 'high': 0.222}
+      function_kwargs: {'low': 0.252, 'high': 0.252}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low': 0.420, 'high': 0.420}
+      function_kwargs: {'low': 0.400, 'high': 0.400}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.225, 'high': 0.225}
+      function_kwargs: {'low': 0.260, 'high': 0.260}
     EMS_5:
       np.random: uniform
       function_kwargs: {'low': 0.325, 'high': 0.325}
@@ -327,53 +293,53 @@ sampled_parameters:
       function_kwargs: {'low': 0.323, 'high': 0.323}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low': 0.221, 'high': 0.221}
+      function_kwargs: {'low': 0.230, 'high': 0.230}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low': 0.220, 'high': 0.220}
+      function_kwargs: {'low': 0.200, 'high': 0.200}
     EMS_9:
       np.random: uniform
       function_kwargs: {'low': 0.230, 'high': 0.230}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low': 0.240, 'high': 0.240}
+      function_kwargs: {'low': 0.250, 'high': 0.250}
     EMS_11:
       np.random: uniform
       function_kwargs: {'low': 0.195, 'high': 0.195}
   'ki_multiplier_11':
     EMS_1:
       np.random: uniform
-      function_kwargs: {'low': 0.270, 'high': 0.270}
+      function_kwargs: {'low': 0.160, 'high': 0.160}
     EMS_2:
       np.random: uniform
-      function_kwargs: {'low': 0.295, 'high': 0.295}
+      function_kwargs: {'low': 0.160, 'high': 0.160}
     EMS_3:
       np.random: uniform
-      function_kwargs: {'low': 0.430, 'high': 0.430}
+      function_kwargs: {'low': 0.350, 'high': 0.350}
     EMS_4:
       np.random: uniform
-      function_kwargs: {'low': 0.375, 'high': 0.375}
+      function_kwargs: {'low': 0.260, 'high': 0.260}
     EMS_5:
       np.random: uniform
-      function_kwargs: {'low': 0.250, 'high': 0.250}
+      function_kwargs: {'low': 0.160, 'high': 0.160}
     EMS_6:
       np.random: uniform
-      function_kwargs: {'low': 0.330, 'high': 0.330}
+      function_kwargs: {'low': 0.120, 'high': 0.120}
     EMS_7:
       np.random: uniform
-      function_kwargs: {'low': 0.340, 'high': 0.340}
+      function_kwargs: {'low': 0.225, 'high': 0.225}
     EMS_8:
       np.random: uniform
-      function_kwargs: {'low': 0.160, 'high': 0.160}
+      function_kwargs: {'low': 0.140, 'high': 0.140}
     EMS_9:
       np.random: uniform
-      function_kwargs: {'low': 0.245, 'high': 0.245}
+      function_kwargs: {'low': 0.160, 'high': 0.160}
     EMS_10:
       np.random: uniform
-      function_kwargs: {'low': 0.240, 'high': 0.240}
+      function_kwargs: {'low': 0.190, 'high': 0.190}
     EMS_11:
       np.random: uniform
-      function_kwargs: {'low': 0.180, 'high': 0.180}
+      function_kwargs: {'low': 0.085, 'high': 0.085}
   'd_Sym':
     EMS_1:
       np.random: uniform

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -229,9 +229,6 @@ intervention_parameters:
   'multiplier_elderly':
     np.random: uniform
     function_kwargs: {'low': 0.6, 'high':0.6}
-  'ki_multiplier_11_EMS_5':
-    np.random: uniform
-    function_kwargs: {'low': 0.450, 'high': 0.450}
 time_parameters:
   ### TIME-VARYING PARAMETER  - DATES
   ### Reduce Ki due to stay-at-home policy 


### PR DESCRIPTION
Updated per Manuela's comments: 

• in the README , added back comment for '20200922 updated parameter fit, changed d_Sym parameters (generic)' 
• in 'experiment_configs/extendedcobey_200428.yaml', ki_multiplier_11_EMS-5 removed 
• in 'experiment_configs/EMSspecific_sample_parameters.yaml' d_Sym 1st definition removed, all regions updated with most recent fitting parameters as of 11/24/2020 
• region 5 ki_multiplier_11 confirmed to now be correct and same in  'experiment_configs/EMSspecific_sample_parameters.yaml' and experiment_configs/spatial_EMS_experiment.yaml ( now 0.160 in both, which corresponds to 11/24/2020 fitting parameter of 0.160)
