### PR TITLE
use median instead of mean in data comparison

### DIFF
--- a/Rfiles/simulation_plotter/compare_simulation_iterations.R
+++ b/Rfiles/simulation_plotter/compare_simulation_iterations.R
@@ -34,6 +34,19 @@ dat2 <- read_csv(file.path(project_path, paste0("NU_civis_outputs/", simdates[2]
 dat3 <- read_csv(file.path(project_path, paste0("NU_civis_outputs/", simdates[3], "/csv/nu_",  simdates[3], ".csv")))
 
 
+### some dates are format  '%m/%d/%Y' instead of '%Y-%m-%d'
+if(as.Date(dat1$date)[1] <= as.Date("2020-01-01")){
+  dat1$date <- as.Date(dat1$date, format='%m/%d/%Y')
+} else{dat1$date <- as.Date(dat1$date)}
+
+if(as.Date(dat2$date)[1] <= as.Date("2020-01-01")){
+  dat2$date <- as.Date(dat2$date, format='%m/%d/%Y')
+} else{dat2$date <- as.Date(dat2$date)}
+
+if(as.Date(dat3$date)[1] <= as.Date("2020-01-01")){
+  dat3$date <- as.Date(dat3$date, format='%m/%d/%Y')
+}else{dat3$date <- as.Date(dat3$date)}
+
 
 dat1$simdate <- simdates[1]
 dat2$simdate <- simdates[2]

--- a/plotters/data_comparison.py
+++ b/plotters/data_comparison.py
@@ -89,9 +89,9 @@ def plot_sim_and_ref_Ki(df, ref_df, channels, data_channel_names, first_day=date
         ax = fig.add_subplot(2,2,c+1)
 
         for k, (ki, kdf) in enumerate(df.groupby('Ki')) :
-            mdf = kdf.groupby('time')[channel].agg([np.mean, CI_5, CI_95, CI_25, CI_75]).reset_index()
+            mdf = kdf.groupby('time')[channel].agg([CI_50, CI_5, CI_95, CI_25, CI_75]).reset_index()
             dates = [first_day + timedelta(days=int(x)) for x in mdf['time']]
-            ax.plot(dates, mdf['mean'], color=palette[k], label=ki)
+            ax.plot(dates, mdf['CI_50'], color=palette[k], label=ki)
             ax.fill_between(dates, mdf['CI_5'], mdf['CI_95'],
                         color=palette[k], linewidth=0, alpha=0.2)
             ax.fill_between(dates, mdf['CI_25'], mdf['CI_75'],
@@ -121,9 +121,9 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, f
         ax = fig.add_subplot(2, 3, c + 1)
 
         # for k, (ki, kdf) in enumerate(df.groupby('Ki')) :
-        mdf = df.groupby('time')[channel].agg([np.mean, CI_5, CI_95, CI_25, CI_75]).reset_index()
+        mdf = df.groupby('time')[channel].agg([CI_50, CI_5, CI_95, CI_25, CI_75]).reset_index()
         dates = [first_day + timedelta(days=int(x)) for x in mdf['time']]
-        ax.plot(dates, mdf['mean'], color=palette[k])
+        ax.plot(dates, mdf['CI_50'], color=palette[k])
         ax.fill_between(dates, mdf['CI_5'], mdf['CI_95'],
                         color=palette[k], linewidth=0, alpha=0.2)
         ax.fill_between(dates, mdf['CI_25'], mdf['CI_75'],

--- a/plotters/data_comparison_spatial.py
+++ b/plotters/data_comparison_spatial.py
@@ -71,9 +71,9 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, f
         ax = fig.add_subplot(2, 3, c + 1)
 
         # for k, (ki, kdf) in enumerate(df.groupby('Ki')) :
-        mdf = df.groupby('time')[channel].agg([np.mean, CI_5, CI_95, CI_25, CI_75]).reset_index()
+        mdf = df.groupby('time')[channel].agg([CI_50,CI_5, CI_95, CI_25, CI_75]).reset_index()
         dates = [first_day + timedelta(days=int(x)) for x in mdf['time']]
-        ax.plot(dates, mdf['mean'], color=palette[k])
+        ax.plot(dates, mdf['CI_50'], color=palette[k])
         ax.fill_between(dates, mdf['CI_5'], mdf['CI_95'],
                         color=palette[k], linewidth=0, alpha=0.2)
         ax.fill_between(dates, mdf['CI_25'], mdf['CI_75'],

--- a/plotters/data_comparison_spatial_2.py
+++ b/plotters/data_comparison_spatial_2.py
@@ -116,9 +116,9 @@ def plot_sim_and_ref(exp_names, ems_nr,
             exp_name_label =  str(exp_name.split('_')[-1])
 
             # for k, (ki, kdf) in enumerate(df.groupby('Ki')) :
-            mdf = df.groupby('time')[channel].agg([np.mean, CI_5, CI_95, CI_25, CI_75]).reset_index()
+            mdf = df.groupby('time')[channel].agg([CI_50, CI_5, CI_95, CI_25, CI_75]).reset_index()
             dates = [first_day + timedelta(days=int(x)) for x in mdf['time']]
-            ax.plot(dates, mdf['mean'], color=palette[d], label=exp_name_label)
+            ax.plot(dates, mdf['CI_50'], color=palette[d], label=exp_name_label)
             ax.fill_between(dates, mdf['CI_5'], mdf['CI_95'],
                         color=palette[d], linewidth=0, alpha=0.1)
             ax.fill_between(dates, mdf['CI_25'], mdf['CI_75'],

--- a/plotters/data_comparison_spatial_3.py
+++ b/plotters/data_comparison_spatial_3.py
@@ -80,12 +80,12 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, p
         ax = fig.add_subplot(2, 3, c + 1)
 
         # for k, (ki, kdf) in enumerate(df.groupby('Ki')) :
-        mdf = df.groupby(['time',param])[channel].agg([np.mean, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
+        mdf = df.groupby(['time',param])[channel].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
 
         for i, rtc in enumerate(mdf[param].unique()):
             mdf_sub = mdf[mdf[param] == rtc]
             dates = [first_day + timedelta(days=int(x)) for x in mdf_sub['time']]
-            ax.plot(dates, mdf_sub['mean'], color=palette[i], label=rtc)
+            ax.plot(dates, mdf_sub['CI_50'], color=palette[i], label=rtc)
 
         ax.fill_between(dates, mdf_sub['CI_2pt5'], mdf_sub['CI_97pt5'], color=palette[i], linewidth=0, alpha=0.2)
 

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -179,7 +179,7 @@ def rename_geography_and_save(df,filename) :
     if "geography_modeled" in dfout.columns:
         dfout['geography_modeled'] = dfout['geography_modeled'].str.replace('ems', 'covidregion_')
 
-    dfout.to_csv(os.path.join(sim_output_path, filename), index=False)
+    dfout.to_csv(os.path.join(sim_output_path, filename), index=False, date_format='%Y-%m-%d')
 
 
 if __name__ == '__main__' :


### PR DESCRIPTION
- use median instead of mean in data comparison, this will require moving `ki_multipliers `up (separate commit for this weeks fitting)
- also edited dateformat when saving csv in [process_for_civis_EMSgrp.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/process_for_civis_EMSgrp.py) and   [iteration comparison r script ](https://github.com/numalariamodeling/covid-chicago/blob/master/Rfiles/simulation_plotter/compare_simulation_iterations.R)
