### PR TITLE
Revised prevalence, seroprevalence and new IFR outcome channels

### DIFF
--- a/emodl/extendedmodel.emodl
+++ b/emodl/extendedmodel.emodl
@@ -94,12 +94,11 @@
 (func infected_det (+ infectious_det H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
 (func infected_cumul (+ infected recovered deaths))  
 
-(func prevalence (/ infected N))  
-(func seroprevalence (/ (+ infected recovered) N))  
+(func prevalence (/ infected (- N deaths)))  
+(func seroprevalence (/ (+ infected recovered) (- N deaths)))  
 
-(func prevalence_det (/ infected_det N))  
-(func seroprevalence_det (/ (+ infected_det recovered_det) N))  
-
+(func prevalence_det (/ infected_det (- N deaths)))  
+(func seroprevalence_det (/ (+ infected_det recovered_det) (- N deaths)))  
 
 
 

--- a/emodl/extendedmodel.emodl
+++ b/emodl/extendedmodel.emodl
@@ -92,13 +92,7 @@
 
 (func infected (+ infectious_det infectious_undet H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
 (func infected_det (+ infectious_det H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
-(func infected_cumul (+ infected recovered deaths))  
-
-(func prevalence (/ infected (- N deaths)))  
-(func seroprevalence (/ (+ infected recovered) (- N deaths)))  
-
-(func prevalence_det (/ infected_det (- N deaths)))  
-(func seroprevalence_det (/ (+ infected_det recovered_det) (- N deaths)))  
+(func infected_cumul (+ infected recovered deaths))   
 
 
 
@@ -141,6 +135,11 @@
 (observe symptomatic_mild_det symptomatic_mild_det)
 (observe symptomatic_severe_det symptomatic_severe_det)
 (observe recovered_det recovered_det)
+
+(observe infectious_undet infectious_undet)
+(observe infectious_det infectious_det)
+(observe infectious_det_symp infectious_det_symp)
+(observe infectious_det_AsP infectious_det_AsP)
 
 
 

--- a/emodl/extendedmodel_EMS.emodl
+++ b/emodl/extendedmodel_EMS.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS.emodl
+++ b/emodl/extendedmodel_EMS.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_changeTD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_changeTD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_dAsP.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_dAsP.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsP_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsP_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dSym.emodl
+++ b/emodl/extendedmodel_EMS_dSym.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dSym.emodl
+++ b/emodl/extendedmodel_EMS_dSym.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dSym_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dSym_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_gradual_reopening.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_gradual_reopening.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
+++ b/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
+++ b/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_interventionStop.emodl
+++ b/emodl/extendedmodel_EMS_interventionStop.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_interventionStop.emodl
+++ b/emodl/extendedmodel_EMS_interventionStop.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_neverSIP.emodl
+++ b/emodl/extendedmodel_EMS_neverSIP.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 ;[INTERVENTIONS]
 ;[ADDITIONAL_TIMEEVENTS]

--- a/emodl/extendedmodel_EMS_neverSIP.emodl
+++ b/emodl/extendedmodel_EMS_neverSIP.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_changeTD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_changeTD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_reopen_rollback.emodl
+++ b/emodl/extendedmodel_EMS_reopen_rollback.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_reopen_rollback.emodl
+++ b/emodl/extendedmodel_EMS_reopen_rollback.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_EMS_rollback.emodl
+++ b/emodl/extendedmodel_EMS_rollback.emodl
@@ -517,11 +517,11 @@
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
 
-(func prevalence_EMS_1 (/ infected_EMS_1 N_EMS_1))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) N_EMS_1))  
+(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 N_EMS_1))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) N_EMS_1))  
+(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
+(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
 
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
@@ -570,11 +570,11 @@
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
 
-(func prevalence_EMS_2 (/ infected_EMS_2 N_EMS_2))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) N_EMS_2))  
+(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 N_EMS_2))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) N_EMS_2))  
+(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
+(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
 
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
@@ -623,11 +623,11 @@
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
 
-(func prevalence_EMS_3 (/ infected_EMS_3 N_EMS_3))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) N_EMS_3))  
+(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 N_EMS_3))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) N_EMS_3))  
+(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
+(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
 
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
@@ -676,11 +676,11 @@
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
 
-(func prevalence_EMS_4 (/ infected_EMS_4 N_EMS_4))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) N_EMS_4))  
+(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 N_EMS_4))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) N_EMS_4))  
+(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
+(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
 
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
@@ -729,11 +729,11 @@
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
 
-(func prevalence_EMS_5 (/ infected_EMS_5 N_EMS_5))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) N_EMS_5))  
+(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 N_EMS_5))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) N_EMS_5))  
+(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
+(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
 
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
@@ -782,11 +782,11 @@
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
 
-(func prevalence_EMS_6 (/ infected_EMS_6 N_EMS_6))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) N_EMS_6))  
+(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 N_EMS_6))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) N_EMS_6))  
+(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
+(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
 
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
@@ -835,11 +835,11 @@
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
 
-(func prevalence_EMS_7 (/ infected_EMS_7 N_EMS_7))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) N_EMS_7))  
+(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 N_EMS_7))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) N_EMS_7))  
+(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
+(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
 
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
@@ -888,11 +888,11 @@
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
 
-(func prevalence_EMS_8 (/ infected_EMS_8 N_EMS_8))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) N_EMS_8))  
+(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 N_EMS_8))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) N_EMS_8))  
+(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
+(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
 
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
@@ -941,11 +941,11 @@
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
 
-(func prevalence_EMS_9 (/ infected_EMS_9 N_EMS_9))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) N_EMS_9))  
+(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 N_EMS_9))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) N_EMS_9))  
+(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
+(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
 
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
@@ -994,11 +994,11 @@
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
 
-(func prevalence_EMS_10 (/ infected_EMS_10 N_EMS_10))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) N_EMS_10))  
+(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 N_EMS_10))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) N_EMS_10))  
+(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
+(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
 
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
@@ -1047,11 +1047,11 @@
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
 
-(func prevalence_EMS_11 (/ infected_EMS_11 N_EMS_11))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) N_EMS_11))  
+(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 N_EMS_11))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) N_EMS_11))  
+(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
+(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
 
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))

--- a/emodl/extendedmodel_EMS_rollback.emodl
+++ b/emodl/extendedmodel_EMS_rollback.emodl
@@ -516,13 +516,7 @@
 (func infected_EMS_1 (+ infectious_det_EMS_1 infectious_undet_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_det_EMS_1 (+ infectious_det_EMS_1 H1_det3::EMS_1 H2_det3::EMS_1 H3_det3::EMS_1 C2_det3::EMS_1 C3_det3::EMS_1))
 (func infected_cumul_EMS_1 (+ infected_EMS_1 recovered_EMS_1 deaths_EMS_1))  
-
-(func prevalence_EMS_1 (/ infected_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_EMS_1 (/ (+ infected_EMS_1 recovered_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
-(func prevalence_det_EMS_1 (/ infected_det_EMS_1 (- N_EMS_1 deaths_EMS_1 )))  
-(func seroprevalence_det_EMS_1 (/ (+ infected_det_EMS_1 recovered_det_EMS_1) (- N_EMS_1 deaths_EMS_1 )))  
-
+(func infected_det_cumul_EMS_1 (+ infected_det_EMS_1 recovered_det_EMS_1 D3_det3::EMS_1))  
 
 (func asymptomatic_EMS_2 (+ As_preD::EMS_2 As::EMS_2 As_det1::EMS_2))
 
@@ -569,13 +563,7 @@
 (func infected_EMS_2 (+ infectious_det_EMS_2 infectious_undet_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_det_EMS_2 (+ infectious_det_EMS_2 H1_det3::EMS_2 H2_det3::EMS_2 H3_det3::EMS_2 C2_det3::EMS_2 C3_det3::EMS_2))
 (func infected_cumul_EMS_2 (+ infected_EMS_2 recovered_EMS_2 deaths_EMS_2))  
-
-(func prevalence_EMS_2 (/ infected_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_EMS_2 (/ (+ infected_EMS_2 recovered_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
-(func prevalence_det_EMS_2 (/ infected_det_EMS_2 (- N_EMS_2 deaths_EMS_2 )))  
-(func seroprevalence_det_EMS_2 (/ (+ infected_det_EMS_2 recovered_det_EMS_2) (- N_EMS_2 deaths_EMS_2 )))  
-
+(func infected_det_cumul_EMS_2 (+ infected_det_EMS_2 recovered_det_EMS_2 D3_det3::EMS_2))  
 
 (func asymptomatic_EMS_3 (+ As_preD::EMS_3 As::EMS_3 As_det1::EMS_3))
 
@@ -622,13 +610,7 @@
 (func infected_EMS_3 (+ infectious_det_EMS_3 infectious_undet_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_det_EMS_3 (+ infectious_det_EMS_3 H1_det3::EMS_3 H2_det3::EMS_3 H3_det3::EMS_3 C2_det3::EMS_3 C3_det3::EMS_3))
 (func infected_cumul_EMS_3 (+ infected_EMS_3 recovered_EMS_3 deaths_EMS_3))  
-
-(func prevalence_EMS_3 (/ infected_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_EMS_3 (/ (+ infected_EMS_3 recovered_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
-(func prevalence_det_EMS_3 (/ infected_det_EMS_3 (- N_EMS_3 deaths_EMS_3 )))  
-(func seroprevalence_det_EMS_3 (/ (+ infected_det_EMS_3 recovered_det_EMS_3) (- N_EMS_3 deaths_EMS_3 )))  
-
+(func infected_det_cumul_EMS_3 (+ infected_det_EMS_3 recovered_det_EMS_3 D3_det3::EMS_3))  
 
 (func asymptomatic_EMS_4 (+ As_preD::EMS_4 As::EMS_4 As_det1::EMS_4))
 
@@ -675,13 +657,7 @@
 (func infected_EMS_4 (+ infectious_det_EMS_4 infectious_undet_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_det_EMS_4 (+ infectious_det_EMS_4 H1_det3::EMS_4 H2_det3::EMS_4 H3_det3::EMS_4 C2_det3::EMS_4 C3_det3::EMS_4))
 (func infected_cumul_EMS_4 (+ infected_EMS_4 recovered_EMS_4 deaths_EMS_4))  
-
-(func prevalence_EMS_4 (/ infected_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_EMS_4 (/ (+ infected_EMS_4 recovered_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
-(func prevalence_det_EMS_4 (/ infected_det_EMS_4 (- N_EMS_4 deaths_EMS_4 )))  
-(func seroprevalence_det_EMS_4 (/ (+ infected_det_EMS_4 recovered_det_EMS_4) (- N_EMS_4 deaths_EMS_4 )))  
-
+(func infected_det_cumul_EMS_4 (+ infected_det_EMS_4 recovered_det_EMS_4 D3_det3::EMS_4))  
 
 (func asymptomatic_EMS_5 (+ As_preD::EMS_5 As::EMS_5 As_det1::EMS_5))
 
@@ -728,13 +704,7 @@
 (func infected_EMS_5 (+ infectious_det_EMS_5 infectious_undet_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_det_EMS_5 (+ infectious_det_EMS_5 H1_det3::EMS_5 H2_det3::EMS_5 H3_det3::EMS_5 C2_det3::EMS_5 C3_det3::EMS_5))
 (func infected_cumul_EMS_5 (+ infected_EMS_5 recovered_EMS_5 deaths_EMS_5))  
-
-(func prevalence_EMS_5 (/ infected_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_EMS_5 (/ (+ infected_EMS_5 recovered_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
-(func prevalence_det_EMS_5 (/ infected_det_EMS_5 (- N_EMS_5 deaths_EMS_5 )))  
-(func seroprevalence_det_EMS_5 (/ (+ infected_det_EMS_5 recovered_det_EMS_5) (- N_EMS_5 deaths_EMS_5 )))  
-
+(func infected_det_cumul_EMS_5 (+ infected_det_EMS_5 recovered_det_EMS_5 D3_det3::EMS_5))  
 
 (func asymptomatic_EMS_6 (+ As_preD::EMS_6 As::EMS_6 As_det1::EMS_6))
 
@@ -781,13 +751,7 @@
 (func infected_EMS_6 (+ infectious_det_EMS_6 infectious_undet_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_det_EMS_6 (+ infectious_det_EMS_6 H1_det3::EMS_6 H2_det3::EMS_6 H3_det3::EMS_6 C2_det3::EMS_6 C3_det3::EMS_6))
 (func infected_cumul_EMS_6 (+ infected_EMS_6 recovered_EMS_6 deaths_EMS_6))  
-
-(func prevalence_EMS_6 (/ infected_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_EMS_6 (/ (+ infected_EMS_6 recovered_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
-(func prevalence_det_EMS_6 (/ infected_det_EMS_6 (- N_EMS_6 deaths_EMS_6 )))  
-(func seroprevalence_det_EMS_6 (/ (+ infected_det_EMS_6 recovered_det_EMS_6) (- N_EMS_6 deaths_EMS_6 )))  
-
+(func infected_det_cumul_EMS_6 (+ infected_det_EMS_6 recovered_det_EMS_6 D3_det3::EMS_6))  
 
 (func asymptomatic_EMS_7 (+ As_preD::EMS_7 As::EMS_7 As_det1::EMS_7))
 
@@ -834,13 +798,7 @@
 (func infected_EMS_7 (+ infectious_det_EMS_7 infectious_undet_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_det_EMS_7 (+ infectious_det_EMS_7 H1_det3::EMS_7 H2_det3::EMS_7 H3_det3::EMS_7 C2_det3::EMS_7 C3_det3::EMS_7))
 (func infected_cumul_EMS_7 (+ infected_EMS_7 recovered_EMS_7 deaths_EMS_7))  
-
-(func prevalence_EMS_7 (/ infected_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_EMS_7 (/ (+ infected_EMS_7 recovered_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
-(func prevalence_det_EMS_7 (/ infected_det_EMS_7 (- N_EMS_7 deaths_EMS_7 )))  
-(func seroprevalence_det_EMS_7 (/ (+ infected_det_EMS_7 recovered_det_EMS_7) (- N_EMS_7 deaths_EMS_7 )))  
-
+(func infected_det_cumul_EMS_7 (+ infected_det_EMS_7 recovered_det_EMS_7 D3_det3::EMS_7))  
 
 (func asymptomatic_EMS_8 (+ As_preD::EMS_8 As::EMS_8 As_det1::EMS_8))
 
@@ -887,13 +845,7 @@
 (func infected_EMS_8 (+ infectious_det_EMS_8 infectious_undet_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_det_EMS_8 (+ infectious_det_EMS_8 H1_det3::EMS_8 H2_det3::EMS_8 H3_det3::EMS_8 C2_det3::EMS_8 C3_det3::EMS_8))
 (func infected_cumul_EMS_8 (+ infected_EMS_8 recovered_EMS_8 deaths_EMS_8))  
-
-(func prevalence_EMS_8 (/ infected_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_EMS_8 (/ (+ infected_EMS_8 recovered_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
-(func prevalence_det_EMS_8 (/ infected_det_EMS_8 (- N_EMS_8 deaths_EMS_8 )))  
-(func seroprevalence_det_EMS_8 (/ (+ infected_det_EMS_8 recovered_det_EMS_8) (- N_EMS_8 deaths_EMS_8 )))  
-
+(func infected_det_cumul_EMS_8 (+ infected_det_EMS_8 recovered_det_EMS_8 D3_det3::EMS_8))  
 
 (func asymptomatic_EMS_9 (+ As_preD::EMS_9 As::EMS_9 As_det1::EMS_9))
 
@@ -940,13 +892,7 @@
 (func infected_EMS_9 (+ infectious_det_EMS_9 infectious_undet_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_det_EMS_9 (+ infectious_det_EMS_9 H1_det3::EMS_9 H2_det3::EMS_9 H3_det3::EMS_9 C2_det3::EMS_9 C3_det3::EMS_9))
 (func infected_cumul_EMS_9 (+ infected_EMS_9 recovered_EMS_9 deaths_EMS_9))  
-
-(func prevalence_EMS_9 (/ infected_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_EMS_9 (/ (+ infected_EMS_9 recovered_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
-(func prevalence_det_EMS_9 (/ infected_det_EMS_9 (- N_EMS_9 deaths_EMS_9 )))  
-(func seroprevalence_det_EMS_9 (/ (+ infected_det_EMS_9 recovered_det_EMS_9) (- N_EMS_9 deaths_EMS_9 )))  
-
+(func infected_det_cumul_EMS_9 (+ infected_det_EMS_9 recovered_det_EMS_9 D3_det3::EMS_9))  
 
 (func asymptomatic_EMS_10 (+ As_preD::EMS_10 As::EMS_10 As_det1::EMS_10))
 
@@ -993,13 +939,7 @@
 (func infected_EMS_10 (+ infectious_det_EMS_10 infectious_undet_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_det_EMS_10 (+ infectious_det_EMS_10 H1_det3::EMS_10 H2_det3::EMS_10 H3_det3::EMS_10 C2_det3::EMS_10 C3_det3::EMS_10))
 (func infected_cumul_EMS_10 (+ infected_EMS_10 recovered_EMS_10 deaths_EMS_10))  
-
-(func prevalence_EMS_10 (/ infected_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_EMS_10 (/ (+ infected_EMS_10 recovered_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
-(func prevalence_det_EMS_10 (/ infected_det_EMS_10 (- N_EMS_10 deaths_EMS_10 )))  
-(func seroprevalence_det_EMS_10 (/ (+ infected_det_EMS_10 recovered_det_EMS_10) (- N_EMS_10 deaths_EMS_10 )))  
-
+(func infected_det_cumul_EMS_10 (+ infected_det_EMS_10 recovered_det_EMS_10 D3_det3::EMS_10))  
 
 (func asymptomatic_EMS_11 (+ As_preD::EMS_11 As::EMS_11 As_det1::EMS_11))
 
@@ -1046,18 +986,15 @@
 (func infected_EMS_11 (+ infectious_det_EMS_11 infectious_undet_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_det_EMS_11 (+ infectious_det_EMS_11 H1_det3::EMS_11 H2_det3::EMS_11 H3_det3::EMS_11 C2_det3::EMS_11 C3_det3::EMS_11))
 (func infected_cumul_EMS_11 (+ infected_EMS_11 recovered_EMS_11 deaths_EMS_11))  
-
-(func prevalence_EMS_11 (/ infected_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_EMS_11 (/ (+ infected_EMS_11 recovered_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
-(func prevalence_det_EMS_11 (/ infected_det_EMS_11 (- N_EMS_11 deaths_EMS_11 )))  
-(func seroprevalence_det_EMS_11 (/ (+ infected_det_EMS_11 recovered_det_EMS_11) (- N_EMS_11 deaths_EMS_11 )))  
-
+(func infected_det_cumul_EMS_11 (+ infected_det_EMS_11 recovered_det_EMS_11 D3_det3::EMS_11))  
 
 (observe susceptible_All (+ S::EMS_1 S::EMS_2 S::EMS_3 S::EMS_4 S::EMS_5 S::EMS_6 S::EMS_7 S::EMS_8 S::EMS_9 S::EMS_10 S::EMS_11))
 (observe infected_All (+ infected_EMS_1 infected_EMS_2 infected_EMS_3 infected_EMS_4 infected_EMS_5 infected_EMS_6 infected_EMS_7 infected_EMS_8 infected_EMS_9 infected_EMS_10 infected_EMS_11))
+(observe infected_det_All (+ infected_det_EMS_1 infected_det_EMS_2 infected_det_EMS_3 infected_det_EMS_4 infected_det_EMS_5 infected_det_EMS_6 infected_det_EMS_7 infected_det_EMS_8 infected_det_EMS_9 infected_det_EMS_10 infected_det_EMS_11))
 (observe recovered_All (+ recovered_EMS_1 recovered_EMS_2 recovered_EMS_3 recovered_EMS_4 recovered_EMS_5 recovered_EMS_6 recovered_EMS_7 recovered_EMS_8 recovered_EMS_9 recovered_EMS_10 recovered_EMS_11))
+(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 (observe infected_cumul_All (+ infected_cumul_EMS_1 infected_cumul_EMS_2 infected_cumul_EMS_3 infected_cumul_EMS_4 infected_cumul_EMS_5 infected_cumul_EMS_6 infected_cumul_EMS_7 infected_cumul_EMS_8 infected_cumul_EMS_9 infected_cumul_EMS_10 infected_cumul_EMS_11))
+(observe infected_det_cumul_All (+ infected_det_cumul_EMS_1 infected_det_cumul_EMS_2 infected_det_cumul_EMS_3 infected_det_cumul_EMS_4 infected_det_cumul_EMS_5 infected_det_cumul_EMS_6 infected_det_cumul_EMS_7 infected_det_cumul_EMS_8 infected_det_cumul_EMS_9 infected_det_cumul_EMS_10 infected_det_cumul_EMS_11))
 (observe asymp_cumul_All (+ asymp_cumul_EMS_1 asymp_cumul_EMS_2 asymp_cumul_EMS_3 asymp_cumul_EMS_4 asymp_cumul_EMS_5 asymp_cumul_EMS_6 asymp_cumul_EMS_7 asymp_cumul_EMS_8 asymp_cumul_EMS_9 asymp_cumul_EMS_10 asymp_cumul_EMS_11))
 (observe asymp_det_cumul_All (+ asymp_det_cumul_EMS_1 asymp_det_cumul_EMS_2 asymp_det_cumul_EMS_3 asymp_det_cumul_EMS_4 asymp_det_cumul_EMS_5 asymp_det_cumul_EMS_6 asymp_det_cumul_EMS_7 asymp_det_cumul_EMS_8 asymp_det_cumul_EMS_9 asymp_det_cumul_EMS_10 asymp_det_cumul_EMS_11))
 (observe symptomatic_mild_All (+ symptomatic_mild_EMS_1 symptomatic_mild_EMS_2 symptomatic_mild_EMS_3 symptomatic_mild_EMS_4 symptomatic_mild_EMS_5 symptomatic_mild_EMS_6 symptomatic_mild_EMS_7 symptomatic_mild_EMS_8 symptomatic_mild_EMS_9 symptomatic_mild_EMS_10 symptomatic_mild_EMS_11))
@@ -1086,13 +1023,14 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
-(observe recovered_det_All (+ recovered_det_EMS_1 recovered_det_EMS_2 recovered_det_EMS_3 recovered_det_EMS_4 recovered_det_EMS_5 recovered_det_EMS_6 recovered_det_EMS_7 recovered_det_EMS_8 recovered_det_EMS_9 recovered_det_EMS_10 recovered_det_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
 (observe infected_EMS-1 infected_EMS_1)
+(observe infected_det_EMS-1 infected_det_EMS_1)
 (observe recovered_EMS-1 recovered_EMS_1)
 (observe infected_cumul_EMS-1 infected_cumul_EMS_1)
+(observe infected_det_cumul_EMS-1 infected_det_cumul_EMS_1)
 
 (observe asymp_cumul_EMS-1 asymp_cumul_EMS_1 )
 (observe asymp_det_cumul_EMS-1 asymp_det_cumul_EMS_1)
@@ -1135,8 +1073,10 @@
 
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
+(observe infected_det_EMS-2 infected_det_EMS_2)
 (observe recovered_EMS-2 recovered_EMS_2)
 (observe infected_cumul_EMS-2 infected_cumul_EMS_2)
+(observe infected_det_cumul_EMS-2 infected_det_cumul_EMS_2)
 
 (observe asymp_cumul_EMS-2 asymp_cumul_EMS_2 )
 (observe asymp_det_cumul_EMS-2 asymp_det_cumul_EMS_2)
@@ -1179,8 +1119,10 @@
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
+(observe infected_det_EMS-3 infected_det_EMS_3)
 (observe recovered_EMS-3 recovered_EMS_3)
 (observe infected_cumul_EMS-3 infected_cumul_EMS_3)
+(observe infected_det_cumul_EMS-3 infected_det_cumul_EMS_3)
 
 (observe asymp_cumul_EMS-3 asymp_cumul_EMS_3 )
 (observe asymp_det_cumul_EMS-3 asymp_det_cumul_EMS_3)
@@ -1223,8 +1165,10 @@
 
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
+(observe infected_det_EMS-4 infected_det_EMS_4)
 (observe recovered_EMS-4 recovered_EMS_4)
 (observe infected_cumul_EMS-4 infected_cumul_EMS_4)
+(observe infected_det_cumul_EMS-4 infected_det_cumul_EMS_4)
 
 (observe asymp_cumul_EMS-4 asymp_cumul_EMS_4 )
 (observe asymp_det_cumul_EMS-4 asymp_det_cumul_EMS_4)
@@ -1267,8 +1211,10 @@
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
+(observe infected_det_EMS-5 infected_det_EMS_5)
 (observe recovered_EMS-5 recovered_EMS_5)
 (observe infected_cumul_EMS-5 infected_cumul_EMS_5)
+(observe infected_det_cumul_EMS-5 infected_det_cumul_EMS_5)
 
 (observe asymp_cumul_EMS-5 asymp_cumul_EMS_5 )
 (observe asymp_det_cumul_EMS-5 asymp_det_cumul_EMS_5)
@@ -1311,8 +1257,10 @@
 
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
+(observe infected_det_EMS-6 infected_det_EMS_6)
 (observe recovered_EMS-6 recovered_EMS_6)
 (observe infected_cumul_EMS-6 infected_cumul_EMS_6)
+(observe infected_det_cumul_EMS-6 infected_det_cumul_EMS_6)
 
 (observe asymp_cumul_EMS-6 asymp_cumul_EMS_6 )
 (observe asymp_det_cumul_EMS-6 asymp_det_cumul_EMS_6)
@@ -1355,8 +1303,10 @@
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
+(observe infected_det_EMS-7 infected_det_EMS_7)
 (observe recovered_EMS-7 recovered_EMS_7)
 (observe infected_cumul_EMS-7 infected_cumul_EMS_7)
+(observe infected_det_cumul_EMS-7 infected_det_cumul_EMS_7)
 
 (observe asymp_cumul_EMS-7 asymp_cumul_EMS_7 )
 (observe asymp_det_cumul_EMS-7 asymp_det_cumul_EMS_7)
@@ -1399,8 +1349,10 @@
 
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
+(observe infected_det_EMS-8 infected_det_EMS_8)
 (observe recovered_EMS-8 recovered_EMS_8)
 (observe infected_cumul_EMS-8 infected_cumul_EMS_8)
+(observe infected_det_cumul_EMS-8 infected_det_cumul_EMS_8)
 
 (observe asymp_cumul_EMS-8 asymp_cumul_EMS_8 )
 (observe asymp_det_cumul_EMS-8 asymp_det_cumul_EMS_8)
@@ -1443,8 +1395,10 @@
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
+(observe infected_det_EMS-9 infected_det_EMS_9)
 (observe recovered_EMS-9 recovered_EMS_9)
 (observe infected_cumul_EMS-9 infected_cumul_EMS_9)
+(observe infected_det_cumul_EMS-9 infected_det_cumul_EMS_9)
 
 (observe asymp_cumul_EMS-9 asymp_cumul_EMS_9 )
 (observe asymp_det_cumul_EMS-9 asymp_det_cumul_EMS_9)
@@ -1487,8 +1441,10 @@
 
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
+(observe infected_det_EMS-10 infected_det_EMS_10)
 (observe recovered_EMS-10 recovered_EMS_10)
 (observe infected_cumul_EMS-10 infected_cumul_EMS_10)
+(observe infected_det_cumul_EMS-10 infected_det_cumul_EMS_10)
 
 (observe asymp_cumul_EMS-10 asymp_cumul_EMS_10 )
 (observe asymp_det_cumul_EMS-10 asymp_det_cumul_EMS_10)
@@ -1531,8 +1487,10 @@
 
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
+(observe infected_det_EMS-11 infected_det_EMS_11)
 (observe recovered_EMS-11 recovered_EMS_11)
 (observe infected_cumul_EMS-11 infected_cumul_EMS_11)
+(observe infected_det_cumul_EMS-11 infected_det_cumul_EMS_11)
 
 (observe asymp_cumul_EMS-11 asymp_cumul_EMS_11 )
 (observe asymp_det_cumul_EMS-11 asymp_det_cumul_EMS_11)
@@ -1683,6 +1641,7 @@
 (param N_EMS_10 (+ @speciesS_EMS_10@ @initialAs_EMS_10@) )
 (param N_EMS_11 (+ @speciesS_EMS_11@ @initialAs_EMS_11@) )
 (param N_All (+  N_EMS_1 N_EMS_2 N_EMS_3 N_EMS_4 N_EMS_5 N_EMS_6 N_EMS_7 N_EMS_8 N_EMS_9 N_EMS_10 N_EMS_11))
+(observe N_All N_All)
 
 
 (observe d_Sys_t d_Sys)

--- a/emodl/extendedmodel_age8.emodl
+++ b/emodl/extendedmodel_age8.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_age8_2ndWave_contactMatrix.emodl
+++ b/emodl/extendedmodel_age8_2ndWave_contactMatrix.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_age8_ChangeTD.emodl
+++ b/emodl/extendedmodel_age8_ChangeTD.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_age8_gradual_reopening.emodl
+++ b/emodl/extendedmodel_age8_gradual_reopening.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_age8_interventionStop.emodl
+++ b/emodl/extendedmodel_age8_interventionStop.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_age8_neverSIP.emodl
+++ b/emodl/extendedmodel_age8_neverSIP.emodl
@@ -367,13 +367,6 @@
 (func infected_det_age0to9 (+ infectious_det_age0to9 H1_det3_age0to9 H2_det3_age0to9 H3_det3_age0to9 C2_det3_age0to9 C3_det3_age0to9))
 (func infected_cumul_age0to9 (+ infected_age0to9 recovered_age0to9 deaths_age0to9))    
 
-(func prevalence_age0to9 (/ infected_age0to9 N_age0to9))    
-(func seroprevalence_age0to9 (/ (+ infected_age0to9 recovered_age0to9) N_age0to9))    
-
-(func prevalence_det_age0to9 (/ infected_det_age0to9 N_age0to9))    
-(func seroprevalence_det_age0to9 (/ (+ infected_det_age0to9 recovered_det_age0to9) N_age0to9))    
-
-
 (func asymptomatic_age10to19  (+ As_preD_age10to19 As_age10to19 As_det1_age10to19))
 
 (func symptomatic_mild_age10to19  (+ Sym_age10to19 Sym_preD_age10to19 Sym_det2a_age10to19 Sym_det2b_age10to19))
@@ -419,13 +412,6 @@
 (func infected_age10to19 (+ infectious_det_age10to19 infectious_undet_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_det_age10to19 (+ infectious_det_age10to19 H1_det3_age10to19 H2_det3_age10to19 H3_det3_age10to19 C2_det3_age10to19 C3_det3_age10to19))
 (func infected_cumul_age10to19 (+ infected_age10to19 recovered_age10to19 deaths_age10to19))    
-
-(func prevalence_age10to19 (/ infected_age10to19 N_age10to19))    
-(func seroprevalence_age10to19 (/ (+ infected_age10to19 recovered_age10to19) N_age10to19))    
-
-(func prevalence_det_age10to19 (/ infected_det_age10to19 N_age10to19))    
-(func seroprevalence_det_age10to19 (/ (+ infected_det_age10to19 recovered_det_age10to19) N_age10to19))    
-
 
 (func asymptomatic_age20to29  (+ As_preD_age20to29 As_age20to29 As_det1_age20to29))
 
@@ -473,13 +459,6 @@
 (func infected_det_age20to29 (+ infectious_det_age20to29 H1_det3_age20to29 H2_det3_age20to29 H3_det3_age20to29 C2_det3_age20to29 C3_det3_age20to29))
 (func infected_cumul_age20to29 (+ infected_age20to29 recovered_age20to29 deaths_age20to29))    
 
-(func prevalence_age20to29 (/ infected_age20to29 N_age20to29))    
-(func seroprevalence_age20to29 (/ (+ infected_age20to29 recovered_age20to29) N_age20to29))    
-
-(func prevalence_det_age20to29 (/ infected_det_age20to29 N_age20to29))    
-(func seroprevalence_det_age20to29 (/ (+ infected_det_age20to29 recovered_det_age20to29) N_age20to29))    
-
-
 (func asymptomatic_age30to39  (+ As_preD_age30to39 As_age30to39 As_det1_age30to39))
 
 (func symptomatic_mild_age30to39  (+ Sym_age30to39 Sym_preD_age30to39 Sym_det2a_age30to39 Sym_det2b_age30to39))
@@ -525,13 +504,6 @@
 (func infected_age30to39 (+ infectious_det_age30to39 infectious_undet_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_det_age30to39 (+ infectious_det_age30to39 H1_det3_age30to39 H2_det3_age30to39 H3_det3_age30to39 C2_det3_age30to39 C3_det3_age30to39))
 (func infected_cumul_age30to39 (+ infected_age30to39 recovered_age30to39 deaths_age30to39))    
-
-(func prevalence_age30to39 (/ infected_age30to39 N_age30to39))    
-(func seroprevalence_age30to39 (/ (+ infected_age30to39 recovered_age30to39) N_age30to39))    
-
-(func prevalence_det_age30to39 (/ infected_det_age30to39 N_age30to39))    
-(func seroprevalence_det_age30to39 (/ (+ infected_det_age30to39 recovered_det_age30to39) N_age30to39))    
-
 
 (func asymptomatic_age40to49  (+ As_preD_age40to49 As_age40to49 As_det1_age40to49))
 
@@ -579,13 +551,6 @@
 (func infected_det_age40to49 (+ infectious_det_age40to49 H1_det3_age40to49 H2_det3_age40to49 H3_det3_age40to49 C2_det3_age40to49 C3_det3_age40to49))
 (func infected_cumul_age40to49 (+ infected_age40to49 recovered_age40to49 deaths_age40to49))    
 
-(func prevalence_age40to49 (/ infected_age40to49 N_age40to49))    
-(func seroprevalence_age40to49 (/ (+ infected_age40to49 recovered_age40to49) N_age40to49))    
-
-(func prevalence_det_age40to49 (/ infected_det_age40to49 N_age40to49))    
-(func seroprevalence_det_age40to49 (/ (+ infected_det_age40to49 recovered_det_age40to49) N_age40to49))    
-
-
 (func asymptomatic_age50to59  (+ As_preD_age50to59 As_age50to59 As_det1_age50to59))
 
 (func symptomatic_mild_age50to59  (+ Sym_age50to59 Sym_preD_age50to59 Sym_det2a_age50to59 Sym_det2b_age50to59))
@@ -631,13 +596,6 @@
 (func infected_age50to59 (+ infectious_det_age50to59 infectious_undet_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_det_age50to59 (+ infectious_det_age50to59 H1_det3_age50to59 H2_det3_age50to59 H3_det3_age50to59 C2_det3_age50to59 C3_det3_age50to59))
 (func infected_cumul_age50to59 (+ infected_age50to59 recovered_age50to59 deaths_age50to59))    
-
-(func prevalence_age50to59 (/ infected_age50to59 N_age50to59))    
-(func seroprevalence_age50to59 (/ (+ infected_age50to59 recovered_age50to59) N_age50to59))    
-
-(func prevalence_det_age50to59 (/ infected_det_age50to59 N_age50to59))    
-(func seroprevalence_det_age50to59 (/ (+ infected_det_age50to59 recovered_det_age50to59) N_age50to59))    
-
 
 (func asymptomatic_age60to69  (+ As_preD_age60to69 As_age60to69 As_det1_age60to69))
 
@@ -685,13 +643,6 @@
 (func infected_det_age60to69 (+ infectious_det_age60to69 H1_det3_age60to69 H2_det3_age60to69 H3_det3_age60to69 C2_det3_age60to69 C3_det3_age60to69))
 (func infected_cumul_age60to69 (+ infected_age60to69 recovered_age60to69 deaths_age60to69))    
 
-(func prevalence_age60to69 (/ infected_age60to69 N_age60to69))    
-(func seroprevalence_age60to69 (/ (+ infected_age60to69 recovered_age60to69) N_age60to69))    
-
-(func prevalence_det_age60to69 (/ infected_det_age60to69 N_age60to69))    
-(func seroprevalence_det_age60to69 (/ (+ infected_det_age60to69 recovered_det_age60to69) N_age60to69))    
-
-
 (func asymptomatic_age70to100  (+ As_preD_age70to100 As_age70to100 As_det1_age70to100))
 
 (func symptomatic_mild_age70to100  (+ Sym_age70to100 Sym_preD_age70to100 Sym_det2a_age70to100 Sym_det2b_age70to100))
@@ -737,13 +688,6 @@
 (func infected_age70to100 (+ infectious_det_age70to100 infectious_undet_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_det_age70to100 (+ infectious_det_age70to100 H1_det3_age70to100 H2_det3_age70to100 H3_det3_age70to100 C2_det3_age70to100 C3_det3_age70to100))
 (func infected_cumul_age70to100 (+ infected_age70to100 recovered_age70to100 deaths_age70to100))    
-
-(func prevalence_age70to100 (/ infected_age70to100 N_age70to100))    
-(func seroprevalence_age70to100 (/ (+ infected_age70to100 recovered_age70to100) N_age70to100))    
-
-(func prevalence_det_age70to100 (/ infected_det_age70to100 N_age70to100))    
-(func seroprevalence_det_age70to100 (/ (+ infected_det_age70to100 recovered_det_age70to100) N_age70to100))    
-
 
 (observe susceptible_All (+ S_age0to9 S_age10to19 S_age20to29 S_age30to39 S_age40to49 S_age50to59 S_age60to69 S_age70to100))
 (observe infected_All (+ infected_age0to9 infected_age10to19 infected_age20to29 infected_age30to39 infected_age40to49 infected_age50to59 infected_age60to69 infected_age70to100))

--- a/emodl/extendedmodel_agelocale_migration_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_migration_scen3.emodl
@@ -2904,11 +2904,11 @@
 (func infected_det_age0to9_EMS_1 (+ infectious_det_age0to9_EMS_1 H1_det3_age0to9::EMS_1 H2_det3_age0to9::EMS_1 H3_det3_age0to9::EMS_1 C2_det3_age0to9::EMS_1 C3_det3_age0to9::EMS_1))
 (func infected_cumul_age0to9_EMS_1 (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1 deaths_age0to9_EMS_1))    
 
-(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 N_age0to9_EMS_1))    
-(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) N_age0to9_EMS_1))    
+(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
+(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
 
-(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 N_age0to9_EMS_1))    
-(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) N_age0to9_EMS_1))    
+(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
+(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
 
 
 (func asymptomatic_age0to9_EMS_2  (+ As_age0to9::EMS_2 As_det1_age0to9::EMS_2))
@@ -2957,11 +2957,11 @@
 (func infected_det_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_cumul_age0to9_EMS_2 (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2 deaths_age0to9_EMS_2))    
 
-(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 N_age0to9_EMS_2))    
-(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) N_age0to9_EMS_2))    
+(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
+(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
 
-(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 N_age0to9_EMS_2))    
-(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) N_age0to9_EMS_2))    
+(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
+(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
 
 
 (func asymptomatic_age0to9_EMS_3  (+ As_age0to9::EMS_3 As_det1_age0to9::EMS_3))
@@ -3010,11 +3010,11 @@
 (func infected_det_age0to9_EMS_3 (+ infectious_det_age0to9_EMS_3 H1_det3_age0to9::EMS_3 H2_det3_age0to9::EMS_3 H3_det3_age0to9::EMS_3 C2_det3_age0to9::EMS_3 C3_det3_age0to9::EMS_3))
 (func infected_cumul_age0to9_EMS_3 (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3 deaths_age0to9_EMS_3))    
 
-(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 N_age0to9_EMS_3))    
-(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) N_age0to9_EMS_3))    
+(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
+(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
 
-(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 N_age0to9_EMS_3))    
-(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) N_age0to9_EMS_3))    
+(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
+(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
 
 
 (func asymptomatic_age0to9_EMS_4  (+ As_age0to9::EMS_4 As_det1_age0to9::EMS_4))
@@ -3063,11 +3063,11 @@
 (func infected_det_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_cumul_age0to9_EMS_4 (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4 deaths_age0to9_EMS_4))    
 
-(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 N_age0to9_EMS_4))    
-(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) N_age0to9_EMS_4))    
+(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
+(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
 
-(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 N_age0to9_EMS_4))    
-(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) N_age0to9_EMS_4))    
+(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
+(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
 
 
 (func asymptomatic_age0to9_EMS_5  (+ As_age0to9::EMS_5 As_det1_age0to9::EMS_5))
@@ -3116,11 +3116,11 @@
 (func infected_det_age0to9_EMS_5 (+ infectious_det_age0to9_EMS_5 H1_det3_age0to9::EMS_5 H2_det3_age0to9::EMS_5 H3_det3_age0to9::EMS_5 C2_det3_age0to9::EMS_5 C3_det3_age0to9::EMS_5))
 (func infected_cumul_age0to9_EMS_5 (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5 deaths_age0to9_EMS_5))    
 
-(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 N_age0to9_EMS_5))    
-(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) N_age0to9_EMS_5))    
+(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
+(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
 
-(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 N_age0to9_EMS_5))    
-(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) N_age0to9_EMS_5))    
+(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
+(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
 
 
 (func asymptomatic_age0to9_EMS_6  (+ As_age0to9::EMS_6 As_det1_age0to9::EMS_6))
@@ -3169,11 +3169,11 @@
 (func infected_det_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_cumul_age0to9_EMS_6 (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6 deaths_age0to9_EMS_6))    
 
-(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 N_age0to9_EMS_6))    
-(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) N_age0to9_EMS_6))    
+(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
+(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
 
-(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 N_age0to9_EMS_6))    
-(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) N_age0to9_EMS_6))    
+(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
+(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
 
 
 (func asymptomatic_age0to9_EMS_7  (+ As_age0to9::EMS_7 As_det1_age0to9::EMS_7))
@@ -3222,11 +3222,11 @@
 (func infected_det_age0to9_EMS_7 (+ infectious_det_age0to9_EMS_7 H1_det3_age0to9::EMS_7 H2_det3_age0to9::EMS_7 H3_det3_age0to9::EMS_7 C2_det3_age0to9::EMS_7 C3_det3_age0to9::EMS_7))
 (func infected_cumul_age0to9_EMS_7 (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7 deaths_age0to9_EMS_7))    
 
-(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 N_age0to9_EMS_7))    
-(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) N_age0to9_EMS_7))    
+(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
+(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
 
-(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 N_age0to9_EMS_7))    
-(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) N_age0to9_EMS_7))    
+(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
+(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
 
 
 (func asymptomatic_age0to9_EMS_8  (+ As_age0to9::EMS_8 As_det1_age0to9::EMS_8))
@@ -3275,11 +3275,11 @@
 (func infected_det_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_cumul_age0to9_EMS_8 (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8 deaths_age0to9_EMS_8))    
 
-(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 N_age0to9_EMS_8))    
-(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) N_age0to9_EMS_8))    
+(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
+(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
 
-(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 N_age0to9_EMS_8))    
-(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) N_age0to9_EMS_8))    
+(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
+(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
 
 
 (func asymptomatic_age0to9_EMS_9  (+ As_age0to9::EMS_9 As_det1_age0to9::EMS_9))
@@ -3328,11 +3328,11 @@
 (func infected_det_age0to9_EMS_9 (+ infectious_det_age0to9_EMS_9 H1_det3_age0to9::EMS_9 H2_det3_age0to9::EMS_9 H3_det3_age0to9::EMS_9 C2_det3_age0to9::EMS_9 C3_det3_age0to9::EMS_9))
 (func infected_cumul_age0to9_EMS_9 (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9 deaths_age0to9_EMS_9))    
 
-(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 N_age0to9_EMS_9))    
-(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) N_age0to9_EMS_9))    
+(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
+(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
 
-(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 N_age0to9_EMS_9))    
-(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) N_age0to9_EMS_9))    
+(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
+(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
 
 
 (func asymptomatic_age0to9_EMS_10  (+ As_age0to9::EMS_10 As_det1_age0to9::EMS_10))
@@ -3381,11 +3381,11 @@
 (func infected_det_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_cumul_age0to9_EMS_10 (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10 deaths_age0to9_EMS_10))    
 
-(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 N_age0to9_EMS_10))    
-(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) N_age0to9_EMS_10))    
+(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
+(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
 
-(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 N_age0to9_EMS_10))    
-(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) N_age0to9_EMS_10))    
+(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
+(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
 
 
 (func asymptomatic_age0to9_EMS_11  (+ As_age0to9::EMS_11 As_det1_age0to9::EMS_11))
@@ -3434,11 +3434,11 @@
 (func infected_det_age0to9_EMS_11 (+ infectious_det_age0to9_EMS_11 H1_det3_age0to9::EMS_11 H2_det3_age0to9::EMS_11 H3_det3_age0to9::EMS_11 C2_det3_age0to9::EMS_11 C3_det3_age0to9::EMS_11))
 (func infected_cumul_age0to9_EMS_11 (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11 deaths_age0to9_EMS_11))    
 
-(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 N_age0to9_EMS_11))    
-(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) N_age0to9_EMS_11))    
+(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
+(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
 
-(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 N_age0to9_EMS_11))    
-(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) N_age0to9_EMS_11))    
+(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
+(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
 
 
 (func asymptomatic_age10to19_EMS_1  (+ As_age10to19::EMS_1 As_det1_age10to19::EMS_1))
@@ -3487,11 +3487,11 @@
 (func infected_det_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_cumul_age10to19_EMS_1 (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1 deaths_age10to19_EMS_1))    
 
-(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 N_age10to19_EMS_1))    
-(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) N_age10to19_EMS_1))    
+(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
+(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
 
-(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 N_age10to19_EMS_1))    
-(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) N_age10to19_EMS_1))    
+(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
+(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
 
 
 (func asymptomatic_age10to19_EMS_2  (+ As_age10to19::EMS_2 As_det1_age10to19::EMS_2))
@@ -3540,11 +3540,11 @@
 (func infected_det_age10to19_EMS_2 (+ infectious_det_age10to19_EMS_2 H1_det3_age10to19::EMS_2 H2_det3_age10to19::EMS_2 H3_det3_age10to19::EMS_2 C2_det3_age10to19::EMS_2 C3_det3_age10to19::EMS_2))
 (func infected_cumul_age10to19_EMS_2 (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2 deaths_age10to19_EMS_2))    
 
-(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 N_age10to19_EMS_2))    
-(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) N_age10to19_EMS_2))    
+(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
+(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
 
-(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 N_age10to19_EMS_2))    
-(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) N_age10to19_EMS_2))    
+(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
+(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
 
 
 (func asymptomatic_age10to19_EMS_3  (+ As_age10to19::EMS_3 As_det1_age10to19::EMS_3))
@@ -3593,11 +3593,11 @@
 (func infected_det_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_cumul_age10to19_EMS_3 (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3 deaths_age10to19_EMS_3))    
 
-(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 N_age10to19_EMS_3))    
-(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) N_age10to19_EMS_3))    
+(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
+(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
 
-(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 N_age10to19_EMS_3))    
-(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) N_age10to19_EMS_3))    
+(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
+(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
 
 
 (func asymptomatic_age10to19_EMS_4  (+ As_age10to19::EMS_4 As_det1_age10to19::EMS_4))
@@ -3646,11 +3646,11 @@
 (func infected_det_age10to19_EMS_4 (+ infectious_det_age10to19_EMS_4 H1_det3_age10to19::EMS_4 H2_det3_age10to19::EMS_4 H3_det3_age10to19::EMS_4 C2_det3_age10to19::EMS_4 C3_det3_age10to19::EMS_4))
 (func infected_cumul_age10to19_EMS_4 (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4 deaths_age10to19_EMS_4))    
 
-(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 N_age10to19_EMS_4))    
-(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) N_age10to19_EMS_4))    
+(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
+(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
 
-(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 N_age10to19_EMS_4))    
-(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) N_age10to19_EMS_4))    
+(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
+(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
 
 
 (func asymptomatic_age10to19_EMS_5  (+ As_age10to19::EMS_5 As_det1_age10to19::EMS_5))
@@ -3699,11 +3699,11 @@
 (func infected_det_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_cumul_age10to19_EMS_5 (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5 deaths_age10to19_EMS_5))    
 
-(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 N_age10to19_EMS_5))    
-(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) N_age10to19_EMS_5))    
+(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
+(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
 
-(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 N_age10to19_EMS_5))    
-(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) N_age10to19_EMS_5))    
+(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
+(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
 
 
 (func asymptomatic_age10to19_EMS_6  (+ As_age10to19::EMS_6 As_det1_age10to19::EMS_6))
@@ -3752,11 +3752,11 @@
 (func infected_det_age10to19_EMS_6 (+ infectious_det_age10to19_EMS_6 H1_det3_age10to19::EMS_6 H2_det3_age10to19::EMS_6 H3_det3_age10to19::EMS_6 C2_det3_age10to19::EMS_6 C3_det3_age10to19::EMS_6))
 (func infected_cumul_age10to19_EMS_6 (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6 deaths_age10to19_EMS_6))    
 
-(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 N_age10to19_EMS_6))    
-(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) N_age10to19_EMS_6))    
+(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
+(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
 
-(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 N_age10to19_EMS_6))    
-(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) N_age10to19_EMS_6))    
+(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
+(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
 
 
 (func asymptomatic_age10to19_EMS_7  (+ As_age10to19::EMS_7 As_det1_age10to19::EMS_7))
@@ -3805,11 +3805,11 @@
 (func infected_det_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_cumul_age10to19_EMS_7 (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7 deaths_age10to19_EMS_7))    
 
-(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 N_age10to19_EMS_7))    
-(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) N_age10to19_EMS_7))    
+(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
+(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
 
-(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 N_age10to19_EMS_7))    
-(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) N_age10to19_EMS_7))    
+(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
+(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
 
 
 (func asymptomatic_age10to19_EMS_8  (+ As_age10to19::EMS_8 As_det1_age10to19::EMS_8))
@@ -3858,11 +3858,11 @@
 (func infected_det_age10to19_EMS_8 (+ infectious_det_age10to19_EMS_8 H1_det3_age10to19::EMS_8 H2_det3_age10to19::EMS_8 H3_det3_age10to19::EMS_8 C2_det3_age10to19::EMS_8 C3_det3_age10to19::EMS_8))
 (func infected_cumul_age10to19_EMS_8 (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8 deaths_age10to19_EMS_8))    
 
-(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 N_age10to19_EMS_8))    
-(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) N_age10to19_EMS_8))    
+(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
+(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
 
-(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 N_age10to19_EMS_8))    
-(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) N_age10to19_EMS_8))    
+(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
+(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
 
 
 (func asymptomatic_age10to19_EMS_9  (+ As_age10to19::EMS_9 As_det1_age10to19::EMS_9))
@@ -3911,11 +3911,11 @@
 (func infected_det_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_cumul_age10to19_EMS_9 (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9 deaths_age10to19_EMS_9))    
 
-(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 N_age10to19_EMS_9))    
-(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) N_age10to19_EMS_9))    
+(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
+(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
 
-(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 N_age10to19_EMS_9))    
-(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) N_age10to19_EMS_9))    
+(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
+(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
 
 
 (func asymptomatic_age10to19_EMS_10  (+ As_age10to19::EMS_10 As_det1_age10to19::EMS_10))
@@ -3964,11 +3964,11 @@
 (func infected_det_age10to19_EMS_10 (+ infectious_det_age10to19_EMS_10 H1_det3_age10to19::EMS_10 H2_det3_age10to19::EMS_10 H3_det3_age10to19::EMS_10 C2_det3_age10to19::EMS_10 C3_det3_age10to19::EMS_10))
 (func infected_cumul_age10to19_EMS_10 (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10 deaths_age10to19_EMS_10))    
 
-(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 N_age10to19_EMS_10))    
-(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) N_age10to19_EMS_10))    
+(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
+(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
 
-(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 N_age10to19_EMS_10))    
-(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) N_age10to19_EMS_10))    
+(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
+(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
 
 
 (func asymptomatic_age10to19_EMS_11  (+ As_age10to19::EMS_11 As_det1_age10to19::EMS_11))
@@ -4017,11 +4017,11 @@
 (func infected_det_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_cumul_age10to19_EMS_11 (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11 deaths_age10to19_EMS_11))    
 
-(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 N_age10to19_EMS_11))    
-(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) N_age10to19_EMS_11))    
+(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
+(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
 
-(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 N_age10to19_EMS_11))    
-(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) N_age10to19_EMS_11))    
+(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
+(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
 
 
 (func asymptomatic_age20to29_EMS_1  (+ As_age20to29::EMS_1 As_det1_age20to29::EMS_1))
@@ -4070,11 +4070,11 @@
 (func infected_det_age20to29_EMS_1 (+ infectious_det_age20to29_EMS_1 H1_det3_age20to29::EMS_1 H2_det3_age20to29::EMS_1 H3_det3_age20to29::EMS_1 C2_det3_age20to29::EMS_1 C3_det3_age20to29::EMS_1))
 (func infected_cumul_age20to29_EMS_1 (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1 deaths_age20to29_EMS_1))    
 
-(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 N_age20to29_EMS_1))    
-(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) N_age20to29_EMS_1))    
+(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
+(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
 
-(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 N_age20to29_EMS_1))    
-(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) N_age20to29_EMS_1))    
+(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
+(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
 
 
 (func asymptomatic_age20to29_EMS_2  (+ As_age20to29::EMS_2 As_det1_age20to29::EMS_2))
@@ -4123,11 +4123,11 @@
 (func infected_det_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_cumul_age20to29_EMS_2 (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2 deaths_age20to29_EMS_2))    
 
-(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 N_age20to29_EMS_2))    
-(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) N_age20to29_EMS_2))    
+(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
+(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
 
-(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 N_age20to29_EMS_2))    
-(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) N_age20to29_EMS_2))    
+(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
+(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
 
 
 (func asymptomatic_age20to29_EMS_3  (+ As_age20to29::EMS_3 As_det1_age20to29::EMS_3))
@@ -4176,11 +4176,11 @@
 (func infected_det_age20to29_EMS_3 (+ infectious_det_age20to29_EMS_3 H1_det3_age20to29::EMS_3 H2_det3_age20to29::EMS_3 H3_det3_age20to29::EMS_3 C2_det3_age20to29::EMS_3 C3_det3_age20to29::EMS_3))
 (func infected_cumul_age20to29_EMS_3 (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3 deaths_age20to29_EMS_3))    
 
-(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 N_age20to29_EMS_3))    
-(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) N_age20to29_EMS_3))    
+(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
+(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
 
-(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 N_age20to29_EMS_3))    
-(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) N_age20to29_EMS_3))    
+(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
+(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
 
 
 (func asymptomatic_age20to29_EMS_4  (+ As_age20to29::EMS_4 As_det1_age20to29::EMS_4))
@@ -4229,11 +4229,11 @@
 (func infected_det_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_cumul_age20to29_EMS_4 (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4 deaths_age20to29_EMS_4))    
 
-(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 N_age20to29_EMS_4))    
-(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) N_age20to29_EMS_4))    
+(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
+(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
 
-(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 N_age20to29_EMS_4))    
-(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) N_age20to29_EMS_4))    
+(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
+(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
 
 
 (func asymptomatic_age20to29_EMS_5  (+ As_age20to29::EMS_5 As_det1_age20to29::EMS_5))
@@ -4282,11 +4282,11 @@
 (func infected_det_age20to29_EMS_5 (+ infectious_det_age20to29_EMS_5 H1_det3_age20to29::EMS_5 H2_det3_age20to29::EMS_5 H3_det3_age20to29::EMS_5 C2_det3_age20to29::EMS_5 C3_det3_age20to29::EMS_5))
 (func infected_cumul_age20to29_EMS_5 (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5 deaths_age20to29_EMS_5))    
 
-(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 N_age20to29_EMS_5))    
-(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) N_age20to29_EMS_5))    
+(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
+(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
 
-(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 N_age20to29_EMS_5))    
-(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) N_age20to29_EMS_5))    
+(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
+(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
 
 
 (func asymptomatic_age20to29_EMS_6  (+ As_age20to29::EMS_6 As_det1_age20to29::EMS_6))
@@ -4335,11 +4335,11 @@
 (func infected_det_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_cumul_age20to29_EMS_6 (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6 deaths_age20to29_EMS_6))    
 
-(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 N_age20to29_EMS_6))    
-(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) N_age20to29_EMS_6))    
+(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
+(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
 
-(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 N_age20to29_EMS_6))    
-(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) N_age20to29_EMS_6))    
+(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
+(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
 
 
 (func asymptomatic_age20to29_EMS_7  (+ As_age20to29::EMS_7 As_det1_age20to29::EMS_7))
@@ -4388,11 +4388,11 @@
 (func infected_det_age20to29_EMS_7 (+ infectious_det_age20to29_EMS_7 H1_det3_age20to29::EMS_7 H2_det3_age20to29::EMS_7 H3_det3_age20to29::EMS_7 C2_det3_age20to29::EMS_7 C3_det3_age20to29::EMS_7))
 (func infected_cumul_age20to29_EMS_7 (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7 deaths_age20to29_EMS_7))    
 
-(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 N_age20to29_EMS_7))    
-(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) N_age20to29_EMS_7))    
+(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
+(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
 
-(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 N_age20to29_EMS_7))    
-(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) N_age20to29_EMS_7))    
+(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
+(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
 
 
 (func asymptomatic_age20to29_EMS_8  (+ As_age20to29::EMS_8 As_det1_age20to29::EMS_8))
@@ -4441,11 +4441,11 @@
 (func infected_det_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_cumul_age20to29_EMS_8 (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8 deaths_age20to29_EMS_8))    
 
-(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 N_age20to29_EMS_8))    
-(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) N_age20to29_EMS_8))    
+(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
+(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
 
-(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 N_age20to29_EMS_8))    
-(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) N_age20to29_EMS_8))    
+(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
+(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
 
 
 (func asymptomatic_age20to29_EMS_9  (+ As_age20to29::EMS_9 As_det1_age20to29::EMS_9))
@@ -4494,11 +4494,11 @@
 (func infected_det_age20to29_EMS_9 (+ infectious_det_age20to29_EMS_9 H1_det3_age20to29::EMS_9 H2_det3_age20to29::EMS_9 H3_det3_age20to29::EMS_9 C2_det3_age20to29::EMS_9 C3_det3_age20to29::EMS_9))
 (func infected_cumul_age20to29_EMS_9 (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9 deaths_age20to29_EMS_9))    
 
-(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 N_age20to29_EMS_9))    
-(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) N_age20to29_EMS_9))    
+(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
+(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
 
-(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 N_age20to29_EMS_9))    
-(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) N_age20to29_EMS_9))    
+(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
+(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
 
 
 (func asymptomatic_age20to29_EMS_10  (+ As_age20to29::EMS_10 As_det1_age20to29::EMS_10))
@@ -4547,11 +4547,11 @@
 (func infected_det_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_cumul_age20to29_EMS_10 (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10 deaths_age20to29_EMS_10))    
 
-(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 N_age20to29_EMS_10))    
-(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) N_age20to29_EMS_10))    
+(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
+(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
 
-(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 N_age20to29_EMS_10))    
-(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) N_age20to29_EMS_10))    
+(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
+(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
 
 
 (func asymptomatic_age20to29_EMS_11  (+ As_age20to29::EMS_11 As_det1_age20to29::EMS_11))
@@ -4600,11 +4600,11 @@
 (func infected_det_age20to29_EMS_11 (+ infectious_det_age20to29_EMS_11 H1_det3_age20to29::EMS_11 H2_det3_age20to29::EMS_11 H3_det3_age20to29::EMS_11 C2_det3_age20to29::EMS_11 C3_det3_age20to29::EMS_11))
 (func infected_cumul_age20to29_EMS_11 (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11 deaths_age20to29_EMS_11))    
 
-(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 N_age20to29_EMS_11))    
-(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) N_age20to29_EMS_11))    
+(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
+(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
 
-(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 N_age20to29_EMS_11))    
-(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) N_age20to29_EMS_11))    
+(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
+(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
 
 
 (func asymptomatic_age30to39_EMS_1  (+ As_age30to39::EMS_1 As_det1_age30to39::EMS_1))
@@ -4653,11 +4653,11 @@
 (func infected_det_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_cumul_age30to39_EMS_1 (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1 deaths_age30to39_EMS_1))    
 
-(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 N_age30to39_EMS_1))    
-(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) N_age30to39_EMS_1))    
+(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
+(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
 
-(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 N_age30to39_EMS_1))    
-(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) N_age30to39_EMS_1))    
+(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
+(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
 
 
 (func asymptomatic_age30to39_EMS_2  (+ As_age30to39::EMS_2 As_det1_age30to39::EMS_2))
@@ -4706,11 +4706,11 @@
 (func infected_det_age30to39_EMS_2 (+ infectious_det_age30to39_EMS_2 H1_det3_age30to39::EMS_2 H2_det3_age30to39::EMS_2 H3_det3_age30to39::EMS_2 C2_det3_age30to39::EMS_2 C3_det3_age30to39::EMS_2))
 (func infected_cumul_age30to39_EMS_2 (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2 deaths_age30to39_EMS_2))    
 
-(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 N_age30to39_EMS_2))    
-(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) N_age30to39_EMS_2))    
+(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
+(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
 
-(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 N_age30to39_EMS_2))    
-(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) N_age30to39_EMS_2))    
+(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
+(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
 
 
 (func asymptomatic_age30to39_EMS_3  (+ As_age30to39::EMS_3 As_det1_age30to39::EMS_3))
@@ -4759,11 +4759,11 @@
 (func infected_det_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_cumul_age30to39_EMS_3 (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3 deaths_age30to39_EMS_3))    
 
-(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 N_age30to39_EMS_3))    
-(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) N_age30to39_EMS_3))    
+(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
+(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
 
-(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 N_age30to39_EMS_3))    
-(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) N_age30to39_EMS_3))    
+(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
+(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
 
 
 (func asymptomatic_age30to39_EMS_4  (+ As_age30to39::EMS_4 As_det1_age30to39::EMS_4))
@@ -4812,11 +4812,11 @@
 (func infected_det_age30to39_EMS_4 (+ infectious_det_age30to39_EMS_4 H1_det3_age30to39::EMS_4 H2_det3_age30to39::EMS_4 H3_det3_age30to39::EMS_4 C2_det3_age30to39::EMS_4 C3_det3_age30to39::EMS_4))
 (func infected_cumul_age30to39_EMS_4 (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4 deaths_age30to39_EMS_4))    
 
-(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 N_age30to39_EMS_4))    
-(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) N_age30to39_EMS_4))    
+(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
+(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
 
-(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 N_age30to39_EMS_4))    
-(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) N_age30to39_EMS_4))    
+(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
+(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
 
 
 (func asymptomatic_age30to39_EMS_5  (+ As_age30to39::EMS_5 As_det1_age30to39::EMS_5))
@@ -4865,11 +4865,11 @@
 (func infected_det_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_cumul_age30to39_EMS_5 (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5 deaths_age30to39_EMS_5))    
 
-(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 N_age30to39_EMS_5))    
-(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) N_age30to39_EMS_5))    
+(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
+(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
 
-(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 N_age30to39_EMS_5))    
-(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) N_age30to39_EMS_5))    
+(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
+(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
 
 
 (func asymptomatic_age30to39_EMS_6  (+ As_age30to39::EMS_6 As_det1_age30to39::EMS_6))
@@ -4918,11 +4918,11 @@
 (func infected_det_age30to39_EMS_6 (+ infectious_det_age30to39_EMS_6 H1_det3_age30to39::EMS_6 H2_det3_age30to39::EMS_6 H3_det3_age30to39::EMS_6 C2_det3_age30to39::EMS_6 C3_det3_age30to39::EMS_6))
 (func infected_cumul_age30to39_EMS_6 (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6 deaths_age30to39_EMS_6))    
 
-(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 N_age30to39_EMS_6))    
-(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) N_age30to39_EMS_6))    
+(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
+(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
 
-(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 N_age30to39_EMS_6))    
-(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) N_age30to39_EMS_6))    
+(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
+(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
 
 
 (func asymptomatic_age30to39_EMS_7  (+ As_age30to39::EMS_7 As_det1_age30to39::EMS_7))
@@ -4971,11 +4971,11 @@
 (func infected_det_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_cumul_age30to39_EMS_7 (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7 deaths_age30to39_EMS_7))    
 
-(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 N_age30to39_EMS_7))    
-(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) N_age30to39_EMS_7))    
+(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
+(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
 
-(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 N_age30to39_EMS_7))    
-(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) N_age30to39_EMS_7))    
+(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
+(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
 
 
 (func asymptomatic_age30to39_EMS_8  (+ As_age30to39::EMS_8 As_det1_age30to39::EMS_8))
@@ -5024,11 +5024,11 @@
 (func infected_det_age30to39_EMS_8 (+ infectious_det_age30to39_EMS_8 H1_det3_age30to39::EMS_8 H2_det3_age30to39::EMS_8 H3_det3_age30to39::EMS_8 C2_det3_age30to39::EMS_8 C3_det3_age30to39::EMS_8))
 (func infected_cumul_age30to39_EMS_8 (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8 deaths_age30to39_EMS_8))    
 
-(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 N_age30to39_EMS_8))    
-(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) N_age30to39_EMS_8))    
+(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
+(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
 
-(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 N_age30to39_EMS_8))    
-(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) N_age30to39_EMS_8))    
+(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
+(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
 
 
 (func asymptomatic_age30to39_EMS_9  (+ As_age30to39::EMS_9 As_det1_age30to39::EMS_9))
@@ -5077,11 +5077,11 @@
 (func infected_det_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_cumul_age30to39_EMS_9 (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9 deaths_age30to39_EMS_9))    
 
-(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 N_age30to39_EMS_9))    
-(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) N_age30to39_EMS_9))    
+(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
+(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
 
-(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 N_age30to39_EMS_9))    
-(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) N_age30to39_EMS_9))    
+(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
+(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
 
 
 (func asymptomatic_age30to39_EMS_10  (+ As_age30to39::EMS_10 As_det1_age30to39::EMS_10))
@@ -5130,11 +5130,11 @@
 (func infected_det_age30to39_EMS_10 (+ infectious_det_age30to39_EMS_10 H1_det3_age30to39::EMS_10 H2_det3_age30to39::EMS_10 H3_det3_age30to39::EMS_10 C2_det3_age30to39::EMS_10 C3_det3_age30to39::EMS_10))
 (func infected_cumul_age30to39_EMS_10 (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10 deaths_age30to39_EMS_10))    
 
-(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 N_age30to39_EMS_10))    
-(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) N_age30to39_EMS_10))    
+(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
+(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
 
-(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 N_age30to39_EMS_10))    
-(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) N_age30to39_EMS_10))    
+(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
+(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
 
 
 (func asymptomatic_age30to39_EMS_11  (+ As_age30to39::EMS_11 As_det1_age30to39::EMS_11))
@@ -5183,11 +5183,11 @@
 (func infected_det_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_cumul_age30to39_EMS_11 (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11 deaths_age30to39_EMS_11))    
 
-(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 N_age30to39_EMS_11))    
-(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) N_age30to39_EMS_11))    
+(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
+(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
 
-(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 N_age30to39_EMS_11))    
-(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) N_age30to39_EMS_11))    
+(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
+(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
 
 
 (func asymptomatic_age40to49_EMS_1  (+ As_age40to49::EMS_1 As_det1_age40to49::EMS_1))
@@ -5236,11 +5236,11 @@
 (func infected_det_age40to49_EMS_1 (+ infectious_det_age40to49_EMS_1 H1_det3_age40to49::EMS_1 H2_det3_age40to49::EMS_1 H3_det3_age40to49::EMS_1 C2_det3_age40to49::EMS_1 C3_det3_age40to49::EMS_1))
 (func infected_cumul_age40to49_EMS_1 (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1 deaths_age40to49_EMS_1))    
 
-(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 N_age40to49_EMS_1))    
-(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) N_age40to49_EMS_1))    
+(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
+(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
 
-(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 N_age40to49_EMS_1))    
-(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) N_age40to49_EMS_1))    
+(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
+(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
 
 
 (func asymptomatic_age40to49_EMS_2  (+ As_age40to49::EMS_2 As_det1_age40to49::EMS_2))
@@ -5289,11 +5289,11 @@
 (func infected_det_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_cumul_age40to49_EMS_2 (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2 deaths_age40to49_EMS_2))    
 
-(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 N_age40to49_EMS_2))    
-(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) N_age40to49_EMS_2))    
+(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
+(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
 
-(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 N_age40to49_EMS_2))    
-(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) N_age40to49_EMS_2))    
+(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
+(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
 
 
 (func asymptomatic_age40to49_EMS_3  (+ As_age40to49::EMS_3 As_det1_age40to49::EMS_3))
@@ -5342,11 +5342,11 @@
 (func infected_det_age40to49_EMS_3 (+ infectious_det_age40to49_EMS_3 H1_det3_age40to49::EMS_3 H2_det3_age40to49::EMS_3 H3_det3_age40to49::EMS_3 C2_det3_age40to49::EMS_3 C3_det3_age40to49::EMS_3))
 (func infected_cumul_age40to49_EMS_3 (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3 deaths_age40to49_EMS_3))    
 
-(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 N_age40to49_EMS_3))    
-(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) N_age40to49_EMS_3))    
+(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
+(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
 
-(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 N_age40to49_EMS_3))    
-(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) N_age40to49_EMS_3))    
+(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
+(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
 
 
 (func asymptomatic_age40to49_EMS_4  (+ As_age40to49::EMS_4 As_det1_age40to49::EMS_4))
@@ -5395,11 +5395,11 @@
 (func infected_det_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_cumul_age40to49_EMS_4 (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4 deaths_age40to49_EMS_4))    
 
-(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 N_age40to49_EMS_4))    
-(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) N_age40to49_EMS_4))    
+(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
+(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
 
-(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 N_age40to49_EMS_4))    
-(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) N_age40to49_EMS_4))    
+(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
+(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
 
 
 (func asymptomatic_age40to49_EMS_5  (+ As_age40to49::EMS_5 As_det1_age40to49::EMS_5))
@@ -5448,11 +5448,11 @@
 (func infected_det_age40to49_EMS_5 (+ infectious_det_age40to49_EMS_5 H1_det3_age40to49::EMS_5 H2_det3_age40to49::EMS_5 H3_det3_age40to49::EMS_5 C2_det3_age40to49::EMS_5 C3_det3_age40to49::EMS_5))
 (func infected_cumul_age40to49_EMS_5 (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5 deaths_age40to49_EMS_5))    
 
-(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 N_age40to49_EMS_5))    
-(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) N_age40to49_EMS_5))    
+(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
+(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
 
-(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 N_age40to49_EMS_5))    
-(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) N_age40to49_EMS_5))    
+(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
+(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
 
 
 (func asymptomatic_age40to49_EMS_6  (+ As_age40to49::EMS_6 As_det1_age40to49::EMS_6))
@@ -5501,11 +5501,11 @@
 (func infected_det_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_cumul_age40to49_EMS_6 (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6 deaths_age40to49_EMS_6))    
 
-(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 N_age40to49_EMS_6))    
-(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) N_age40to49_EMS_6))    
+(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
+(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
 
-(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 N_age40to49_EMS_6))    
-(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) N_age40to49_EMS_6))    
+(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
+(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
 
 
 (func asymptomatic_age40to49_EMS_7  (+ As_age40to49::EMS_7 As_det1_age40to49::EMS_7))
@@ -5554,11 +5554,11 @@
 (func infected_det_age40to49_EMS_7 (+ infectious_det_age40to49_EMS_7 H1_det3_age40to49::EMS_7 H2_det3_age40to49::EMS_7 H3_det3_age40to49::EMS_7 C2_det3_age40to49::EMS_7 C3_det3_age40to49::EMS_7))
 (func infected_cumul_age40to49_EMS_7 (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7 deaths_age40to49_EMS_7))    
 
-(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 N_age40to49_EMS_7))    
-(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) N_age40to49_EMS_7))    
+(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
+(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
 
-(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 N_age40to49_EMS_7))    
-(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) N_age40to49_EMS_7))    
+(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
+(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
 
 
 (func asymptomatic_age40to49_EMS_8  (+ As_age40to49::EMS_8 As_det1_age40to49::EMS_8))
@@ -5607,11 +5607,11 @@
 (func infected_det_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_cumul_age40to49_EMS_8 (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8 deaths_age40to49_EMS_8))    
 
-(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 N_age40to49_EMS_8))    
-(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) N_age40to49_EMS_8))    
+(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
+(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
 
-(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 N_age40to49_EMS_8))    
-(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) N_age40to49_EMS_8))    
+(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
+(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
 
 
 (func asymptomatic_age40to49_EMS_9  (+ As_age40to49::EMS_9 As_det1_age40to49::EMS_9))
@@ -5660,11 +5660,11 @@
 (func infected_det_age40to49_EMS_9 (+ infectious_det_age40to49_EMS_9 H1_det3_age40to49::EMS_9 H2_det3_age40to49::EMS_9 H3_det3_age40to49::EMS_9 C2_det3_age40to49::EMS_9 C3_det3_age40to49::EMS_9))
 (func infected_cumul_age40to49_EMS_9 (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9 deaths_age40to49_EMS_9))    
 
-(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 N_age40to49_EMS_9))    
-(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) N_age40to49_EMS_9))    
+(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
+(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
 
-(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 N_age40to49_EMS_9))    
-(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) N_age40to49_EMS_9))    
+(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
+(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
 
 
 (func asymptomatic_age40to49_EMS_10  (+ As_age40to49::EMS_10 As_det1_age40to49::EMS_10))
@@ -5713,11 +5713,11 @@
 (func infected_det_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_cumul_age40to49_EMS_10 (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10 deaths_age40to49_EMS_10))    
 
-(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 N_age40to49_EMS_10))    
-(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) N_age40to49_EMS_10))    
+(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
+(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
 
-(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 N_age40to49_EMS_10))    
-(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) N_age40to49_EMS_10))    
+(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
+(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
 
 
 (func asymptomatic_age40to49_EMS_11  (+ As_age40to49::EMS_11 As_det1_age40to49::EMS_11))
@@ -5766,11 +5766,11 @@
 (func infected_det_age40to49_EMS_11 (+ infectious_det_age40to49_EMS_11 H1_det3_age40to49::EMS_11 H2_det3_age40to49::EMS_11 H3_det3_age40to49::EMS_11 C2_det3_age40to49::EMS_11 C3_det3_age40to49::EMS_11))
 (func infected_cumul_age40to49_EMS_11 (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11 deaths_age40to49_EMS_11))    
 
-(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 N_age40to49_EMS_11))    
-(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) N_age40to49_EMS_11))    
+(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
+(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
 
-(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 N_age40to49_EMS_11))    
-(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) N_age40to49_EMS_11))    
+(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
+(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
 
 
 (func asymptomatic_age50to59_EMS_1  (+ As_age50to59::EMS_1 As_det1_age50to59::EMS_1))
@@ -5819,11 +5819,11 @@
 (func infected_det_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_cumul_age50to59_EMS_1 (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1 deaths_age50to59_EMS_1))    
 
-(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 N_age50to59_EMS_1))    
-(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) N_age50to59_EMS_1))    
+(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
+(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
 
-(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 N_age50to59_EMS_1))    
-(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) N_age50to59_EMS_1))    
+(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
+(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
 
 
 (func asymptomatic_age50to59_EMS_2  (+ As_age50to59::EMS_2 As_det1_age50to59::EMS_2))
@@ -5872,11 +5872,11 @@
 (func infected_det_age50to59_EMS_2 (+ infectious_det_age50to59_EMS_2 H1_det3_age50to59::EMS_2 H2_det3_age50to59::EMS_2 H3_det3_age50to59::EMS_2 C2_det3_age50to59::EMS_2 C3_det3_age50to59::EMS_2))
 (func infected_cumul_age50to59_EMS_2 (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2 deaths_age50to59_EMS_2))    
 
-(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 N_age50to59_EMS_2))    
-(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) N_age50to59_EMS_2))    
+(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
+(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
 
-(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 N_age50to59_EMS_2))    
-(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) N_age50to59_EMS_2))    
+(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
+(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
 
 
 (func asymptomatic_age50to59_EMS_3  (+ As_age50to59::EMS_3 As_det1_age50to59::EMS_3))
@@ -5925,11 +5925,11 @@
 (func infected_det_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_cumul_age50to59_EMS_3 (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3 deaths_age50to59_EMS_3))    
 
-(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 N_age50to59_EMS_3))    
-(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) N_age50to59_EMS_3))    
+(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
+(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
 
-(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 N_age50to59_EMS_3))    
-(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) N_age50to59_EMS_3))    
+(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
+(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
 
 
 (func asymptomatic_age50to59_EMS_4  (+ As_age50to59::EMS_4 As_det1_age50to59::EMS_4))
@@ -5978,11 +5978,11 @@
 (func infected_det_age50to59_EMS_4 (+ infectious_det_age50to59_EMS_4 H1_det3_age50to59::EMS_4 H2_det3_age50to59::EMS_4 H3_det3_age50to59::EMS_4 C2_det3_age50to59::EMS_4 C3_det3_age50to59::EMS_4))
 (func infected_cumul_age50to59_EMS_4 (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4 deaths_age50to59_EMS_4))    
 
-(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 N_age50to59_EMS_4))    
-(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) N_age50to59_EMS_4))    
+(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
+(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
 
-(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 N_age50to59_EMS_4))    
-(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) N_age50to59_EMS_4))    
+(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
+(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
 
 
 (func asymptomatic_age50to59_EMS_5  (+ As_age50to59::EMS_5 As_det1_age50to59::EMS_5))
@@ -6031,11 +6031,11 @@
 (func infected_det_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_cumul_age50to59_EMS_5 (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5 deaths_age50to59_EMS_5))    
 
-(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 N_age50to59_EMS_5))    
-(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) N_age50to59_EMS_5))    
+(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
+(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
 
-(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 N_age50to59_EMS_5))    
-(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) N_age50to59_EMS_5))    
+(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
+(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
 
 
 (func asymptomatic_age50to59_EMS_6  (+ As_age50to59::EMS_6 As_det1_age50to59::EMS_6))
@@ -6084,11 +6084,11 @@
 (func infected_det_age50to59_EMS_6 (+ infectious_det_age50to59_EMS_6 H1_det3_age50to59::EMS_6 H2_det3_age50to59::EMS_6 H3_det3_age50to59::EMS_6 C2_det3_age50to59::EMS_6 C3_det3_age50to59::EMS_6))
 (func infected_cumul_age50to59_EMS_6 (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6 deaths_age50to59_EMS_6))    
 
-(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 N_age50to59_EMS_6))    
-(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) N_age50to59_EMS_6))    
+(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
+(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
 
-(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 N_age50to59_EMS_6))    
-(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) N_age50to59_EMS_6))    
+(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
+(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
 
 
 (func asymptomatic_age50to59_EMS_7  (+ As_age50to59::EMS_7 As_det1_age50to59::EMS_7))
@@ -6137,11 +6137,11 @@
 (func infected_det_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_cumul_age50to59_EMS_7 (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7 deaths_age50to59_EMS_7))    
 
-(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 N_age50to59_EMS_7))    
-(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) N_age50to59_EMS_7))    
+(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
+(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
 
-(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 N_age50to59_EMS_7))    
-(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) N_age50to59_EMS_7))    
+(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
+(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
 
 
 (func asymptomatic_age50to59_EMS_8  (+ As_age50to59::EMS_8 As_det1_age50to59::EMS_8))
@@ -6190,11 +6190,11 @@
 (func infected_det_age50to59_EMS_8 (+ infectious_det_age50to59_EMS_8 H1_det3_age50to59::EMS_8 H2_det3_age50to59::EMS_8 H3_det3_age50to59::EMS_8 C2_det3_age50to59::EMS_8 C3_det3_age50to59::EMS_8))
 (func infected_cumul_age50to59_EMS_8 (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8 deaths_age50to59_EMS_8))    
 
-(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 N_age50to59_EMS_8))    
-(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) N_age50to59_EMS_8))    
+(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
+(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
 
-(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 N_age50to59_EMS_8))    
-(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) N_age50to59_EMS_8))    
+(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
+(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
 
 
 (func asymptomatic_age50to59_EMS_9  (+ As_age50to59::EMS_9 As_det1_age50to59::EMS_9))
@@ -6243,11 +6243,11 @@
 (func infected_det_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_cumul_age50to59_EMS_9 (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9 deaths_age50to59_EMS_9))    
 
-(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 N_age50to59_EMS_9))    
-(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) N_age50to59_EMS_9))    
+(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
+(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
 
-(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 N_age50to59_EMS_9))    
-(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) N_age50to59_EMS_9))    
+(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
+(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
 
 
 (func asymptomatic_age50to59_EMS_10  (+ As_age50to59::EMS_10 As_det1_age50to59::EMS_10))
@@ -6296,11 +6296,11 @@
 (func infected_det_age50to59_EMS_10 (+ infectious_det_age50to59_EMS_10 H1_det3_age50to59::EMS_10 H2_det3_age50to59::EMS_10 H3_det3_age50to59::EMS_10 C2_det3_age50to59::EMS_10 C3_det3_age50to59::EMS_10))
 (func infected_cumul_age50to59_EMS_10 (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10 deaths_age50to59_EMS_10))    
 
-(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 N_age50to59_EMS_10))    
-(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) N_age50to59_EMS_10))    
+(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
+(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
 
-(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 N_age50to59_EMS_10))    
-(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) N_age50to59_EMS_10))    
+(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
+(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
 
 
 (func asymptomatic_age50to59_EMS_11  (+ As_age50to59::EMS_11 As_det1_age50to59::EMS_11))
@@ -6349,11 +6349,11 @@
 (func infected_det_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_cumul_age50to59_EMS_11 (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11 deaths_age50to59_EMS_11))    
 
-(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 N_age50to59_EMS_11))    
-(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) N_age50to59_EMS_11))    
+(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
+(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
 
-(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 N_age50to59_EMS_11))    
-(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) N_age50to59_EMS_11))    
+(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
+(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
 
 
 (func asymptomatic_age60to69_EMS_1  (+ As_age60to69::EMS_1 As_det1_age60to69::EMS_1))
@@ -6402,11 +6402,11 @@
 (func infected_det_age60to69_EMS_1 (+ infectious_det_age60to69_EMS_1 H1_det3_age60to69::EMS_1 H2_det3_age60to69::EMS_1 H3_det3_age60to69::EMS_1 C2_det3_age60to69::EMS_1 C3_det3_age60to69::EMS_1))
 (func infected_cumul_age60to69_EMS_1 (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1 deaths_age60to69_EMS_1))    
 
-(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 N_age60to69_EMS_1))    
-(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) N_age60to69_EMS_1))    
+(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
+(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
 
-(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 N_age60to69_EMS_1))    
-(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) N_age60to69_EMS_1))    
+(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
+(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
 
 
 (func asymptomatic_age60to69_EMS_2  (+ As_age60to69::EMS_2 As_det1_age60to69::EMS_2))
@@ -6455,11 +6455,11 @@
 (func infected_det_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_cumul_age60to69_EMS_2 (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2 deaths_age60to69_EMS_2))    
 
-(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 N_age60to69_EMS_2))    
-(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) N_age60to69_EMS_2))    
+(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
+(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
 
-(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 N_age60to69_EMS_2))    
-(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) N_age60to69_EMS_2))    
+(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
+(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
 
 
 (func asymptomatic_age60to69_EMS_3  (+ As_age60to69::EMS_3 As_det1_age60to69::EMS_3))
@@ -6508,11 +6508,11 @@
 (func infected_det_age60to69_EMS_3 (+ infectious_det_age60to69_EMS_3 H1_det3_age60to69::EMS_3 H2_det3_age60to69::EMS_3 H3_det3_age60to69::EMS_3 C2_det3_age60to69::EMS_3 C3_det3_age60to69::EMS_3))
 (func infected_cumul_age60to69_EMS_3 (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3 deaths_age60to69_EMS_3))    
 
-(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 N_age60to69_EMS_3))    
-(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) N_age60to69_EMS_3))    
+(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
+(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
 
-(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 N_age60to69_EMS_3))    
-(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) N_age60to69_EMS_3))    
+(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
+(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
 
 
 (func asymptomatic_age60to69_EMS_4  (+ As_age60to69::EMS_4 As_det1_age60to69::EMS_4))
@@ -6561,11 +6561,11 @@
 (func infected_det_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_cumul_age60to69_EMS_4 (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4 deaths_age60to69_EMS_4))    
 
-(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 N_age60to69_EMS_4))    
-(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) N_age60to69_EMS_4))    
+(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
+(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
 
-(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 N_age60to69_EMS_4))    
-(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) N_age60to69_EMS_4))    
+(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
+(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
 
 
 (func asymptomatic_age60to69_EMS_5  (+ As_age60to69::EMS_5 As_det1_age60to69::EMS_5))
@@ -6614,11 +6614,11 @@
 (func infected_det_age60to69_EMS_5 (+ infectious_det_age60to69_EMS_5 H1_det3_age60to69::EMS_5 H2_det3_age60to69::EMS_5 H3_det3_age60to69::EMS_5 C2_det3_age60to69::EMS_5 C3_det3_age60to69::EMS_5))
 (func infected_cumul_age60to69_EMS_5 (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5 deaths_age60to69_EMS_5))    
 
-(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 N_age60to69_EMS_5))    
-(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) N_age60to69_EMS_5))    
+(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
+(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
 
-(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 N_age60to69_EMS_5))    
-(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) N_age60to69_EMS_5))    
+(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
+(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
 
 
 (func asymptomatic_age60to69_EMS_6  (+ As_age60to69::EMS_6 As_det1_age60to69::EMS_6))
@@ -6667,11 +6667,11 @@
 (func infected_det_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_cumul_age60to69_EMS_6 (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6 deaths_age60to69_EMS_6))    
 
-(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 N_age60to69_EMS_6))    
-(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) N_age60to69_EMS_6))    
+(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
+(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
 
-(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 N_age60to69_EMS_6))    
-(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) N_age60to69_EMS_6))    
+(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
+(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
 
 
 (func asymptomatic_age60to69_EMS_7  (+ As_age60to69::EMS_7 As_det1_age60to69::EMS_7))
@@ -6720,11 +6720,11 @@
 (func infected_det_age60to69_EMS_7 (+ infectious_det_age60to69_EMS_7 H1_det3_age60to69::EMS_7 H2_det3_age60to69::EMS_7 H3_det3_age60to69::EMS_7 C2_det3_age60to69::EMS_7 C3_det3_age60to69::EMS_7))
 (func infected_cumul_age60to69_EMS_7 (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7 deaths_age60to69_EMS_7))    
 
-(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 N_age60to69_EMS_7))    
-(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) N_age60to69_EMS_7))    
+(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
+(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
 
-(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 N_age60to69_EMS_7))    
-(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) N_age60to69_EMS_7))    
+(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
+(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
 
 
 (func asymptomatic_age60to69_EMS_8  (+ As_age60to69::EMS_8 As_det1_age60to69::EMS_8))
@@ -6773,11 +6773,11 @@
 (func infected_det_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_cumul_age60to69_EMS_8 (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8 deaths_age60to69_EMS_8))    
 
-(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 N_age60to69_EMS_8))    
-(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) N_age60to69_EMS_8))    
+(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
+(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
 
-(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 N_age60to69_EMS_8))    
-(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) N_age60to69_EMS_8))    
+(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
+(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
 
 
 (func asymptomatic_age60to69_EMS_9  (+ As_age60to69::EMS_9 As_det1_age60to69::EMS_9))
@@ -6826,11 +6826,11 @@
 (func infected_det_age60to69_EMS_9 (+ infectious_det_age60to69_EMS_9 H1_det3_age60to69::EMS_9 H2_det3_age60to69::EMS_9 H3_det3_age60to69::EMS_9 C2_det3_age60to69::EMS_9 C3_det3_age60to69::EMS_9))
 (func infected_cumul_age60to69_EMS_9 (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9 deaths_age60to69_EMS_9))    
 
-(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 N_age60to69_EMS_9))    
-(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) N_age60to69_EMS_9))    
+(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
+(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
 
-(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 N_age60to69_EMS_9))    
-(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) N_age60to69_EMS_9))    
+(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
+(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
 
 
 (func asymptomatic_age60to69_EMS_10  (+ As_age60to69::EMS_10 As_det1_age60to69::EMS_10))
@@ -6879,11 +6879,11 @@
 (func infected_det_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_cumul_age60to69_EMS_10 (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10 deaths_age60to69_EMS_10))    
 
-(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 N_age60to69_EMS_10))    
-(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) N_age60to69_EMS_10))    
+(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
+(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
 
-(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 N_age60to69_EMS_10))    
-(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) N_age60to69_EMS_10))    
+(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
+(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
 
 
 (func asymptomatic_age60to69_EMS_11  (+ As_age60to69::EMS_11 As_det1_age60to69::EMS_11))
@@ -6932,11 +6932,11 @@
 (func infected_det_age60to69_EMS_11 (+ infectious_det_age60to69_EMS_11 H1_det3_age60to69::EMS_11 H2_det3_age60to69::EMS_11 H3_det3_age60to69::EMS_11 C2_det3_age60to69::EMS_11 C3_det3_age60to69::EMS_11))
 (func infected_cumul_age60to69_EMS_11 (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11 deaths_age60to69_EMS_11))    
 
-(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 N_age60to69_EMS_11))    
-(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) N_age60to69_EMS_11))    
+(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
+(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
 
-(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 N_age60to69_EMS_11))    
-(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) N_age60to69_EMS_11))    
+(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
+(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
 
 
 (func asymptomatic_age70to100_EMS_1  (+ As_age70to100::EMS_1 As_det1_age70to100::EMS_1))
@@ -6985,11 +6985,11 @@
 (func infected_det_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_cumul_age70to100_EMS_1 (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1 deaths_age70to100_EMS_1))    
 
-(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 N_age70to100_EMS_1))    
-(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) N_age70to100_EMS_1))    
+(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
+(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
 
-(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 N_age70to100_EMS_1))    
-(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) N_age70to100_EMS_1))    
+(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
+(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
 
 
 (func asymptomatic_age70to100_EMS_2  (+ As_age70to100::EMS_2 As_det1_age70to100::EMS_2))
@@ -7038,11 +7038,11 @@
 (func infected_det_age70to100_EMS_2 (+ infectious_det_age70to100_EMS_2 H1_det3_age70to100::EMS_2 H2_det3_age70to100::EMS_2 H3_det3_age70to100::EMS_2 C2_det3_age70to100::EMS_2 C3_det3_age70to100::EMS_2))
 (func infected_cumul_age70to100_EMS_2 (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2 deaths_age70to100_EMS_2))    
 
-(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 N_age70to100_EMS_2))    
-(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) N_age70to100_EMS_2))    
+(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
+(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
 
-(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 N_age70to100_EMS_2))    
-(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) N_age70to100_EMS_2))    
+(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
+(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
 
 
 (func asymptomatic_age70to100_EMS_3  (+ As_age70to100::EMS_3 As_det1_age70to100::EMS_3))
@@ -7091,11 +7091,11 @@
 (func infected_det_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_cumul_age70to100_EMS_3 (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3 deaths_age70to100_EMS_3))    
 
-(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 N_age70to100_EMS_3))    
-(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) N_age70to100_EMS_3))    
+(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
+(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
 
-(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 N_age70to100_EMS_3))    
-(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) N_age70to100_EMS_3))    
+(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
+(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
 
 
 (func asymptomatic_age70to100_EMS_4  (+ As_age70to100::EMS_4 As_det1_age70to100::EMS_4))
@@ -7144,11 +7144,11 @@
 (func infected_det_age70to100_EMS_4 (+ infectious_det_age70to100_EMS_4 H1_det3_age70to100::EMS_4 H2_det3_age70to100::EMS_4 H3_det3_age70to100::EMS_4 C2_det3_age70to100::EMS_4 C3_det3_age70to100::EMS_4))
 (func infected_cumul_age70to100_EMS_4 (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4 deaths_age70to100_EMS_4))    
 
-(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 N_age70to100_EMS_4))    
-(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) N_age70to100_EMS_4))    
+(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
+(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
 
-(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 N_age70to100_EMS_4))    
-(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) N_age70to100_EMS_4))    
+(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
+(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
 
 
 (func asymptomatic_age70to100_EMS_5  (+ As_age70to100::EMS_5 As_det1_age70to100::EMS_5))
@@ -7197,11 +7197,11 @@
 (func infected_det_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_cumul_age70to100_EMS_5 (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5 deaths_age70to100_EMS_5))    
 
-(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 N_age70to100_EMS_5))    
-(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) N_age70to100_EMS_5))    
+(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
+(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
 
-(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 N_age70to100_EMS_5))    
-(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) N_age70to100_EMS_5))    
+(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
+(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
 
 
 (func asymptomatic_age70to100_EMS_6  (+ As_age70to100::EMS_6 As_det1_age70to100::EMS_6))
@@ -7250,11 +7250,11 @@
 (func infected_det_age70to100_EMS_6 (+ infectious_det_age70to100_EMS_6 H1_det3_age70to100::EMS_6 H2_det3_age70to100::EMS_6 H3_det3_age70to100::EMS_6 C2_det3_age70to100::EMS_6 C3_det3_age70to100::EMS_6))
 (func infected_cumul_age70to100_EMS_6 (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6 deaths_age70to100_EMS_6))    
 
-(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 N_age70to100_EMS_6))    
-(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) N_age70to100_EMS_6))    
+(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
+(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
 
-(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 N_age70to100_EMS_6))    
-(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) N_age70to100_EMS_6))    
+(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
+(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
 
 
 (func asymptomatic_age70to100_EMS_7  (+ As_age70to100::EMS_7 As_det1_age70to100::EMS_7))
@@ -7303,11 +7303,11 @@
 (func infected_det_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_cumul_age70to100_EMS_7 (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7 deaths_age70to100_EMS_7))    
 
-(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 N_age70to100_EMS_7))    
-(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) N_age70to100_EMS_7))    
+(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
+(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
 
-(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 N_age70to100_EMS_7))    
-(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) N_age70to100_EMS_7))    
+(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
+(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
 
 
 (func asymptomatic_age70to100_EMS_8  (+ As_age70to100::EMS_8 As_det1_age70to100::EMS_8))
@@ -7356,11 +7356,11 @@
 (func infected_det_age70to100_EMS_8 (+ infectious_det_age70to100_EMS_8 H1_det3_age70to100::EMS_8 H2_det3_age70to100::EMS_8 H3_det3_age70to100::EMS_8 C2_det3_age70to100::EMS_8 C3_det3_age70to100::EMS_8))
 (func infected_cumul_age70to100_EMS_8 (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8 deaths_age70to100_EMS_8))    
 
-(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 N_age70to100_EMS_8))    
-(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) N_age70to100_EMS_8))    
+(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
+(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
 
-(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 N_age70to100_EMS_8))    
-(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) N_age70to100_EMS_8))    
+(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
+(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
 
 
 (func asymptomatic_age70to100_EMS_9  (+ As_age70to100::EMS_9 As_det1_age70to100::EMS_9))
@@ -7409,11 +7409,11 @@
 (func infected_det_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_cumul_age70to100_EMS_9 (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9 deaths_age70to100_EMS_9))    
 
-(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 N_age70to100_EMS_9))    
-(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) N_age70to100_EMS_9))    
+(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
+(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
 
-(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 N_age70to100_EMS_9))    
-(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) N_age70to100_EMS_9))    
+(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
+(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
 
 
 (func asymptomatic_age70to100_EMS_10  (+ As_age70to100::EMS_10 As_det1_age70to100::EMS_10))
@@ -7462,11 +7462,11 @@
 (func infected_det_age70to100_EMS_10 (+ infectious_det_age70to100_EMS_10 H1_det3_age70to100::EMS_10 H2_det3_age70to100::EMS_10 H3_det3_age70to100::EMS_10 C2_det3_age70to100::EMS_10 C3_det3_age70to100::EMS_10))
 (func infected_cumul_age70to100_EMS_10 (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10 deaths_age70to100_EMS_10))    
 
-(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 N_age70to100_EMS_10))    
-(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) N_age70to100_EMS_10))    
+(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
+(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
 
-(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 N_age70to100_EMS_10))    
-(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) N_age70to100_EMS_10))    
+(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
+(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
 
 
 (func asymptomatic_age70to100_EMS_11  (+ As_age70to100::EMS_11 As_det1_age70to100::EMS_11))
@@ -7515,11 +7515,11 @@
 (func infected_det_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_cumul_age70to100_EMS_11 (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11 deaths_age70to100_EMS_11))    
 
-(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 N_age70to100_EMS_11))    
-(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) N_age70to100_EMS_11))    
+(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
+(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
 
-(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 N_age70to100_EMS_11))    
-(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) N_age70to100_EMS_11))    
+(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
+(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
 
 
 (observe susceptible_All (+ S_age0to9::EMS_1 S_age0to9::EMS_2 S_age0to9::EMS_3 S_age0to9::EMS_4 S_age0to9::EMS_5 S_age0to9::EMS_6 S_age0to9::EMS_7 S_age0to9::EMS_8 S_age0to9::EMS_9 S_age0to9::EMS_10 S_age0to9::EMS_11 S_age10to19::EMS_1 S_age10to19::EMS_2 S_age10to19::EMS_3 S_age10to19::EMS_4 S_age10to19::EMS_5 S_age10to19::EMS_6 S_age10to19::EMS_7 S_age10to19::EMS_8 S_age10to19::EMS_9 S_age10to19::EMS_10 S_age10to19::EMS_11 S_age20to29::EMS_1 S_age20to29::EMS_2 S_age20to29::EMS_3 S_age20to29::EMS_4 S_age20to29::EMS_5 S_age20to29::EMS_6 S_age20to29::EMS_7 S_age20to29::EMS_8 S_age20to29::EMS_9 S_age20to29::EMS_10 S_age20to29::EMS_11 S_age30to39::EMS_1 S_age30to39::EMS_2 S_age30to39::EMS_3 S_age30to39::EMS_4 S_age30to39::EMS_5 S_age30to39::EMS_6 S_age30to39::EMS_7 S_age30to39::EMS_8 S_age30to39::EMS_9 S_age30to39::EMS_10 S_age30to39::EMS_11 S_age40to49::EMS_1 S_age40to49::EMS_2 S_age40to49::EMS_3 S_age40to49::EMS_4 S_age40to49::EMS_5 S_age40to49::EMS_6 S_age40to49::EMS_7 S_age40to49::EMS_8 S_age40to49::EMS_9 S_age40to49::EMS_10 S_age40to49::EMS_11 S_age50to59::EMS_1 S_age50to59::EMS_2 S_age50to59::EMS_3 S_age50to59::EMS_4 S_age50to59::EMS_5 S_age50to59::EMS_6 S_age50to59::EMS_7 S_age50to59::EMS_8 S_age50to59::EMS_9 S_age50to59::EMS_10 S_age50to59::EMS_11 S_age60to69::EMS_1 S_age60to69::EMS_2 S_age60to69::EMS_3 S_age60to69::EMS_4 S_age60to69::EMS_5 S_age60to69::EMS_6 S_age60to69::EMS_7 S_age60to69::EMS_8 S_age60to69::EMS_9 S_age60to69::EMS_10 S_age60to69::EMS_11 S_age70to100::EMS_1 S_age70to100::EMS_2 S_age70to100::EMS_3 S_age70to100::EMS_4 S_age70to100::EMS_5 S_age70to100::EMS_6 S_age70to100::EMS_7 S_age70to100::EMS_8 S_age70to100::EMS_9 S_age70to100::EMS_10 S_age70to100::EMS_11))
@@ -12219,12 +12219,14 @@
 (param Ki_red3b_EMS_1 (* Ki_EMS_1 @ki_multiplier_3b_EMS_1@))
 (param Ki_red3c_EMS_1 (* Ki_EMS_1 @ki_multiplier_3c_EMS_1@))
 (param Ki_red4_EMS_1 (* Ki_EMS_1 @ki_multiplier_4_EMS_1@))
+(param Ki_red5_EMS_1 (* Ki_EMS_1 @ki_multiplier_5_EMS_1@))
 (param Ki_red6_EMS_1 (* Ki_EMS_1 @ki_multiplier_6_EMS_1@))
 (param Ki_red7_EMS_1 (* Ki_EMS_1 @ki_multiplier_7_EMS_1@))
 (param Ki_red8_EMS_1 (* Ki_EMS_1 @ki_multiplier_8_EMS_1@))
 (param Ki_red9_EMS_1 (* Ki_EMS_1 @ki_multiplier_9_EMS_1@))
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
+(param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
 
 (param backtonormal_multiplier_1_EMS_1  (/ (- Ki_red6_EMS_1  Ki_red4_EMS_1 ) (- Ki_EMS_1 Ki_red4_EMS_1 ) ) )  
 (observe backtonormal_multiplier_1_EMS_1 backtonormal_multiplier_1_EMS_1)
@@ -12233,23 +12235,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_1 Ki_red3c_EMS_1)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_1 Ki_red4_EMS_1)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_1 Ki_red5_EMS_1)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_1 Ki_red6_EMS_1)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_1 Ki_red7_EMS_1)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_1 Ki_red8_EMS_1)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_1 Ki_red9_EMS_1)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
 (param Ki_red3c_EMS_2 (* Ki_EMS_2 @ki_multiplier_3c_EMS_2@))
 (param Ki_red4_EMS_2 (* Ki_EMS_2 @ki_multiplier_4_EMS_2@))
+(param Ki_red5_EMS_2 (* Ki_EMS_2 @ki_multiplier_5_EMS_2@))
 (param Ki_red6_EMS_2 (* Ki_EMS_2 @ki_multiplier_6_EMS_2@))
 (param Ki_red7_EMS_2 (* Ki_EMS_2 @ki_multiplier_7_EMS_2@))
 (param Ki_red8_EMS_2 (* Ki_EMS_2 @ki_multiplier_8_EMS_2@))
 (param Ki_red9_EMS_2 (* Ki_EMS_2 @ki_multiplier_9_EMS_2@))
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
+(param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
 
 (param backtonormal_multiplier_1_EMS_2  (/ (- Ki_red6_EMS_2  Ki_red4_EMS_2 ) (- Ki_EMS_2 Ki_red4_EMS_2 ) ) )  
 (observe backtonormal_multiplier_1_EMS_2 backtonormal_multiplier_1_EMS_2)
@@ -12258,23 +12264,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_2 Ki_red3c_EMS_2)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_2 Ki_red4_EMS_2)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_2 Ki_red5_EMS_2)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_2 Ki_red6_EMS_2)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_2 Ki_red7_EMS_2)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_2 Ki_red8_EMS_2)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_2 Ki_red9_EMS_2)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
 (param Ki_red3c_EMS_3 (* Ki_EMS_3 @ki_multiplier_3c_EMS_3@))
 (param Ki_red4_EMS_3 (* Ki_EMS_3 @ki_multiplier_4_EMS_3@))
+(param Ki_red5_EMS_3 (* Ki_EMS_3 @ki_multiplier_5_EMS_3@))
 (param Ki_red6_EMS_3 (* Ki_EMS_3 @ki_multiplier_6_EMS_3@))
 (param Ki_red7_EMS_3 (* Ki_EMS_3 @ki_multiplier_7_EMS_3@))
 (param Ki_red8_EMS_3 (* Ki_EMS_3 @ki_multiplier_8_EMS_3@))
 (param Ki_red9_EMS_3 (* Ki_EMS_3 @ki_multiplier_9_EMS_3@))
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
+(param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
 
 (param backtonormal_multiplier_1_EMS_3  (/ (- Ki_red6_EMS_3  Ki_red4_EMS_3 ) (- Ki_EMS_3 Ki_red4_EMS_3 ) ) )  
 (observe backtonormal_multiplier_1_EMS_3 backtonormal_multiplier_1_EMS_3)
@@ -12283,23 +12293,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_3 Ki_red3c_EMS_3)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_3 Ki_red4_EMS_3)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_3 Ki_red5_EMS_3)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_3 Ki_red6_EMS_3)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_3 Ki_red7_EMS_3)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_3 Ki_red8_EMS_3)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_3 Ki_red9_EMS_3)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
 (param Ki_red3c_EMS_4 (* Ki_EMS_4 @ki_multiplier_3c_EMS_4@))
 (param Ki_red4_EMS_4 (* Ki_EMS_4 @ki_multiplier_4_EMS_4@))
+(param Ki_red5_EMS_4 (* Ki_EMS_4 @ki_multiplier_5_EMS_4@))
 (param Ki_red6_EMS_4 (* Ki_EMS_4 @ki_multiplier_6_EMS_4@))
 (param Ki_red7_EMS_4 (* Ki_EMS_4 @ki_multiplier_7_EMS_4@))
 (param Ki_red8_EMS_4 (* Ki_EMS_4 @ki_multiplier_8_EMS_4@))
 (param Ki_red9_EMS_4 (* Ki_EMS_4 @ki_multiplier_9_EMS_4@))
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
+(param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
 
 (param backtonormal_multiplier_1_EMS_4  (/ (- Ki_red6_EMS_4  Ki_red4_EMS_4 ) (- Ki_EMS_4 Ki_red4_EMS_4 ) ) )  
 (observe backtonormal_multiplier_1_EMS_4 backtonormal_multiplier_1_EMS_4)
@@ -12308,23 +12322,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_4 Ki_red3c_EMS_4)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_4 Ki_red4_EMS_4)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_4 Ki_red5_EMS_4)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_4 Ki_red6_EMS_4)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_4 Ki_red7_EMS_4)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_4 Ki_red8_EMS_4)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_4 Ki_red9_EMS_4)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
 (param Ki_red3c_EMS_5 (* Ki_EMS_5 @ki_multiplier_3c_EMS_5@))
 (param Ki_red4_EMS_5 (* Ki_EMS_5 @ki_multiplier_4_EMS_5@))
+(param Ki_red5_EMS_5 (* Ki_EMS_5 @ki_multiplier_5_EMS_5@))
 (param Ki_red6_EMS_5 (* Ki_EMS_5 @ki_multiplier_6_EMS_5@))
 (param Ki_red7_EMS_5 (* Ki_EMS_5 @ki_multiplier_7_EMS_5@))
 (param Ki_red8_EMS_5 (* Ki_EMS_5 @ki_multiplier_8_EMS_5@))
 (param Ki_red9_EMS_5 (* Ki_EMS_5 @ki_multiplier_9_EMS_5@))
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
+(param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
 
 (param backtonormal_multiplier_1_EMS_5  (/ (- Ki_red6_EMS_5  Ki_red4_EMS_5 ) (- Ki_EMS_5 Ki_red4_EMS_5 ) ) )  
 (observe backtonormal_multiplier_1_EMS_5 backtonormal_multiplier_1_EMS_5)
@@ -12333,23 +12351,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_5 Ki_red3c_EMS_5)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_5 Ki_red4_EMS_5)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_5 Ki_red5_EMS_5)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_5 Ki_red6_EMS_5)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_5 Ki_red7_EMS_5)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_5 Ki_red8_EMS_5)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_5 Ki_red9_EMS_5)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
 (param Ki_red3c_EMS_6 (* Ki_EMS_6 @ki_multiplier_3c_EMS_6@))
 (param Ki_red4_EMS_6 (* Ki_EMS_6 @ki_multiplier_4_EMS_6@))
+(param Ki_red5_EMS_6 (* Ki_EMS_6 @ki_multiplier_5_EMS_6@))
 (param Ki_red6_EMS_6 (* Ki_EMS_6 @ki_multiplier_6_EMS_6@))
 (param Ki_red7_EMS_6 (* Ki_EMS_6 @ki_multiplier_7_EMS_6@))
 (param Ki_red8_EMS_6 (* Ki_EMS_6 @ki_multiplier_8_EMS_6@))
 (param Ki_red9_EMS_6 (* Ki_EMS_6 @ki_multiplier_9_EMS_6@))
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
+(param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
 
 (param backtonormal_multiplier_1_EMS_6  (/ (- Ki_red6_EMS_6  Ki_red4_EMS_6 ) (- Ki_EMS_6 Ki_red4_EMS_6 ) ) )  
 (observe backtonormal_multiplier_1_EMS_6 backtonormal_multiplier_1_EMS_6)
@@ -12358,23 +12380,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_6 Ki_red3c_EMS_6)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_6 Ki_red4_EMS_6)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_6 Ki_red5_EMS_6)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_6 Ki_red6_EMS_6)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_6 Ki_red7_EMS_6)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_6 Ki_red8_EMS_6)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_6 Ki_red9_EMS_6)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
 (param Ki_red3c_EMS_7 (* Ki_EMS_7 @ki_multiplier_3c_EMS_7@))
 (param Ki_red4_EMS_7 (* Ki_EMS_7 @ki_multiplier_4_EMS_7@))
+(param Ki_red5_EMS_7 (* Ki_EMS_7 @ki_multiplier_5_EMS_7@))
 (param Ki_red6_EMS_7 (* Ki_EMS_7 @ki_multiplier_6_EMS_7@))
 (param Ki_red7_EMS_7 (* Ki_EMS_7 @ki_multiplier_7_EMS_7@))
 (param Ki_red8_EMS_7 (* Ki_EMS_7 @ki_multiplier_8_EMS_7@))
 (param Ki_red9_EMS_7 (* Ki_EMS_7 @ki_multiplier_9_EMS_7@))
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
+(param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
 
 (param backtonormal_multiplier_1_EMS_7  (/ (- Ki_red6_EMS_7  Ki_red4_EMS_7 ) (- Ki_EMS_7 Ki_red4_EMS_7 ) ) )  
 (observe backtonormal_multiplier_1_EMS_7 backtonormal_multiplier_1_EMS_7)
@@ -12383,23 +12409,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_7 Ki_red3c_EMS_7)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_7 Ki_red4_EMS_7)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_7 Ki_red5_EMS_7)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_7 Ki_red6_EMS_7)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_7 Ki_red7_EMS_7)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_7 Ki_red8_EMS_7)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_7 Ki_red9_EMS_7)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
 (param Ki_red3c_EMS_8 (* Ki_EMS_8 @ki_multiplier_3c_EMS_8@))
 (param Ki_red4_EMS_8 (* Ki_EMS_8 @ki_multiplier_4_EMS_8@))
+(param Ki_red5_EMS_8 (* Ki_EMS_8 @ki_multiplier_5_EMS_8@))
 (param Ki_red6_EMS_8 (* Ki_EMS_8 @ki_multiplier_6_EMS_8@))
 (param Ki_red7_EMS_8 (* Ki_EMS_8 @ki_multiplier_7_EMS_8@))
 (param Ki_red8_EMS_8 (* Ki_EMS_8 @ki_multiplier_8_EMS_8@))
 (param Ki_red9_EMS_8 (* Ki_EMS_8 @ki_multiplier_9_EMS_8@))
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
+(param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
 
 (param backtonormal_multiplier_1_EMS_8  (/ (- Ki_red6_EMS_8  Ki_red4_EMS_8 ) (- Ki_EMS_8 Ki_red4_EMS_8 ) ) )  
 (observe backtonormal_multiplier_1_EMS_8 backtonormal_multiplier_1_EMS_8)
@@ -12408,23 +12438,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_8 Ki_red3c_EMS_8)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_8 Ki_red4_EMS_8)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_8 Ki_red5_EMS_8)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_8 Ki_red6_EMS_8)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_8 Ki_red7_EMS_8)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_8 Ki_red8_EMS_8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_8 Ki_red9_EMS_8)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
 (param Ki_red3c_EMS_9 (* Ki_EMS_9 @ki_multiplier_3c_EMS_9@))
 (param Ki_red4_EMS_9 (* Ki_EMS_9 @ki_multiplier_4_EMS_9@))
+(param Ki_red5_EMS_9 (* Ki_EMS_9 @ki_multiplier_5_EMS_9@))
 (param Ki_red6_EMS_9 (* Ki_EMS_9 @ki_multiplier_6_EMS_9@))
 (param Ki_red7_EMS_9 (* Ki_EMS_9 @ki_multiplier_7_EMS_9@))
 (param Ki_red8_EMS_9 (* Ki_EMS_9 @ki_multiplier_8_EMS_9@))
 (param Ki_red9_EMS_9 (* Ki_EMS_9 @ki_multiplier_9_EMS_9@))
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
+(param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
 
 (param backtonormal_multiplier_1_EMS_9  (/ (- Ki_red6_EMS_9  Ki_red4_EMS_9 ) (- Ki_EMS_9 Ki_red4_EMS_9 ) ) )  
 (observe backtonormal_multiplier_1_EMS_9 backtonormal_multiplier_1_EMS_9)
@@ -12433,23 +12467,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_9 Ki_red3c_EMS_9)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_9 Ki_red4_EMS_9)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_9 Ki_red5_EMS_9)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_9 Ki_red6_EMS_9)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_9 Ki_red7_EMS_9)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_9 Ki_red8_EMS_9)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_9 Ki_red9_EMS_9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
 (param Ki_red3c_EMS_10 (* Ki_EMS_10 @ki_multiplier_3c_EMS_10@))
 (param Ki_red4_EMS_10 (* Ki_EMS_10 @ki_multiplier_4_EMS_10@))
+(param Ki_red5_EMS_10 (* Ki_EMS_10 @ki_multiplier_5_EMS_10@))
 (param Ki_red6_EMS_10 (* Ki_EMS_10 @ki_multiplier_6_EMS_10@))
 (param Ki_red7_EMS_10 (* Ki_EMS_10 @ki_multiplier_7_EMS_10@))
 (param Ki_red8_EMS_10 (* Ki_EMS_10 @ki_multiplier_8_EMS_10@))
 (param Ki_red9_EMS_10 (* Ki_EMS_10 @ki_multiplier_9_EMS_10@))
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
+(param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
 
 (param backtonormal_multiplier_1_EMS_10  (/ (- Ki_red6_EMS_10  Ki_red4_EMS_10 ) (- Ki_EMS_10 Ki_red4_EMS_10 ) ) )  
 (observe backtonormal_multiplier_1_EMS_10 backtonormal_multiplier_1_EMS_10)
@@ -12458,23 +12496,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_10 Ki_red3c_EMS_10)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_10 Ki_red4_EMS_10)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_10 Ki_red5_EMS_10)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_10 Ki_red6_EMS_10)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_10 Ki_red7_EMS_10)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_10 Ki_red8_EMS_10)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_10 Ki_red9_EMS_10)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
 (param Ki_red3c_EMS_11 (* Ki_EMS_11 @ki_multiplier_3c_EMS_11@))
 (param Ki_red4_EMS_11 (* Ki_EMS_11 @ki_multiplier_4_EMS_11@))
+(param Ki_red5_EMS_11 (* Ki_EMS_11 @ki_multiplier_5_EMS_11@))
 (param Ki_red6_EMS_11 (* Ki_EMS_11 @ki_multiplier_6_EMS_11@))
 (param Ki_red7_EMS_11 (* Ki_EMS_11 @ki_multiplier_7_EMS_11@))
 (param Ki_red8_EMS_11 (* Ki_EMS_11 @ki_multiplier_8_EMS_11@))
 (param Ki_red9_EMS_11 (* Ki_EMS_11 @ki_multiplier_9_EMS_11@))
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
+(param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
 
 (param backtonormal_multiplier_1_EMS_11  (/ (- Ki_red6_EMS_11  Ki_red4_EMS_11 ) (- Ki_EMS_11 Ki_red4_EMS_11 ) ) )  
 (observe backtonormal_multiplier_1_EMS_11 backtonormal_multiplier_1_EMS_11)
@@ -12483,12 +12525,14 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_11 Ki_red3c_EMS_11)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_11 Ki_red4_EMS_11)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_11 Ki_red6_EMS_11)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_11 Ki_red7_EMS_11)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_11 Ki_red8_EMS_11)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_11 Ki_red9_EMS_11)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_agelocale_migration_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_migration_scen3.emodl
@@ -2904,13 +2904,6 @@
 (func infected_det_age0to9_EMS_1 (+ infectious_det_age0to9_EMS_1 H1_det3_age0to9::EMS_1 H2_det3_age0to9::EMS_1 H3_det3_age0to9::EMS_1 C2_det3_age0to9::EMS_1 C3_det3_age0to9::EMS_1))
 (func infected_cumul_age0to9_EMS_1 (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1 deaths_age0to9_EMS_1))    
 
-(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-
-(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-
-
 (func asymptomatic_age0to9_EMS_2  (+ As_age0to9::EMS_2 As_det1_age0to9::EMS_2))
 
 (func symptomatic_mild_age0to9_EMS_2  (+ Sym_age0to9::EMS_2 Sym_det2_age0to9::EMS_2))
@@ -2956,13 +2949,6 @@
 (func infected_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 infectious_undet_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_det_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_cumul_age0to9_EMS_2 (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2 deaths_age0to9_EMS_2))    
-
-(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-
-(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-
 
 (func asymptomatic_age0to9_EMS_3  (+ As_age0to9::EMS_3 As_det1_age0to9::EMS_3))
 
@@ -3010,13 +2996,6 @@
 (func infected_det_age0to9_EMS_3 (+ infectious_det_age0to9_EMS_3 H1_det3_age0to9::EMS_3 H2_det3_age0to9::EMS_3 H3_det3_age0to9::EMS_3 C2_det3_age0to9::EMS_3 C3_det3_age0to9::EMS_3))
 (func infected_cumul_age0to9_EMS_3 (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3 deaths_age0to9_EMS_3))    
 
-(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-
-(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-
-
 (func asymptomatic_age0to9_EMS_4  (+ As_age0to9::EMS_4 As_det1_age0to9::EMS_4))
 
 (func symptomatic_mild_age0to9_EMS_4  (+ Sym_age0to9::EMS_4 Sym_det2_age0to9::EMS_4))
@@ -3062,13 +3041,6 @@
 (func infected_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 infectious_undet_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_det_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_cumul_age0to9_EMS_4 (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4 deaths_age0to9_EMS_4))    
-
-(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-
-(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-
 
 (func asymptomatic_age0to9_EMS_5  (+ As_age0to9::EMS_5 As_det1_age0to9::EMS_5))
 
@@ -3116,13 +3088,6 @@
 (func infected_det_age0to9_EMS_5 (+ infectious_det_age0to9_EMS_5 H1_det3_age0to9::EMS_5 H2_det3_age0to9::EMS_5 H3_det3_age0to9::EMS_5 C2_det3_age0to9::EMS_5 C3_det3_age0to9::EMS_5))
 (func infected_cumul_age0to9_EMS_5 (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5 deaths_age0to9_EMS_5))    
 
-(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-
-(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-
-
 (func asymptomatic_age0to9_EMS_6  (+ As_age0to9::EMS_6 As_det1_age0to9::EMS_6))
 
 (func symptomatic_mild_age0to9_EMS_6  (+ Sym_age0to9::EMS_6 Sym_det2_age0to9::EMS_6))
@@ -3168,13 +3133,6 @@
 (func infected_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 infectious_undet_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_det_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_cumul_age0to9_EMS_6 (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6 deaths_age0to9_EMS_6))    
-
-(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-
-(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-
 
 (func asymptomatic_age0to9_EMS_7  (+ As_age0to9::EMS_7 As_det1_age0to9::EMS_7))
 
@@ -3222,13 +3180,6 @@
 (func infected_det_age0to9_EMS_7 (+ infectious_det_age0to9_EMS_7 H1_det3_age0to9::EMS_7 H2_det3_age0to9::EMS_7 H3_det3_age0to9::EMS_7 C2_det3_age0to9::EMS_7 C3_det3_age0to9::EMS_7))
 (func infected_cumul_age0to9_EMS_7 (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7 deaths_age0to9_EMS_7))    
 
-(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-
-(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-
-
 (func asymptomatic_age0to9_EMS_8  (+ As_age0to9::EMS_8 As_det1_age0to9::EMS_8))
 
 (func symptomatic_mild_age0to9_EMS_8  (+ Sym_age0to9::EMS_8 Sym_det2_age0to9::EMS_8))
@@ -3274,13 +3225,6 @@
 (func infected_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 infectious_undet_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_det_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_cumul_age0to9_EMS_8 (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8 deaths_age0to9_EMS_8))    
-
-(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-
-(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-
 
 (func asymptomatic_age0to9_EMS_9  (+ As_age0to9::EMS_9 As_det1_age0to9::EMS_9))
 
@@ -3328,13 +3272,6 @@
 (func infected_det_age0to9_EMS_9 (+ infectious_det_age0to9_EMS_9 H1_det3_age0to9::EMS_9 H2_det3_age0to9::EMS_9 H3_det3_age0to9::EMS_9 C2_det3_age0to9::EMS_9 C3_det3_age0to9::EMS_9))
 (func infected_cumul_age0to9_EMS_9 (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9 deaths_age0to9_EMS_9))    
 
-(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-
-(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-
-
 (func asymptomatic_age0to9_EMS_10  (+ As_age0to9::EMS_10 As_det1_age0to9::EMS_10))
 
 (func symptomatic_mild_age0to9_EMS_10  (+ Sym_age0to9::EMS_10 Sym_det2_age0to9::EMS_10))
@@ -3380,13 +3317,6 @@
 (func infected_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 infectious_undet_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_det_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_cumul_age0to9_EMS_10 (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10 deaths_age0to9_EMS_10))    
-
-(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-
-(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-
 
 (func asymptomatic_age0to9_EMS_11  (+ As_age0to9::EMS_11 As_det1_age0to9::EMS_11))
 
@@ -3434,13 +3364,6 @@
 (func infected_det_age0to9_EMS_11 (+ infectious_det_age0to9_EMS_11 H1_det3_age0to9::EMS_11 H2_det3_age0to9::EMS_11 H3_det3_age0to9::EMS_11 C2_det3_age0to9::EMS_11 C3_det3_age0to9::EMS_11))
 (func infected_cumul_age0to9_EMS_11 (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11 deaths_age0to9_EMS_11))    
 
-(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-
-(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-
-
 (func asymptomatic_age10to19_EMS_1  (+ As_age10to19::EMS_1 As_det1_age10to19::EMS_1))
 
 (func symptomatic_mild_age10to19_EMS_1  (+ Sym_age10to19::EMS_1 Sym_det2_age10to19::EMS_1))
@@ -3486,13 +3409,6 @@
 (func infected_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 infectious_undet_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_det_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_cumul_age10to19_EMS_1 (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1 deaths_age10to19_EMS_1))    
-
-(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-
-(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-
 
 (func asymptomatic_age10to19_EMS_2  (+ As_age10to19::EMS_2 As_det1_age10to19::EMS_2))
 
@@ -3540,13 +3456,6 @@
 (func infected_det_age10to19_EMS_2 (+ infectious_det_age10to19_EMS_2 H1_det3_age10to19::EMS_2 H2_det3_age10to19::EMS_2 H3_det3_age10to19::EMS_2 C2_det3_age10to19::EMS_2 C3_det3_age10to19::EMS_2))
 (func infected_cumul_age10to19_EMS_2 (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2 deaths_age10to19_EMS_2))    
 
-(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-
-(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-
-
 (func asymptomatic_age10to19_EMS_3  (+ As_age10to19::EMS_3 As_det1_age10to19::EMS_3))
 
 (func symptomatic_mild_age10to19_EMS_3  (+ Sym_age10to19::EMS_3 Sym_det2_age10to19::EMS_3))
@@ -3592,13 +3501,6 @@
 (func infected_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 infectious_undet_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_det_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_cumul_age10to19_EMS_3 (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3 deaths_age10to19_EMS_3))    
-
-(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-
-(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-
 
 (func asymptomatic_age10to19_EMS_4  (+ As_age10to19::EMS_4 As_det1_age10to19::EMS_4))
 
@@ -3646,13 +3548,6 @@
 (func infected_det_age10to19_EMS_4 (+ infectious_det_age10to19_EMS_4 H1_det3_age10to19::EMS_4 H2_det3_age10to19::EMS_4 H3_det3_age10to19::EMS_4 C2_det3_age10to19::EMS_4 C3_det3_age10to19::EMS_4))
 (func infected_cumul_age10to19_EMS_4 (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4 deaths_age10to19_EMS_4))    
 
-(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-
-(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-
-
 (func asymptomatic_age10to19_EMS_5  (+ As_age10to19::EMS_5 As_det1_age10to19::EMS_5))
 
 (func symptomatic_mild_age10to19_EMS_5  (+ Sym_age10to19::EMS_5 Sym_det2_age10to19::EMS_5))
@@ -3698,13 +3593,6 @@
 (func infected_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 infectious_undet_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_det_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_cumul_age10to19_EMS_5 (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5 deaths_age10to19_EMS_5))    
-
-(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-
-(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-
 
 (func asymptomatic_age10to19_EMS_6  (+ As_age10to19::EMS_6 As_det1_age10to19::EMS_6))
 
@@ -3752,13 +3640,6 @@
 (func infected_det_age10to19_EMS_6 (+ infectious_det_age10to19_EMS_6 H1_det3_age10to19::EMS_6 H2_det3_age10to19::EMS_6 H3_det3_age10to19::EMS_6 C2_det3_age10to19::EMS_6 C3_det3_age10to19::EMS_6))
 (func infected_cumul_age10to19_EMS_6 (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6 deaths_age10to19_EMS_6))    
 
-(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-
-(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-
-
 (func asymptomatic_age10to19_EMS_7  (+ As_age10to19::EMS_7 As_det1_age10to19::EMS_7))
 
 (func symptomatic_mild_age10to19_EMS_7  (+ Sym_age10to19::EMS_7 Sym_det2_age10to19::EMS_7))
@@ -3804,13 +3685,6 @@
 (func infected_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 infectious_undet_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_det_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_cumul_age10to19_EMS_7 (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7 deaths_age10to19_EMS_7))    
-
-(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-
-(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-
 
 (func asymptomatic_age10to19_EMS_8  (+ As_age10to19::EMS_8 As_det1_age10to19::EMS_8))
 
@@ -3858,13 +3732,6 @@
 (func infected_det_age10to19_EMS_8 (+ infectious_det_age10to19_EMS_8 H1_det3_age10to19::EMS_8 H2_det3_age10to19::EMS_8 H3_det3_age10to19::EMS_8 C2_det3_age10to19::EMS_8 C3_det3_age10to19::EMS_8))
 (func infected_cumul_age10to19_EMS_8 (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8 deaths_age10to19_EMS_8))    
 
-(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-
-(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-
-
 (func asymptomatic_age10to19_EMS_9  (+ As_age10to19::EMS_9 As_det1_age10to19::EMS_9))
 
 (func symptomatic_mild_age10to19_EMS_9  (+ Sym_age10to19::EMS_9 Sym_det2_age10to19::EMS_9))
@@ -3910,13 +3777,6 @@
 (func infected_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 infectious_undet_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_det_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_cumul_age10to19_EMS_9 (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9 deaths_age10to19_EMS_9))    
-
-(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-
-(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-
 
 (func asymptomatic_age10to19_EMS_10  (+ As_age10to19::EMS_10 As_det1_age10to19::EMS_10))
 
@@ -3964,13 +3824,6 @@
 (func infected_det_age10to19_EMS_10 (+ infectious_det_age10to19_EMS_10 H1_det3_age10to19::EMS_10 H2_det3_age10to19::EMS_10 H3_det3_age10to19::EMS_10 C2_det3_age10to19::EMS_10 C3_det3_age10to19::EMS_10))
 (func infected_cumul_age10to19_EMS_10 (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10 deaths_age10to19_EMS_10))    
 
-(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-
-(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-
-
 (func asymptomatic_age10to19_EMS_11  (+ As_age10to19::EMS_11 As_det1_age10to19::EMS_11))
 
 (func symptomatic_mild_age10to19_EMS_11  (+ Sym_age10to19::EMS_11 Sym_det2_age10to19::EMS_11))
@@ -4016,13 +3869,6 @@
 (func infected_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 infectious_undet_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_det_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_cumul_age10to19_EMS_11 (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11 deaths_age10to19_EMS_11))    
-
-(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-
-(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-
 
 (func asymptomatic_age20to29_EMS_1  (+ As_age20to29::EMS_1 As_det1_age20to29::EMS_1))
 
@@ -4070,13 +3916,6 @@
 (func infected_det_age20to29_EMS_1 (+ infectious_det_age20to29_EMS_1 H1_det3_age20to29::EMS_1 H2_det3_age20to29::EMS_1 H3_det3_age20to29::EMS_1 C2_det3_age20to29::EMS_1 C3_det3_age20to29::EMS_1))
 (func infected_cumul_age20to29_EMS_1 (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1 deaths_age20to29_EMS_1))    
 
-(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-
-(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-
-
 (func asymptomatic_age20to29_EMS_2  (+ As_age20to29::EMS_2 As_det1_age20to29::EMS_2))
 
 (func symptomatic_mild_age20to29_EMS_2  (+ Sym_age20to29::EMS_2 Sym_det2_age20to29::EMS_2))
@@ -4122,13 +3961,6 @@
 (func infected_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 infectious_undet_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_det_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_cumul_age20to29_EMS_2 (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2 deaths_age20to29_EMS_2))    
-
-(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-
-(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-
 
 (func asymptomatic_age20to29_EMS_3  (+ As_age20to29::EMS_3 As_det1_age20to29::EMS_3))
 
@@ -4176,13 +4008,6 @@
 (func infected_det_age20to29_EMS_3 (+ infectious_det_age20to29_EMS_3 H1_det3_age20to29::EMS_3 H2_det3_age20to29::EMS_3 H3_det3_age20to29::EMS_3 C2_det3_age20to29::EMS_3 C3_det3_age20to29::EMS_3))
 (func infected_cumul_age20to29_EMS_3 (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3 deaths_age20to29_EMS_3))    
 
-(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-
-(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-
-
 (func asymptomatic_age20to29_EMS_4  (+ As_age20to29::EMS_4 As_det1_age20to29::EMS_4))
 
 (func symptomatic_mild_age20to29_EMS_4  (+ Sym_age20to29::EMS_4 Sym_det2_age20to29::EMS_4))
@@ -4228,13 +4053,6 @@
 (func infected_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 infectious_undet_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_det_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_cumul_age20to29_EMS_4 (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4 deaths_age20to29_EMS_4))    
-
-(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-
-(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-
 
 (func asymptomatic_age20to29_EMS_5  (+ As_age20to29::EMS_5 As_det1_age20to29::EMS_5))
 
@@ -4282,13 +4100,6 @@
 (func infected_det_age20to29_EMS_5 (+ infectious_det_age20to29_EMS_5 H1_det3_age20to29::EMS_5 H2_det3_age20to29::EMS_5 H3_det3_age20to29::EMS_5 C2_det3_age20to29::EMS_5 C3_det3_age20to29::EMS_5))
 (func infected_cumul_age20to29_EMS_5 (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5 deaths_age20to29_EMS_5))    
 
-(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-
-(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-
-
 (func asymptomatic_age20to29_EMS_6  (+ As_age20to29::EMS_6 As_det1_age20to29::EMS_6))
 
 (func symptomatic_mild_age20to29_EMS_6  (+ Sym_age20to29::EMS_6 Sym_det2_age20to29::EMS_6))
@@ -4334,13 +4145,6 @@
 (func infected_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 infectious_undet_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_det_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_cumul_age20to29_EMS_6 (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6 deaths_age20to29_EMS_6))    
-
-(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-
-(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-
 
 (func asymptomatic_age20to29_EMS_7  (+ As_age20to29::EMS_7 As_det1_age20to29::EMS_7))
 
@@ -4388,13 +4192,6 @@
 (func infected_det_age20to29_EMS_7 (+ infectious_det_age20to29_EMS_7 H1_det3_age20to29::EMS_7 H2_det3_age20to29::EMS_7 H3_det3_age20to29::EMS_7 C2_det3_age20to29::EMS_7 C3_det3_age20to29::EMS_7))
 (func infected_cumul_age20to29_EMS_7 (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7 deaths_age20to29_EMS_7))    
 
-(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-
-(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-
-
 (func asymptomatic_age20to29_EMS_8  (+ As_age20to29::EMS_8 As_det1_age20to29::EMS_8))
 
 (func symptomatic_mild_age20to29_EMS_8  (+ Sym_age20to29::EMS_8 Sym_det2_age20to29::EMS_8))
@@ -4440,13 +4237,6 @@
 (func infected_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 infectious_undet_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_det_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_cumul_age20to29_EMS_8 (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8 deaths_age20to29_EMS_8))    
-
-(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-
-(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-
 
 (func asymptomatic_age20to29_EMS_9  (+ As_age20to29::EMS_9 As_det1_age20to29::EMS_9))
 
@@ -4494,13 +4284,6 @@
 (func infected_det_age20to29_EMS_9 (+ infectious_det_age20to29_EMS_9 H1_det3_age20to29::EMS_9 H2_det3_age20to29::EMS_9 H3_det3_age20to29::EMS_9 C2_det3_age20to29::EMS_9 C3_det3_age20to29::EMS_9))
 (func infected_cumul_age20to29_EMS_9 (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9 deaths_age20to29_EMS_9))    
 
-(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-
-(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-
-
 (func asymptomatic_age20to29_EMS_10  (+ As_age20to29::EMS_10 As_det1_age20to29::EMS_10))
 
 (func symptomatic_mild_age20to29_EMS_10  (+ Sym_age20to29::EMS_10 Sym_det2_age20to29::EMS_10))
@@ -4546,13 +4329,6 @@
 (func infected_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 infectious_undet_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_det_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_cumul_age20to29_EMS_10 (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10 deaths_age20to29_EMS_10))    
-
-(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-
-(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-
 
 (func asymptomatic_age20to29_EMS_11  (+ As_age20to29::EMS_11 As_det1_age20to29::EMS_11))
 
@@ -4600,13 +4376,6 @@
 (func infected_det_age20to29_EMS_11 (+ infectious_det_age20to29_EMS_11 H1_det3_age20to29::EMS_11 H2_det3_age20to29::EMS_11 H3_det3_age20to29::EMS_11 C2_det3_age20to29::EMS_11 C3_det3_age20to29::EMS_11))
 (func infected_cumul_age20to29_EMS_11 (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11 deaths_age20to29_EMS_11))    
 
-(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-
-(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-
-
 (func asymptomatic_age30to39_EMS_1  (+ As_age30to39::EMS_1 As_det1_age30to39::EMS_1))
 
 (func symptomatic_mild_age30to39_EMS_1  (+ Sym_age30to39::EMS_1 Sym_det2_age30to39::EMS_1))
@@ -4652,13 +4421,6 @@
 (func infected_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 infectious_undet_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_det_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_cumul_age30to39_EMS_1 (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1 deaths_age30to39_EMS_1))    
-
-(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-
-(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-
 
 (func asymptomatic_age30to39_EMS_2  (+ As_age30to39::EMS_2 As_det1_age30to39::EMS_2))
 
@@ -4706,13 +4468,6 @@
 (func infected_det_age30to39_EMS_2 (+ infectious_det_age30to39_EMS_2 H1_det3_age30to39::EMS_2 H2_det3_age30to39::EMS_2 H3_det3_age30to39::EMS_2 C2_det3_age30to39::EMS_2 C3_det3_age30to39::EMS_2))
 (func infected_cumul_age30to39_EMS_2 (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2 deaths_age30to39_EMS_2))    
 
-(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-
-(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-
-
 (func asymptomatic_age30to39_EMS_3  (+ As_age30to39::EMS_3 As_det1_age30to39::EMS_3))
 
 (func symptomatic_mild_age30to39_EMS_3  (+ Sym_age30to39::EMS_3 Sym_det2_age30to39::EMS_3))
@@ -4758,13 +4513,6 @@
 (func infected_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 infectious_undet_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_det_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_cumul_age30to39_EMS_3 (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3 deaths_age30to39_EMS_3))    
-
-(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-
-(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-
 
 (func asymptomatic_age30to39_EMS_4  (+ As_age30to39::EMS_4 As_det1_age30to39::EMS_4))
 
@@ -4812,13 +4560,6 @@
 (func infected_det_age30to39_EMS_4 (+ infectious_det_age30to39_EMS_4 H1_det3_age30to39::EMS_4 H2_det3_age30to39::EMS_4 H3_det3_age30to39::EMS_4 C2_det3_age30to39::EMS_4 C3_det3_age30to39::EMS_4))
 (func infected_cumul_age30to39_EMS_4 (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4 deaths_age30to39_EMS_4))    
 
-(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-
-(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-
-
 (func asymptomatic_age30to39_EMS_5  (+ As_age30to39::EMS_5 As_det1_age30to39::EMS_5))
 
 (func symptomatic_mild_age30to39_EMS_5  (+ Sym_age30to39::EMS_5 Sym_det2_age30to39::EMS_5))
@@ -4864,13 +4605,6 @@
 (func infected_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 infectious_undet_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_det_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_cumul_age30to39_EMS_5 (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5 deaths_age30to39_EMS_5))    
-
-(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-
-(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-
 
 (func asymptomatic_age30to39_EMS_6  (+ As_age30to39::EMS_6 As_det1_age30to39::EMS_6))
 
@@ -4918,13 +4652,6 @@
 (func infected_det_age30to39_EMS_6 (+ infectious_det_age30to39_EMS_6 H1_det3_age30to39::EMS_6 H2_det3_age30to39::EMS_6 H3_det3_age30to39::EMS_6 C2_det3_age30to39::EMS_6 C3_det3_age30to39::EMS_6))
 (func infected_cumul_age30to39_EMS_6 (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6 deaths_age30to39_EMS_6))    
 
-(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-
-(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-
-
 (func asymptomatic_age30to39_EMS_7  (+ As_age30to39::EMS_7 As_det1_age30to39::EMS_7))
 
 (func symptomatic_mild_age30to39_EMS_7  (+ Sym_age30to39::EMS_7 Sym_det2_age30to39::EMS_7))
@@ -4970,13 +4697,6 @@
 (func infected_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 infectious_undet_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_det_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_cumul_age30to39_EMS_7 (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7 deaths_age30to39_EMS_7))    
-
-(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-
-(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-
 
 (func asymptomatic_age30to39_EMS_8  (+ As_age30to39::EMS_8 As_det1_age30to39::EMS_8))
 
@@ -5024,13 +4744,6 @@
 (func infected_det_age30to39_EMS_8 (+ infectious_det_age30to39_EMS_8 H1_det3_age30to39::EMS_8 H2_det3_age30to39::EMS_8 H3_det3_age30to39::EMS_8 C2_det3_age30to39::EMS_8 C3_det3_age30to39::EMS_8))
 (func infected_cumul_age30to39_EMS_8 (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8 deaths_age30to39_EMS_8))    
 
-(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-
-(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-
-
 (func asymptomatic_age30to39_EMS_9  (+ As_age30to39::EMS_9 As_det1_age30to39::EMS_9))
 
 (func symptomatic_mild_age30to39_EMS_9  (+ Sym_age30to39::EMS_9 Sym_det2_age30to39::EMS_9))
@@ -5076,13 +4789,6 @@
 (func infected_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 infectious_undet_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_det_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_cumul_age30to39_EMS_9 (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9 deaths_age30to39_EMS_9))    
-
-(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-
-(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-
 
 (func asymptomatic_age30to39_EMS_10  (+ As_age30to39::EMS_10 As_det1_age30to39::EMS_10))
 
@@ -5130,13 +4836,6 @@
 (func infected_det_age30to39_EMS_10 (+ infectious_det_age30to39_EMS_10 H1_det3_age30to39::EMS_10 H2_det3_age30to39::EMS_10 H3_det3_age30to39::EMS_10 C2_det3_age30to39::EMS_10 C3_det3_age30to39::EMS_10))
 (func infected_cumul_age30to39_EMS_10 (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10 deaths_age30to39_EMS_10))    
 
-(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-
-(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-
-
 (func asymptomatic_age30to39_EMS_11  (+ As_age30to39::EMS_11 As_det1_age30to39::EMS_11))
 
 (func symptomatic_mild_age30to39_EMS_11  (+ Sym_age30to39::EMS_11 Sym_det2_age30to39::EMS_11))
@@ -5182,13 +4881,6 @@
 (func infected_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 infectious_undet_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_det_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_cumul_age30to39_EMS_11 (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11 deaths_age30to39_EMS_11))    
-
-(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-
-(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-
 
 (func asymptomatic_age40to49_EMS_1  (+ As_age40to49::EMS_1 As_det1_age40to49::EMS_1))
 
@@ -5236,13 +4928,6 @@
 (func infected_det_age40to49_EMS_1 (+ infectious_det_age40to49_EMS_1 H1_det3_age40to49::EMS_1 H2_det3_age40to49::EMS_1 H3_det3_age40to49::EMS_1 C2_det3_age40to49::EMS_1 C3_det3_age40to49::EMS_1))
 (func infected_cumul_age40to49_EMS_1 (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1 deaths_age40to49_EMS_1))    
 
-(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-
-(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-
-
 (func asymptomatic_age40to49_EMS_2  (+ As_age40to49::EMS_2 As_det1_age40to49::EMS_2))
 
 (func symptomatic_mild_age40to49_EMS_2  (+ Sym_age40to49::EMS_2 Sym_det2_age40to49::EMS_2))
@@ -5288,13 +4973,6 @@
 (func infected_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 infectious_undet_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_det_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_cumul_age40to49_EMS_2 (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2 deaths_age40to49_EMS_2))    
-
-(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-
-(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-
 
 (func asymptomatic_age40to49_EMS_3  (+ As_age40to49::EMS_3 As_det1_age40to49::EMS_3))
 
@@ -5342,13 +5020,6 @@
 (func infected_det_age40to49_EMS_3 (+ infectious_det_age40to49_EMS_3 H1_det3_age40to49::EMS_3 H2_det3_age40to49::EMS_3 H3_det3_age40to49::EMS_3 C2_det3_age40to49::EMS_3 C3_det3_age40to49::EMS_3))
 (func infected_cumul_age40to49_EMS_3 (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3 deaths_age40to49_EMS_3))    
 
-(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-
-(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-
-
 (func asymptomatic_age40to49_EMS_4  (+ As_age40to49::EMS_4 As_det1_age40to49::EMS_4))
 
 (func symptomatic_mild_age40to49_EMS_4  (+ Sym_age40to49::EMS_4 Sym_det2_age40to49::EMS_4))
@@ -5394,13 +5065,6 @@
 (func infected_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 infectious_undet_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_det_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_cumul_age40to49_EMS_4 (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4 deaths_age40to49_EMS_4))    
-
-(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-
-(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-
 
 (func asymptomatic_age40to49_EMS_5  (+ As_age40to49::EMS_5 As_det1_age40to49::EMS_5))
 
@@ -5448,13 +5112,6 @@
 (func infected_det_age40to49_EMS_5 (+ infectious_det_age40to49_EMS_5 H1_det3_age40to49::EMS_5 H2_det3_age40to49::EMS_5 H3_det3_age40to49::EMS_5 C2_det3_age40to49::EMS_5 C3_det3_age40to49::EMS_5))
 (func infected_cumul_age40to49_EMS_5 (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5 deaths_age40to49_EMS_5))    
 
-(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-
-(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-
-
 (func asymptomatic_age40to49_EMS_6  (+ As_age40to49::EMS_6 As_det1_age40to49::EMS_6))
 
 (func symptomatic_mild_age40to49_EMS_6  (+ Sym_age40to49::EMS_6 Sym_det2_age40to49::EMS_6))
@@ -5500,13 +5157,6 @@
 (func infected_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 infectious_undet_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_det_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_cumul_age40to49_EMS_6 (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6 deaths_age40to49_EMS_6))    
-
-(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-
-(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-
 
 (func asymptomatic_age40to49_EMS_7  (+ As_age40to49::EMS_7 As_det1_age40to49::EMS_7))
 
@@ -5554,13 +5204,6 @@
 (func infected_det_age40to49_EMS_7 (+ infectious_det_age40to49_EMS_7 H1_det3_age40to49::EMS_7 H2_det3_age40to49::EMS_7 H3_det3_age40to49::EMS_7 C2_det3_age40to49::EMS_7 C3_det3_age40to49::EMS_7))
 (func infected_cumul_age40to49_EMS_7 (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7 deaths_age40to49_EMS_7))    
 
-(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-
-(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-
-
 (func asymptomatic_age40to49_EMS_8  (+ As_age40to49::EMS_8 As_det1_age40to49::EMS_8))
 
 (func symptomatic_mild_age40to49_EMS_8  (+ Sym_age40to49::EMS_8 Sym_det2_age40to49::EMS_8))
@@ -5606,13 +5249,6 @@
 (func infected_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 infectious_undet_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_det_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_cumul_age40to49_EMS_8 (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8 deaths_age40to49_EMS_8))    
-
-(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-
-(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-
 
 (func asymptomatic_age40to49_EMS_9  (+ As_age40to49::EMS_9 As_det1_age40to49::EMS_9))
 
@@ -5660,13 +5296,6 @@
 (func infected_det_age40to49_EMS_9 (+ infectious_det_age40to49_EMS_9 H1_det3_age40to49::EMS_9 H2_det3_age40to49::EMS_9 H3_det3_age40to49::EMS_9 C2_det3_age40to49::EMS_9 C3_det3_age40to49::EMS_9))
 (func infected_cumul_age40to49_EMS_9 (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9 deaths_age40to49_EMS_9))    
 
-(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-
-(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-
-
 (func asymptomatic_age40to49_EMS_10  (+ As_age40to49::EMS_10 As_det1_age40to49::EMS_10))
 
 (func symptomatic_mild_age40to49_EMS_10  (+ Sym_age40to49::EMS_10 Sym_det2_age40to49::EMS_10))
@@ -5712,13 +5341,6 @@
 (func infected_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 infectious_undet_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_det_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_cumul_age40to49_EMS_10 (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10 deaths_age40to49_EMS_10))    
-
-(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-
-(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-
 
 (func asymptomatic_age40to49_EMS_11  (+ As_age40to49::EMS_11 As_det1_age40to49::EMS_11))
 
@@ -5766,13 +5388,6 @@
 (func infected_det_age40to49_EMS_11 (+ infectious_det_age40to49_EMS_11 H1_det3_age40to49::EMS_11 H2_det3_age40to49::EMS_11 H3_det3_age40to49::EMS_11 C2_det3_age40to49::EMS_11 C3_det3_age40to49::EMS_11))
 (func infected_cumul_age40to49_EMS_11 (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11 deaths_age40to49_EMS_11))    
 
-(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-
-(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-
-
 (func asymptomatic_age50to59_EMS_1  (+ As_age50to59::EMS_1 As_det1_age50to59::EMS_1))
 
 (func symptomatic_mild_age50to59_EMS_1  (+ Sym_age50to59::EMS_1 Sym_det2_age50to59::EMS_1))
@@ -5818,13 +5433,6 @@
 (func infected_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 infectious_undet_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_det_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_cumul_age50to59_EMS_1 (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1 deaths_age50to59_EMS_1))    
-
-(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-
-(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-
 
 (func asymptomatic_age50to59_EMS_2  (+ As_age50to59::EMS_2 As_det1_age50to59::EMS_2))
 
@@ -5872,13 +5480,6 @@
 (func infected_det_age50to59_EMS_2 (+ infectious_det_age50to59_EMS_2 H1_det3_age50to59::EMS_2 H2_det3_age50to59::EMS_2 H3_det3_age50to59::EMS_2 C2_det3_age50to59::EMS_2 C3_det3_age50to59::EMS_2))
 (func infected_cumul_age50to59_EMS_2 (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2 deaths_age50to59_EMS_2))    
 
-(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-
-(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-
-
 (func asymptomatic_age50to59_EMS_3  (+ As_age50to59::EMS_3 As_det1_age50to59::EMS_3))
 
 (func symptomatic_mild_age50to59_EMS_3  (+ Sym_age50to59::EMS_3 Sym_det2_age50to59::EMS_3))
@@ -5924,13 +5525,6 @@
 (func infected_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 infectious_undet_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_det_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_cumul_age50to59_EMS_3 (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3 deaths_age50to59_EMS_3))    
-
-(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-
-(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-
 
 (func asymptomatic_age50to59_EMS_4  (+ As_age50to59::EMS_4 As_det1_age50to59::EMS_4))
 
@@ -5978,13 +5572,6 @@
 (func infected_det_age50to59_EMS_4 (+ infectious_det_age50to59_EMS_4 H1_det3_age50to59::EMS_4 H2_det3_age50to59::EMS_4 H3_det3_age50to59::EMS_4 C2_det3_age50to59::EMS_4 C3_det3_age50to59::EMS_4))
 (func infected_cumul_age50to59_EMS_4 (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4 deaths_age50to59_EMS_4))    
 
-(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-
-(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-
-
 (func asymptomatic_age50to59_EMS_5  (+ As_age50to59::EMS_5 As_det1_age50to59::EMS_5))
 
 (func symptomatic_mild_age50to59_EMS_5  (+ Sym_age50to59::EMS_5 Sym_det2_age50to59::EMS_5))
@@ -6030,13 +5617,6 @@
 (func infected_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 infectious_undet_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_det_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_cumul_age50to59_EMS_5 (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5 deaths_age50to59_EMS_5))    
-
-(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-
-(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-
 
 (func asymptomatic_age50to59_EMS_6  (+ As_age50to59::EMS_6 As_det1_age50to59::EMS_6))
 
@@ -6084,13 +5664,6 @@
 (func infected_det_age50to59_EMS_6 (+ infectious_det_age50to59_EMS_6 H1_det3_age50to59::EMS_6 H2_det3_age50to59::EMS_6 H3_det3_age50to59::EMS_6 C2_det3_age50to59::EMS_6 C3_det3_age50to59::EMS_6))
 (func infected_cumul_age50to59_EMS_6 (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6 deaths_age50to59_EMS_6))    
 
-(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-
-(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-
-
 (func asymptomatic_age50to59_EMS_7  (+ As_age50to59::EMS_7 As_det1_age50to59::EMS_7))
 
 (func symptomatic_mild_age50to59_EMS_7  (+ Sym_age50to59::EMS_7 Sym_det2_age50to59::EMS_7))
@@ -6136,13 +5709,6 @@
 (func infected_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 infectious_undet_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_det_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_cumul_age50to59_EMS_7 (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7 deaths_age50to59_EMS_7))    
-
-(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-
-(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-
 
 (func asymptomatic_age50to59_EMS_8  (+ As_age50to59::EMS_8 As_det1_age50to59::EMS_8))
 
@@ -6190,13 +5756,6 @@
 (func infected_det_age50to59_EMS_8 (+ infectious_det_age50to59_EMS_8 H1_det3_age50to59::EMS_8 H2_det3_age50to59::EMS_8 H3_det3_age50to59::EMS_8 C2_det3_age50to59::EMS_8 C3_det3_age50to59::EMS_8))
 (func infected_cumul_age50to59_EMS_8 (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8 deaths_age50to59_EMS_8))    
 
-(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-
-(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-
-
 (func asymptomatic_age50to59_EMS_9  (+ As_age50to59::EMS_9 As_det1_age50to59::EMS_9))
 
 (func symptomatic_mild_age50to59_EMS_9  (+ Sym_age50to59::EMS_9 Sym_det2_age50to59::EMS_9))
@@ -6242,13 +5801,6 @@
 (func infected_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 infectious_undet_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_det_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_cumul_age50to59_EMS_9 (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9 deaths_age50to59_EMS_9))    
-
-(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-
-(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-
 
 (func asymptomatic_age50to59_EMS_10  (+ As_age50to59::EMS_10 As_det1_age50to59::EMS_10))
 
@@ -6296,13 +5848,6 @@
 (func infected_det_age50to59_EMS_10 (+ infectious_det_age50to59_EMS_10 H1_det3_age50to59::EMS_10 H2_det3_age50to59::EMS_10 H3_det3_age50to59::EMS_10 C2_det3_age50to59::EMS_10 C3_det3_age50to59::EMS_10))
 (func infected_cumul_age50to59_EMS_10 (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10 deaths_age50to59_EMS_10))    
 
-(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-
-(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-
-
 (func asymptomatic_age50to59_EMS_11  (+ As_age50to59::EMS_11 As_det1_age50to59::EMS_11))
 
 (func symptomatic_mild_age50to59_EMS_11  (+ Sym_age50to59::EMS_11 Sym_det2_age50to59::EMS_11))
@@ -6348,13 +5893,6 @@
 (func infected_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 infectious_undet_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_det_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_cumul_age50to59_EMS_11 (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11 deaths_age50to59_EMS_11))    
-
-(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-
-(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-
 
 (func asymptomatic_age60to69_EMS_1  (+ As_age60to69::EMS_1 As_det1_age60to69::EMS_1))
 
@@ -6402,13 +5940,6 @@
 (func infected_det_age60to69_EMS_1 (+ infectious_det_age60to69_EMS_1 H1_det3_age60to69::EMS_1 H2_det3_age60to69::EMS_1 H3_det3_age60to69::EMS_1 C2_det3_age60to69::EMS_1 C3_det3_age60to69::EMS_1))
 (func infected_cumul_age60to69_EMS_1 (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1 deaths_age60to69_EMS_1))    
 
-(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-
-(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-
-
 (func asymptomatic_age60to69_EMS_2  (+ As_age60to69::EMS_2 As_det1_age60to69::EMS_2))
 
 (func symptomatic_mild_age60to69_EMS_2  (+ Sym_age60to69::EMS_2 Sym_det2_age60to69::EMS_2))
@@ -6454,13 +5985,6 @@
 (func infected_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 infectious_undet_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_det_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_cumul_age60to69_EMS_2 (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2 deaths_age60to69_EMS_2))    
-
-(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-
-(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-
 
 (func asymptomatic_age60to69_EMS_3  (+ As_age60to69::EMS_3 As_det1_age60to69::EMS_3))
 
@@ -6508,13 +6032,6 @@
 (func infected_det_age60to69_EMS_3 (+ infectious_det_age60to69_EMS_3 H1_det3_age60to69::EMS_3 H2_det3_age60to69::EMS_3 H3_det3_age60to69::EMS_3 C2_det3_age60to69::EMS_3 C3_det3_age60to69::EMS_3))
 (func infected_cumul_age60to69_EMS_3 (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3 deaths_age60to69_EMS_3))    
 
-(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-
-(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-
-
 (func asymptomatic_age60to69_EMS_4  (+ As_age60to69::EMS_4 As_det1_age60to69::EMS_4))
 
 (func symptomatic_mild_age60to69_EMS_4  (+ Sym_age60to69::EMS_4 Sym_det2_age60to69::EMS_4))
@@ -6560,13 +6077,6 @@
 (func infected_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 infectious_undet_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_det_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_cumul_age60to69_EMS_4 (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4 deaths_age60to69_EMS_4))    
-
-(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-
-(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-
 
 (func asymptomatic_age60to69_EMS_5  (+ As_age60to69::EMS_5 As_det1_age60to69::EMS_5))
 
@@ -6614,13 +6124,6 @@
 (func infected_det_age60to69_EMS_5 (+ infectious_det_age60to69_EMS_5 H1_det3_age60to69::EMS_5 H2_det3_age60to69::EMS_5 H3_det3_age60to69::EMS_5 C2_det3_age60to69::EMS_5 C3_det3_age60to69::EMS_5))
 (func infected_cumul_age60to69_EMS_5 (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5 deaths_age60to69_EMS_5))    
 
-(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-
-(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-
-
 (func asymptomatic_age60to69_EMS_6  (+ As_age60to69::EMS_6 As_det1_age60to69::EMS_6))
 
 (func symptomatic_mild_age60to69_EMS_6  (+ Sym_age60to69::EMS_6 Sym_det2_age60to69::EMS_6))
@@ -6666,13 +6169,6 @@
 (func infected_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 infectious_undet_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_det_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_cumul_age60to69_EMS_6 (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6 deaths_age60to69_EMS_6))    
-
-(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-
-(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-
 
 (func asymptomatic_age60to69_EMS_7  (+ As_age60to69::EMS_7 As_det1_age60to69::EMS_7))
 
@@ -6720,13 +6216,6 @@
 (func infected_det_age60to69_EMS_7 (+ infectious_det_age60to69_EMS_7 H1_det3_age60to69::EMS_7 H2_det3_age60to69::EMS_7 H3_det3_age60to69::EMS_7 C2_det3_age60to69::EMS_7 C3_det3_age60to69::EMS_7))
 (func infected_cumul_age60to69_EMS_7 (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7 deaths_age60to69_EMS_7))    
 
-(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-
-(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-
-
 (func asymptomatic_age60to69_EMS_8  (+ As_age60to69::EMS_8 As_det1_age60to69::EMS_8))
 
 (func symptomatic_mild_age60to69_EMS_8  (+ Sym_age60to69::EMS_8 Sym_det2_age60to69::EMS_8))
@@ -6772,13 +6261,6 @@
 (func infected_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 infectious_undet_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_det_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_cumul_age60to69_EMS_8 (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8 deaths_age60to69_EMS_8))    
-
-(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-
-(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-
 
 (func asymptomatic_age60to69_EMS_9  (+ As_age60to69::EMS_9 As_det1_age60to69::EMS_9))
 
@@ -6826,13 +6308,6 @@
 (func infected_det_age60to69_EMS_9 (+ infectious_det_age60to69_EMS_9 H1_det3_age60to69::EMS_9 H2_det3_age60to69::EMS_9 H3_det3_age60to69::EMS_9 C2_det3_age60to69::EMS_9 C3_det3_age60to69::EMS_9))
 (func infected_cumul_age60to69_EMS_9 (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9 deaths_age60to69_EMS_9))    
 
-(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-
-(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-
-
 (func asymptomatic_age60to69_EMS_10  (+ As_age60to69::EMS_10 As_det1_age60to69::EMS_10))
 
 (func symptomatic_mild_age60to69_EMS_10  (+ Sym_age60to69::EMS_10 Sym_det2_age60to69::EMS_10))
@@ -6878,13 +6353,6 @@
 (func infected_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 infectious_undet_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_det_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_cumul_age60to69_EMS_10 (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10 deaths_age60to69_EMS_10))    
-
-(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-
-(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-
 
 (func asymptomatic_age60to69_EMS_11  (+ As_age60to69::EMS_11 As_det1_age60to69::EMS_11))
 
@@ -6932,13 +6400,6 @@
 (func infected_det_age60to69_EMS_11 (+ infectious_det_age60to69_EMS_11 H1_det3_age60to69::EMS_11 H2_det3_age60to69::EMS_11 H3_det3_age60to69::EMS_11 C2_det3_age60to69::EMS_11 C3_det3_age60to69::EMS_11))
 (func infected_cumul_age60to69_EMS_11 (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11 deaths_age60to69_EMS_11))    
 
-(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-
-(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-
-
 (func asymptomatic_age70to100_EMS_1  (+ As_age70to100::EMS_1 As_det1_age70to100::EMS_1))
 
 (func symptomatic_mild_age70to100_EMS_1  (+ Sym_age70to100::EMS_1 Sym_det2_age70to100::EMS_1))
@@ -6984,13 +6445,6 @@
 (func infected_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 infectious_undet_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_det_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_cumul_age70to100_EMS_1 (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1 deaths_age70to100_EMS_1))    
-
-(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-
-(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-
 
 (func asymptomatic_age70to100_EMS_2  (+ As_age70to100::EMS_2 As_det1_age70to100::EMS_2))
 
@@ -7038,13 +6492,6 @@
 (func infected_det_age70to100_EMS_2 (+ infectious_det_age70to100_EMS_2 H1_det3_age70to100::EMS_2 H2_det3_age70to100::EMS_2 H3_det3_age70to100::EMS_2 C2_det3_age70to100::EMS_2 C3_det3_age70to100::EMS_2))
 (func infected_cumul_age70to100_EMS_2 (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2 deaths_age70to100_EMS_2))    
 
-(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-
-(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-
-
 (func asymptomatic_age70to100_EMS_3  (+ As_age70to100::EMS_3 As_det1_age70to100::EMS_3))
 
 (func symptomatic_mild_age70to100_EMS_3  (+ Sym_age70to100::EMS_3 Sym_det2_age70to100::EMS_3))
@@ -7090,13 +6537,6 @@
 (func infected_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 infectious_undet_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_det_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_cumul_age70to100_EMS_3 (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3 deaths_age70to100_EMS_3))    
-
-(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-
-(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-
 
 (func asymptomatic_age70to100_EMS_4  (+ As_age70to100::EMS_4 As_det1_age70to100::EMS_4))
 
@@ -7144,13 +6584,6 @@
 (func infected_det_age70to100_EMS_4 (+ infectious_det_age70to100_EMS_4 H1_det3_age70to100::EMS_4 H2_det3_age70to100::EMS_4 H3_det3_age70to100::EMS_4 C2_det3_age70to100::EMS_4 C3_det3_age70to100::EMS_4))
 (func infected_cumul_age70to100_EMS_4 (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4 deaths_age70to100_EMS_4))    
 
-(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-
-(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-
-
 (func asymptomatic_age70to100_EMS_5  (+ As_age70to100::EMS_5 As_det1_age70to100::EMS_5))
 
 (func symptomatic_mild_age70to100_EMS_5  (+ Sym_age70to100::EMS_5 Sym_det2_age70to100::EMS_5))
@@ -7196,13 +6629,6 @@
 (func infected_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 infectious_undet_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_det_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_cumul_age70to100_EMS_5 (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5 deaths_age70to100_EMS_5))    
-
-(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-
-(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-
 
 (func asymptomatic_age70to100_EMS_6  (+ As_age70to100::EMS_6 As_det1_age70to100::EMS_6))
 
@@ -7250,13 +6676,6 @@
 (func infected_det_age70to100_EMS_6 (+ infectious_det_age70to100_EMS_6 H1_det3_age70to100::EMS_6 H2_det3_age70to100::EMS_6 H3_det3_age70to100::EMS_6 C2_det3_age70to100::EMS_6 C3_det3_age70to100::EMS_6))
 (func infected_cumul_age70to100_EMS_6 (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6 deaths_age70to100_EMS_6))    
 
-(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-
-(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-
-
 (func asymptomatic_age70to100_EMS_7  (+ As_age70to100::EMS_7 As_det1_age70to100::EMS_7))
 
 (func symptomatic_mild_age70to100_EMS_7  (+ Sym_age70to100::EMS_7 Sym_det2_age70to100::EMS_7))
@@ -7302,13 +6721,6 @@
 (func infected_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 infectious_undet_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_det_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_cumul_age70to100_EMS_7 (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7 deaths_age70to100_EMS_7))    
-
-(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-
-(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-
 
 (func asymptomatic_age70to100_EMS_8  (+ As_age70to100::EMS_8 As_det1_age70to100::EMS_8))
 
@@ -7356,13 +6768,6 @@
 (func infected_det_age70to100_EMS_8 (+ infectious_det_age70to100_EMS_8 H1_det3_age70to100::EMS_8 H2_det3_age70to100::EMS_8 H3_det3_age70to100::EMS_8 C2_det3_age70to100::EMS_8 C3_det3_age70to100::EMS_8))
 (func infected_cumul_age70to100_EMS_8 (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8 deaths_age70to100_EMS_8))    
 
-(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-
-(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-
-
 (func asymptomatic_age70to100_EMS_9  (+ As_age70to100::EMS_9 As_det1_age70to100::EMS_9))
 
 (func symptomatic_mild_age70to100_EMS_9  (+ Sym_age70to100::EMS_9 Sym_det2_age70to100::EMS_9))
@@ -7408,13 +6813,6 @@
 (func infected_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 infectious_undet_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_det_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_cumul_age70to100_EMS_9 (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9 deaths_age70to100_EMS_9))    
-
-(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-
-(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-
 
 (func asymptomatic_age70to100_EMS_10  (+ As_age70to100::EMS_10 As_det1_age70to100::EMS_10))
 
@@ -7462,13 +6860,6 @@
 (func infected_det_age70to100_EMS_10 (+ infectious_det_age70to100_EMS_10 H1_det3_age70to100::EMS_10 H2_det3_age70to100::EMS_10 H3_det3_age70to100::EMS_10 C2_det3_age70to100::EMS_10 C3_det3_age70to100::EMS_10))
 (func infected_cumul_age70to100_EMS_10 (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10 deaths_age70to100_EMS_10))    
 
-(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-
-(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-
-
 (func asymptomatic_age70to100_EMS_11  (+ As_age70to100::EMS_11 As_det1_age70to100::EMS_11))
 
 (func symptomatic_mild_age70to100_EMS_11  (+ Sym_age70to100::EMS_11 Sym_det2_age70to100::EMS_11))
@@ -7514,13 +6905,6 @@
 (func infected_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 infectious_undet_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_det_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_cumul_age70to100_EMS_11 (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11 deaths_age70to100_EMS_11))    
-
-(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-
-(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-
 
 (observe susceptible_All (+ S_age0to9::EMS_1 S_age0to9::EMS_2 S_age0to9::EMS_3 S_age0to9::EMS_4 S_age0to9::EMS_5 S_age0to9::EMS_6 S_age0to9::EMS_7 S_age0to9::EMS_8 S_age0to9::EMS_9 S_age0to9::EMS_10 S_age0to9::EMS_11 S_age10to19::EMS_1 S_age10to19::EMS_2 S_age10to19::EMS_3 S_age10to19::EMS_4 S_age10to19::EMS_5 S_age10to19::EMS_6 S_age10to19::EMS_7 S_age10to19::EMS_8 S_age10to19::EMS_9 S_age10to19::EMS_10 S_age10to19::EMS_11 S_age20to29::EMS_1 S_age20to29::EMS_2 S_age20to29::EMS_3 S_age20to29::EMS_4 S_age20to29::EMS_5 S_age20to29::EMS_6 S_age20to29::EMS_7 S_age20to29::EMS_8 S_age20to29::EMS_9 S_age20to29::EMS_10 S_age20to29::EMS_11 S_age30to39::EMS_1 S_age30to39::EMS_2 S_age30to39::EMS_3 S_age30to39::EMS_4 S_age30to39::EMS_5 S_age30to39::EMS_6 S_age30to39::EMS_7 S_age30to39::EMS_8 S_age30to39::EMS_9 S_age30to39::EMS_10 S_age30to39::EMS_11 S_age40to49::EMS_1 S_age40to49::EMS_2 S_age40to49::EMS_3 S_age40to49::EMS_4 S_age40to49::EMS_5 S_age40to49::EMS_6 S_age40to49::EMS_7 S_age40to49::EMS_8 S_age40to49::EMS_9 S_age40to49::EMS_10 S_age40to49::EMS_11 S_age50to59::EMS_1 S_age50to59::EMS_2 S_age50to59::EMS_3 S_age50to59::EMS_4 S_age50to59::EMS_5 S_age50to59::EMS_6 S_age50to59::EMS_7 S_age50to59::EMS_8 S_age50to59::EMS_9 S_age50to59::EMS_10 S_age50to59::EMS_11 S_age60to69::EMS_1 S_age60to69::EMS_2 S_age60to69::EMS_3 S_age60to69::EMS_4 S_age60to69::EMS_5 S_age60to69::EMS_6 S_age60to69::EMS_7 S_age60to69::EMS_8 S_age60to69::EMS_9 S_age60to69::EMS_10 S_age60to69::EMS_11 S_age70to100::EMS_1 S_age70to100::EMS_2 S_age70to100::EMS_3 S_age70to100::EMS_4 S_age70to100::EMS_5 S_age70to100::EMS_6 S_age70to100::EMS_7 S_age70to100::EMS_8 S_age70to100::EMS_9 S_age70to100::EMS_10 S_age70to100::EMS_11))
 (observe infected_All (+ infected_age0to9_EMS_1 infected_age0to9_EMS_2 infected_age0to9_EMS_3 infected_age0to9_EMS_4 infected_age0to9_EMS_5 infected_age0to9_EMS_6 infected_age0to9_EMS_7 infected_age0to9_EMS_8 infected_age0to9_EMS_9 infected_age0to9_EMS_10 infected_age0to9_EMS_11 infected_age10to19_EMS_1 infected_age10to19_EMS_2 infected_age10to19_EMS_3 infected_age10to19_EMS_4 infected_age10to19_EMS_5 infected_age10to19_EMS_6 infected_age10to19_EMS_7 infected_age10to19_EMS_8 infected_age10to19_EMS_9 infected_age10to19_EMS_10 infected_age10to19_EMS_11 infected_age20to29_EMS_1 infected_age20to29_EMS_2 infected_age20to29_EMS_3 infected_age20to29_EMS_4 infected_age20to29_EMS_5 infected_age20to29_EMS_6 infected_age20to29_EMS_7 infected_age20to29_EMS_8 infected_age20to29_EMS_9 infected_age20to29_EMS_10 infected_age20to29_EMS_11 infected_age30to39_EMS_1 infected_age30to39_EMS_2 infected_age30to39_EMS_3 infected_age30to39_EMS_4 infected_age30to39_EMS_5 infected_age30to39_EMS_6 infected_age30to39_EMS_7 infected_age30to39_EMS_8 infected_age30to39_EMS_9 infected_age30to39_EMS_10 infected_age30to39_EMS_11 infected_age40to49_EMS_1 infected_age40to49_EMS_2 infected_age40to49_EMS_3 infected_age40to49_EMS_4 infected_age40to49_EMS_5 infected_age40to49_EMS_6 infected_age40to49_EMS_7 infected_age40to49_EMS_8 infected_age40to49_EMS_9 infected_age40to49_EMS_10 infected_age40to49_EMS_11 infected_age50to59_EMS_1 infected_age50to59_EMS_2 infected_age50to59_EMS_3 infected_age50to59_EMS_4 infected_age50to59_EMS_5 infected_age50to59_EMS_6 infected_age50to59_EMS_7 infected_age50to59_EMS_8 infected_age50to59_EMS_9 infected_age50to59_EMS_10 infected_age50to59_EMS_11 infected_age60to69_EMS_1 infected_age60to69_EMS_2 infected_age60to69_EMS_3 infected_age60to69_EMS_4 infected_age60to69_EMS_5 infected_age60to69_EMS_6 infected_age60to69_EMS_7 infected_age60to69_EMS_8 infected_age60to69_EMS_9 infected_age60to69_EMS_10 infected_age60to69_EMS_11 infected_age70to100_EMS_1 infected_age70to100_EMS_2 infected_age70to100_EMS_3 infected_age70to100_EMS_4 infected_age70to100_EMS_5 infected_age70to100_EMS_6 infected_age70to100_EMS_7 infected_age70to100_EMS_8 infected_age70to100_EMS_9 infected_age70to100_EMS_10 infected_age70to100_EMS_11))

--- a/emodl/extendedmodel_agelocale_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_scen3.emodl
@@ -2904,13 +2904,6 @@
 (func infected_det_age0to9_EMS_1 (+ infectious_det_age0to9_EMS_1 H1_det3_age0to9::EMS_1 H2_det3_age0to9::EMS_1 H3_det3_age0to9::EMS_1 C2_det3_age0to9::EMS_1 C3_det3_age0to9::EMS_1))
 (func infected_cumul_age0to9_EMS_1 (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1 deaths_age0to9_EMS_1))    
 
-(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-
-(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
-
-
 (func asymptomatic_age0to9_EMS_2  (+ As_age0to9::EMS_2 As_det1_age0to9::EMS_2))
 
 (func symptomatic_mild_age0to9_EMS_2  (+ Sym_age0to9::EMS_2 Sym_det2_age0to9::EMS_2))
@@ -2956,13 +2949,6 @@
 (func infected_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 infectious_undet_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_det_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_cumul_age0to9_EMS_2 (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2 deaths_age0to9_EMS_2))    
-
-(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-
-(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
-
 
 (func asymptomatic_age0to9_EMS_3  (+ As_age0to9::EMS_3 As_det1_age0to9::EMS_3))
 
@@ -3010,13 +2996,6 @@
 (func infected_det_age0to9_EMS_3 (+ infectious_det_age0to9_EMS_3 H1_det3_age0to9::EMS_3 H2_det3_age0to9::EMS_3 H3_det3_age0to9::EMS_3 C2_det3_age0to9::EMS_3 C3_det3_age0to9::EMS_3))
 (func infected_cumul_age0to9_EMS_3 (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3 deaths_age0to9_EMS_3))    
 
-(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-
-(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
-
-
 (func asymptomatic_age0to9_EMS_4  (+ As_age0to9::EMS_4 As_det1_age0to9::EMS_4))
 
 (func symptomatic_mild_age0to9_EMS_4  (+ Sym_age0to9::EMS_4 Sym_det2_age0to9::EMS_4))
@@ -3062,13 +3041,6 @@
 (func infected_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 infectious_undet_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_det_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_cumul_age0to9_EMS_4 (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4 deaths_age0to9_EMS_4))    
-
-(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-
-(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
-
 
 (func asymptomatic_age0to9_EMS_5  (+ As_age0to9::EMS_5 As_det1_age0to9::EMS_5))
 
@@ -3116,13 +3088,6 @@
 (func infected_det_age0to9_EMS_5 (+ infectious_det_age0to9_EMS_5 H1_det3_age0to9::EMS_5 H2_det3_age0to9::EMS_5 H3_det3_age0to9::EMS_5 C2_det3_age0to9::EMS_5 C3_det3_age0to9::EMS_5))
 (func infected_cumul_age0to9_EMS_5 (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5 deaths_age0to9_EMS_5))    
 
-(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-
-(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
-
-
 (func asymptomatic_age0to9_EMS_6  (+ As_age0to9::EMS_6 As_det1_age0to9::EMS_6))
 
 (func symptomatic_mild_age0to9_EMS_6  (+ Sym_age0to9::EMS_6 Sym_det2_age0to9::EMS_6))
@@ -3168,13 +3133,6 @@
 (func infected_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 infectious_undet_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_det_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_cumul_age0to9_EMS_6 (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6 deaths_age0to9_EMS_6))    
-
-(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-
-(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
-
 
 (func asymptomatic_age0to9_EMS_7  (+ As_age0to9::EMS_7 As_det1_age0to9::EMS_7))
 
@@ -3222,13 +3180,6 @@
 (func infected_det_age0to9_EMS_7 (+ infectious_det_age0to9_EMS_7 H1_det3_age0to9::EMS_7 H2_det3_age0to9::EMS_7 H3_det3_age0to9::EMS_7 C2_det3_age0to9::EMS_7 C3_det3_age0to9::EMS_7))
 (func infected_cumul_age0to9_EMS_7 (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7 deaths_age0to9_EMS_7))    
 
-(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-
-(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
-
-
 (func asymptomatic_age0to9_EMS_8  (+ As_age0to9::EMS_8 As_det1_age0to9::EMS_8))
 
 (func symptomatic_mild_age0to9_EMS_8  (+ Sym_age0to9::EMS_8 Sym_det2_age0to9::EMS_8))
@@ -3274,13 +3225,6 @@
 (func infected_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 infectious_undet_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_det_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_cumul_age0to9_EMS_8 (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8 deaths_age0to9_EMS_8))    
-
-(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-
-(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
-
 
 (func asymptomatic_age0to9_EMS_9  (+ As_age0to9::EMS_9 As_det1_age0to9::EMS_9))
 
@@ -3328,13 +3272,6 @@
 (func infected_det_age0to9_EMS_9 (+ infectious_det_age0to9_EMS_9 H1_det3_age0to9::EMS_9 H2_det3_age0to9::EMS_9 H3_det3_age0to9::EMS_9 C2_det3_age0to9::EMS_9 C3_det3_age0to9::EMS_9))
 (func infected_cumul_age0to9_EMS_9 (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9 deaths_age0to9_EMS_9))    
 
-(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-
-(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
-
-
 (func asymptomatic_age0to9_EMS_10  (+ As_age0to9::EMS_10 As_det1_age0to9::EMS_10))
 
 (func symptomatic_mild_age0to9_EMS_10  (+ Sym_age0to9::EMS_10 Sym_det2_age0to9::EMS_10))
@@ -3380,13 +3317,6 @@
 (func infected_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 infectious_undet_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_det_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_cumul_age0to9_EMS_10 (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10 deaths_age0to9_EMS_10))    
-
-(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-
-(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
-
 
 (func asymptomatic_age0to9_EMS_11  (+ As_age0to9::EMS_11 As_det1_age0to9::EMS_11))
 
@@ -3434,13 +3364,6 @@
 (func infected_det_age0to9_EMS_11 (+ infectious_det_age0to9_EMS_11 H1_det3_age0to9::EMS_11 H2_det3_age0to9::EMS_11 H3_det3_age0to9::EMS_11 C2_det3_age0to9::EMS_11 C3_det3_age0to9::EMS_11))
 (func infected_cumul_age0to9_EMS_11 (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11 deaths_age0to9_EMS_11))    
 
-(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-
-(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
-
-
 (func asymptomatic_age10to19_EMS_1  (+ As_age10to19::EMS_1 As_det1_age10to19::EMS_1))
 
 (func symptomatic_mild_age10to19_EMS_1  (+ Sym_age10to19::EMS_1 Sym_det2_age10to19::EMS_1))
@@ -3486,13 +3409,6 @@
 (func infected_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 infectious_undet_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_det_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_cumul_age10to19_EMS_1 (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1 deaths_age10to19_EMS_1))    
-
-(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-
-(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
-
 
 (func asymptomatic_age10to19_EMS_2  (+ As_age10to19::EMS_2 As_det1_age10to19::EMS_2))
 
@@ -3540,13 +3456,6 @@
 (func infected_det_age10to19_EMS_2 (+ infectious_det_age10to19_EMS_2 H1_det3_age10to19::EMS_2 H2_det3_age10to19::EMS_2 H3_det3_age10to19::EMS_2 C2_det3_age10to19::EMS_2 C3_det3_age10to19::EMS_2))
 (func infected_cumul_age10to19_EMS_2 (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2 deaths_age10to19_EMS_2))    
 
-(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-
-(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
-
-
 (func asymptomatic_age10to19_EMS_3  (+ As_age10to19::EMS_3 As_det1_age10to19::EMS_3))
 
 (func symptomatic_mild_age10to19_EMS_3  (+ Sym_age10to19::EMS_3 Sym_det2_age10to19::EMS_3))
@@ -3592,13 +3501,6 @@
 (func infected_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 infectious_undet_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_det_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_cumul_age10to19_EMS_3 (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3 deaths_age10to19_EMS_3))    
-
-(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-
-(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
-
 
 (func asymptomatic_age10to19_EMS_4  (+ As_age10to19::EMS_4 As_det1_age10to19::EMS_4))
 
@@ -3646,13 +3548,6 @@
 (func infected_det_age10to19_EMS_4 (+ infectious_det_age10to19_EMS_4 H1_det3_age10to19::EMS_4 H2_det3_age10to19::EMS_4 H3_det3_age10to19::EMS_4 C2_det3_age10to19::EMS_4 C3_det3_age10to19::EMS_4))
 (func infected_cumul_age10to19_EMS_4 (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4 deaths_age10to19_EMS_4))    
 
-(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-
-(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
-
-
 (func asymptomatic_age10to19_EMS_5  (+ As_age10to19::EMS_5 As_det1_age10to19::EMS_5))
 
 (func symptomatic_mild_age10to19_EMS_5  (+ Sym_age10to19::EMS_5 Sym_det2_age10to19::EMS_5))
@@ -3698,13 +3593,6 @@
 (func infected_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 infectious_undet_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_det_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_cumul_age10to19_EMS_5 (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5 deaths_age10to19_EMS_5))    
-
-(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-
-(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
-
 
 (func asymptomatic_age10to19_EMS_6  (+ As_age10to19::EMS_6 As_det1_age10to19::EMS_6))
 
@@ -3752,13 +3640,6 @@
 (func infected_det_age10to19_EMS_6 (+ infectious_det_age10to19_EMS_6 H1_det3_age10to19::EMS_6 H2_det3_age10to19::EMS_6 H3_det3_age10to19::EMS_6 C2_det3_age10to19::EMS_6 C3_det3_age10to19::EMS_6))
 (func infected_cumul_age10to19_EMS_6 (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6 deaths_age10to19_EMS_6))    
 
-(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-
-(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
-
-
 (func asymptomatic_age10to19_EMS_7  (+ As_age10to19::EMS_7 As_det1_age10to19::EMS_7))
 
 (func symptomatic_mild_age10to19_EMS_7  (+ Sym_age10to19::EMS_7 Sym_det2_age10to19::EMS_7))
@@ -3804,13 +3685,6 @@
 (func infected_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 infectious_undet_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_det_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_cumul_age10to19_EMS_7 (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7 deaths_age10to19_EMS_7))    
-
-(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-
-(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
-
 
 (func asymptomatic_age10to19_EMS_8  (+ As_age10to19::EMS_8 As_det1_age10to19::EMS_8))
 
@@ -3858,13 +3732,6 @@
 (func infected_det_age10to19_EMS_8 (+ infectious_det_age10to19_EMS_8 H1_det3_age10to19::EMS_8 H2_det3_age10to19::EMS_8 H3_det3_age10to19::EMS_8 C2_det3_age10to19::EMS_8 C3_det3_age10to19::EMS_8))
 (func infected_cumul_age10to19_EMS_8 (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8 deaths_age10to19_EMS_8))    
 
-(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-
-(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
-
-
 (func asymptomatic_age10to19_EMS_9  (+ As_age10to19::EMS_9 As_det1_age10to19::EMS_9))
 
 (func symptomatic_mild_age10to19_EMS_9  (+ Sym_age10to19::EMS_9 Sym_det2_age10to19::EMS_9))
@@ -3910,13 +3777,6 @@
 (func infected_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 infectious_undet_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_det_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_cumul_age10to19_EMS_9 (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9 deaths_age10to19_EMS_9))    
-
-(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-
-(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
-
 
 (func asymptomatic_age10to19_EMS_10  (+ As_age10to19::EMS_10 As_det1_age10to19::EMS_10))
 
@@ -3964,13 +3824,6 @@
 (func infected_det_age10to19_EMS_10 (+ infectious_det_age10to19_EMS_10 H1_det3_age10to19::EMS_10 H2_det3_age10to19::EMS_10 H3_det3_age10to19::EMS_10 C2_det3_age10to19::EMS_10 C3_det3_age10to19::EMS_10))
 (func infected_cumul_age10to19_EMS_10 (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10 deaths_age10to19_EMS_10))    
 
-(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-
-(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
-
-
 (func asymptomatic_age10to19_EMS_11  (+ As_age10to19::EMS_11 As_det1_age10to19::EMS_11))
 
 (func symptomatic_mild_age10to19_EMS_11  (+ Sym_age10to19::EMS_11 Sym_det2_age10to19::EMS_11))
@@ -4016,13 +3869,6 @@
 (func infected_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 infectious_undet_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_det_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_cumul_age10to19_EMS_11 (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11 deaths_age10to19_EMS_11))    
-
-(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-
-(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
-
 
 (func asymptomatic_age20to29_EMS_1  (+ As_age20to29::EMS_1 As_det1_age20to29::EMS_1))
 
@@ -4070,13 +3916,6 @@
 (func infected_det_age20to29_EMS_1 (+ infectious_det_age20to29_EMS_1 H1_det3_age20to29::EMS_1 H2_det3_age20to29::EMS_1 H3_det3_age20to29::EMS_1 C2_det3_age20to29::EMS_1 C3_det3_age20to29::EMS_1))
 (func infected_cumul_age20to29_EMS_1 (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1 deaths_age20to29_EMS_1))    
 
-(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-
-(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
-
-
 (func asymptomatic_age20to29_EMS_2  (+ As_age20to29::EMS_2 As_det1_age20to29::EMS_2))
 
 (func symptomatic_mild_age20to29_EMS_2  (+ Sym_age20to29::EMS_2 Sym_det2_age20to29::EMS_2))
@@ -4122,13 +3961,6 @@
 (func infected_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 infectious_undet_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_det_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_cumul_age20to29_EMS_2 (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2 deaths_age20to29_EMS_2))    
-
-(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-
-(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
-
 
 (func asymptomatic_age20to29_EMS_3  (+ As_age20to29::EMS_3 As_det1_age20to29::EMS_3))
 
@@ -4176,13 +4008,6 @@
 (func infected_det_age20to29_EMS_3 (+ infectious_det_age20to29_EMS_3 H1_det3_age20to29::EMS_3 H2_det3_age20to29::EMS_3 H3_det3_age20to29::EMS_3 C2_det3_age20to29::EMS_3 C3_det3_age20to29::EMS_3))
 (func infected_cumul_age20to29_EMS_3 (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3 deaths_age20to29_EMS_3))    
 
-(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-
-(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
-
-
 (func asymptomatic_age20to29_EMS_4  (+ As_age20to29::EMS_4 As_det1_age20to29::EMS_4))
 
 (func symptomatic_mild_age20to29_EMS_4  (+ Sym_age20to29::EMS_4 Sym_det2_age20to29::EMS_4))
@@ -4228,13 +4053,6 @@
 (func infected_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 infectious_undet_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_det_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_cumul_age20to29_EMS_4 (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4 deaths_age20to29_EMS_4))    
-
-(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-
-(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
-
 
 (func asymptomatic_age20to29_EMS_5  (+ As_age20to29::EMS_5 As_det1_age20to29::EMS_5))
 
@@ -4282,13 +4100,6 @@
 (func infected_det_age20to29_EMS_5 (+ infectious_det_age20to29_EMS_5 H1_det3_age20to29::EMS_5 H2_det3_age20to29::EMS_5 H3_det3_age20to29::EMS_5 C2_det3_age20to29::EMS_5 C3_det3_age20to29::EMS_5))
 (func infected_cumul_age20to29_EMS_5 (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5 deaths_age20to29_EMS_5))    
 
-(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-
-(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
-
-
 (func asymptomatic_age20to29_EMS_6  (+ As_age20to29::EMS_6 As_det1_age20to29::EMS_6))
 
 (func symptomatic_mild_age20to29_EMS_6  (+ Sym_age20to29::EMS_6 Sym_det2_age20to29::EMS_6))
@@ -4334,13 +4145,6 @@
 (func infected_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 infectious_undet_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_det_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_cumul_age20to29_EMS_6 (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6 deaths_age20to29_EMS_6))    
-
-(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-
-(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
-
 
 (func asymptomatic_age20to29_EMS_7  (+ As_age20to29::EMS_7 As_det1_age20to29::EMS_7))
 
@@ -4388,13 +4192,6 @@
 (func infected_det_age20to29_EMS_7 (+ infectious_det_age20to29_EMS_7 H1_det3_age20to29::EMS_7 H2_det3_age20to29::EMS_7 H3_det3_age20to29::EMS_7 C2_det3_age20to29::EMS_7 C3_det3_age20to29::EMS_7))
 (func infected_cumul_age20to29_EMS_7 (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7 deaths_age20to29_EMS_7))    
 
-(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-
-(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
-
-
 (func asymptomatic_age20to29_EMS_8  (+ As_age20to29::EMS_8 As_det1_age20to29::EMS_8))
 
 (func symptomatic_mild_age20to29_EMS_8  (+ Sym_age20to29::EMS_8 Sym_det2_age20to29::EMS_8))
@@ -4440,13 +4237,6 @@
 (func infected_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 infectious_undet_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_det_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_cumul_age20to29_EMS_8 (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8 deaths_age20to29_EMS_8))    
-
-(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-
-(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
-
 
 (func asymptomatic_age20to29_EMS_9  (+ As_age20to29::EMS_9 As_det1_age20to29::EMS_9))
 
@@ -4494,13 +4284,6 @@
 (func infected_det_age20to29_EMS_9 (+ infectious_det_age20to29_EMS_9 H1_det3_age20to29::EMS_9 H2_det3_age20to29::EMS_9 H3_det3_age20to29::EMS_9 C2_det3_age20to29::EMS_9 C3_det3_age20to29::EMS_9))
 (func infected_cumul_age20to29_EMS_9 (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9 deaths_age20to29_EMS_9))    
 
-(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-
-(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
-
-
 (func asymptomatic_age20to29_EMS_10  (+ As_age20to29::EMS_10 As_det1_age20to29::EMS_10))
 
 (func symptomatic_mild_age20to29_EMS_10  (+ Sym_age20to29::EMS_10 Sym_det2_age20to29::EMS_10))
@@ -4546,13 +4329,6 @@
 (func infected_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 infectious_undet_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_det_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_cumul_age20to29_EMS_10 (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10 deaths_age20to29_EMS_10))    
-
-(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-
-(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
-
 
 (func asymptomatic_age20to29_EMS_11  (+ As_age20to29::EMS_11 As_det1_age20to29::EMS_11))
 
@@ -4600,13 +4376,6 @@
 (func infected_det_age20to29_EMS_11 (+ infectious_det_age20to29_EMS_11 H1_det3_age20to29::EMS_11 H2_det3_age20to29::EMS_11 H3_det3_age20to29::EMS_11 C2_det3_age20to29::EMS_11 C3_det3_age20to29::EMS_11))
 (func infected_cumul_age20to29_EMS_11 (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11 deaths_age20to29_EMS_11))    
 
-(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-
-(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
-
-
 (func asymptomatic_age30to39_EMS_1  (+ As_age30to39::EMS_1 As_det1_age30to39::EMS_1))
 
 (func symptomatic_mild_age30to39_EMS_1  (+ Sym_age30to39::EMS_1 Sym_det2_age30to39::EMS_1))
@@ -4652,13 +4421,6 @@
 (func infected_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 infectious_undet_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_det_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_cumul_age30to39_EMS_1 (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1 deaths_age30to39_EMS_1))    
-
-(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-
-(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
-
 
 (func asymptomatic_age30to39_EMS_2  (+ As_age30to39::EMS_2 As_det1_age30to39::EMS_2))
 
@@ -4706,13 +4468,6 @@
 (func infected_det_age30to39_EMS_2 (+ infectious_det_age30to39_EMS_2 H1_det3_age30to39::EMS_2 H2_det3_age30to39::EMS_2 H3_det3_age30to39::EMS_2 C2_det3_age30to39::EMS_2 C3_det3_age30to39::EMS_2))
 (func infected_cumul_age30to39_EMS_2 (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2 deaths_age30to39_EMS_2))    
 
-(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-
-(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
-
-
 (func asymptomatic_age30to39_EMS_3  (+ As_age30to39::EMS_3 As_det1_age30to39::EMS_3))
 
 (func symptomatic_mild_age30to39_EMS_3  (+ Sym_age30to39::EMS_3 Sym_det2_age30to39::EMS_3))
@@ -4758,13 +4513,6 @@
 (func infected_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 infectious_undet_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_det_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_cumul_age30to39_EMS_3 (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3 deaths_age30to39_EMS_3))    
-
-(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-
-(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
-
 
 (func asymptomatic_age30to39_EMS_4  (+ As_age30to39::EMS_4 As_det1_age30to39::EMS_4))
 
@@ -4812,13 +4560,6 @@
 (func infected_det_age30to39_EMS_4 (+ infectious_det_age30to39_EMS_4 H1_det3_age30to39::EMS_4 H2_det3_age30to39::EMS_4 H3_det3_age30to39::EMS_4 C2_det3_age30to39::EMS_4 C3_det3_age30to39::EMS_4))
 (func infected_cumul_age30to39_EMS_4 (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4 deaths_age30to39_EMS_4))    
 
-(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-
-(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
-
-
 (func asymptomatic_age30to39_EMS_5  (+ As_age30to39::EMS_5 As_det1_age30to39::EMS_5))
 
 (func symptomatic_mild_age30to39_EMS_5  (+ Sym_age30to39::EMS_5 Sym_det2_age30to39::EMS_5))
@@ -4864,13 +4605,6 @@
 (func infected_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 infectious_undet_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_det_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_cumul_age30to39_EMS_5 (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5 deaths_age30to39_EMS_5))    
-
-(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-
-(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
-
 
 (func asymptomatic_age30to39_EMS_6  (+ As_age30to39::EMS_6 As_det1_age30to39::EMS_6))
 
@@ -4918,13 +4652,6 @@
 (func infected_det_age30to39_EMS_6 (+ infectious_det_age30to39_EMS_6 H1_det3_age30to39::EMS_6 H2_det3_age30to39::EMS_6 H3_det3_age30to39::EMS_6 C2_det3_age30to39::EMS_6 C3_det3_age30to39::EMS_6))
 (func infected_cumul_age30to39_EMS_6 (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6 deaths_age30to39_EMS_6))    
 
-(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-
-(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
-
-
 (func asymptomatic_age30to39_EMS_7  (+ As_age30to39::EMS_7 As_det1_age30to39::EMS_7))
 
 (func symptomatic_mild_age30to39_EMS_7  (+ Sym_age30to39::EMS_7 Sym_det2_age30to39::EMS_7))
@@ -4970,13 +4697,6 @@
 (func infected_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 infectious_undet_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_det_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_cumul_age30to39_EMS_7 (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7 deaths_age30to39_EMS_7))    
-
-(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-
-(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
-
 
 (func asymptomatic_age30to39_EMS_8  (+ As_age30to39::EMS_8 As_det1_age30to39::EMS_8))
 
@@ -5024,13 +4744,6 @@
 (func infected_det_age30to39_EMS_8 (+ infectious_det_age30to39_EMS_8 H1_det3_age30to39::EMS_8 H2_det3_age30to39::EMS_8 H3_det3_age30to39::EMS_8 C2_det3_age30to39::EMS_8 C3_det3_age30to39::EMS_8))
 (func infected_cumul_age30to39_EMS_8 (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8 deaths_age30to39_EMS_8))    
 
-(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-
-(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
-
-
 (func asymptomatic_age30to39_EMS_9  (+ As_age30to39::EMS_9 As_det1_age30to39::EMS_9))
 
 (func symptomatic_mild_age30to39_EMS_9  (+ Sym_age30to39::EMS_9 Sym_det2_age30to39::EMS_9))
@@ -5076,13 +4789,6 @@
 (func infected_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 infectious_undet_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_det_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_cumul_age30to39_EMS_9 (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9 deaths_age30to39_EMS_9))    
-
-(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-
-(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
-
 
 (func asymptomatic_age30to39_EMS_10  (+ As_age30to39::EMS_10 As_det1_age30to39::EMS_10))
 
@@ -5130,13 +4836,6 @@
 (func infected_det_age30to39_EMS_10 (+ infectious_det_age30to39_EMS_10 H1_det3_age30to39::EMS_10 H2_det3_age30to39::EMS_10 H3_det3_age30to39::EMS_10 C2_det3_age30to39::EMS_10 C3_det3_age30to39::EMS_10))
 (func infected_cumul_age30to39_EMS_10 (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10 deaths_age30to39_EMS_10))    
 
-(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-
-(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
-
-
 (func asymptomatic_age30to39_EMS_11  (+ As_age30to39::EMS_11 As_det1_age30to39::EMS_11))
 
 (func symptomatic_mild_age30to39_EMS_11  (+ Sym_age30to39::EMS_11 Sym_det2_age30to39::EMS_11))
@@ -5182,13 +4881,6 @@
 (func infected_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 infectious_undet_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_det_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_cumul_age30to39_EMS_11 (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11 deaths_age30to39_EMS_11))    
-
-(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-
-(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
-
 
 (func asymptomatic_age40to49_EMS_1  (+ As_age40to49::EMS_1 As_det1_age40to49::EMS_1))
 
@@ -5236,13 +4928,6 @@
 (func infected_det_age40to49_EMS_1 (+ infectious_det_age40to49_EMS_1 H1_det3_age40to49::EMS_1 H2_det3_age40to49::EMS_1 H3_det3_age40to49::EMS_1 C2_det3_age40to49::EMS_1 C3_det3_age40to49::EMS_1))
 (func infected_cumul_age40to49_EMS_1 (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1 deaths_age40to49_EMS_1))    
 
-(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-
-(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
-
-
 (func asymptomatic_age40to49_EMS_2  (+ As_age40to49::EMS_2 As_det1_age40to49::EMS_2))
 
 (func symptomatic_mild_age40to49_EMS_2  (+ Sym_age40to49::EMS_2 Sym_det2_age40to49::EMS_2))
@@ -5288,13 +4973,6 @@
 (func infected_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 infectious_undet_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_det_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_cumul_age40to49_EMS_2 (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2 deaths_age40to49_EMS_2))    
-
-(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-
-(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
-
 
 (func asymptomatic_age40to49_EMS_3  (+ As_age40to49::EMS_3 As_det1_age40to49::EMS_3))
 
@@ -5342,13 +5020,6 @@
 (func infected_det_age40to49_EMS_3 (+ infectious_det_age40to49_EMS_3 H1_det3_age40to49::EMS_3 H2_det3_age40to49::EMS_3 H3_det3_age40to49::EMS_3 C2_det3_age40to49::EMS_3 C3_det3_age40to49::EMS_3))
 (func infected_cumul_age40to49_EMS_3 (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3 deaths_age40to49_EMS_3))    
 
-(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-
-(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
-
-
 (func asymptomatic_age40to49_EMS_4  (+ As_age40to49::EMS_4 As_det1_age40to49::EMS_4))
 
 (func symptomatic_mild_age40to49_EMS_4  (+ Sym_age40to49::EMS_4 Sym_det2_age40to49::EMS_4))
@@ -5394,13 +5065,6 @@
 (func infected_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 infectious_undet_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_det_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_cumul_age40to49_EMS_4 (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4 deaths_age40to49_EMS_4))    
-
-(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-
-(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
-
 
 (func asymptomatic_age40to49_EMS_5  (+ As_age40to49::EMS_5 As_det1_age40to49::EMS_5))
 
@@ -5448,13 +5112,6 @@
 (func infected_det_age40to49_EMS_5 (+ infectious_det_age40to49_EMS_5 H1_det3_age40to49::EMS_5 H2_det3_age40to49::EMS_5 H3_det3_age40to49::EMS_5 C2_det3_age40to49::EMS_5 C3_det3_age40to49::EMS_5))
 (func infected_cumul_age40to49_EMS_5 (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5 deaths_age40to49_EMS_5))    
 
-(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-
-(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
-
-
 (func asymptomatic_age40to49_EMS_6  (+ As_age40to49::EMS_6 As_det1_age40to49::EMS_6))
 
 (func symptomatic_mild_age40to49_EMS_6  (+ Sym_age40to49::EMS_6 Sym_det2_age40to49::EMS_6))
@@ -5500,13 +5157,6 @@
 (func infected_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 infectious_undet_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_det_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_cumul_age40to49_EMS_6 (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6 deaths_age40to49_EMS_6))    
-
-(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-
-(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
-
 
 (func asymptomatic_age40to49_EMS_7  (+ As_age40to49::EMS_7 As_det1_age40to49::EMS_7))
 
@@ -5554,13 +5204,6 @@
 (func infected_det_age40to49_EMS_7 (+ infectious_det_age40to49_EMS_7 H1_det3_age40to49::EMS_7 H2_det3_age40to49::EMS_7 H3_det3_age40to49::EMS_7 C2_det3_age40to49::EMS_7 C3_det3_age40to49::EMS_7))
 (func infected_cumul_age40to49_EMS_7 (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7 deaths_age40to49_EMS_7))    
 
-(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-
-(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
-
-
 (func asymptomatic_age40to49_EMS_8  (+ As_age40to49::EMS_8 As_det1_age40to49::EMS_8))
 
 (func symptomatic_mild_age40to49_EMS_8  (+ Sym_age40to49::EMS_8 Sym_det2_age40to49::EMS_8))
@@ -5606,13 +5249,6 @@
 (func infected_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 infectious_undet_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_det_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_cumul_age40to49_EMS_8 (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8 deaths_age40to49_EMS_8))    
-
-(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-
-(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
-
 
 (func asymptomatic_age40to49_EMS_9  (+ As_age40to49::EMS_9 As_det1_age40to49::EMS_9))
 
@@ -5660,13 +5296,6 @@
 (func infected_det_age40to49_EMS_9 (+ infectious_det_age40to49_EMS_9 H1_det3_age40to49::EMS_9 H2_det3_age40to49::EMS_9 H3_det3_age40to49::EMS_9 C2_det3_age40to49::EMS_9 C3_det3_age40to49::EMS_9))
 (func infected_cumul_age40to49_EMS_9 (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9 deaths_age40to49_EMS_9))    
 
-(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-
-(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
-
-
 (func asymptomatic_age40to49_EMS_10  (+ As_age40to49::EMS_10 As_det1_age40to49::EMS_10))
 
 (func symptomatic_mild_age40to49_EMS_10  (+ Sym_age40to49::EMS_10 Sym_det2_age40to49::EMS_10))
@@ -5712,13 +5341,6 @@
 (func infected_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 infectious_undet_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_det_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_cumul_age40to49_EMS_10 (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10 deaths_age40to49_EMS_10))    
-
-(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-
-(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
-
 
 (func asymptomatic_age40to49_EMS_11  (+ As_age40to49::EMS_11 As_det1_age40to49::EMS_11))
 
@@ -5766,13 +5388,6 @@
 (func infected_det_age40to49_EMS_11 (+ infectious_det_age40to49_EMS_11 H1_det3_age40to49::EMS_11 H2_det3_age40to49::EMS_11 H3_det3_age40to49::EMS_11 C2_det3_age40to49::EMS_11 C3_det3_age40to49::EMS_11))
 (func infected_cumul_age40to49_EMS_11 (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11 deaths_age40to49_EMS_11))    
 
-(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-
-(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
-
-
 (func asymptomatic_age50to59_EMS_1  (+ As_age50to59::EMS_1 As_det1_age50to59::EMS_1))
 
 (func symptomatic_mild_age50to59_EMS_1  (+ Sym_age50to59::EMS_1 Sym_det2_age50to59::EMS_1))
@@ -5818,13 +5433,6 @@
 (func infected_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 infectious_undet_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_det_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_cumul_age50to59_EMS_1 (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1 deaths_age50to59_EMS_1))    
-
-(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-
-(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
-
 
 (func asymptomatic_age50to59_EMS_2  (+ As_age50to59::EMS_2 As_det1_age50to59::EMS_2))
 
@@ -5872,13 +5480,6 @@
 (func infected_det_age50to59_EMS_2 (+ infectious_det_age50to59_EMS_2 H1_det3_age50to59::EMS_2 H2_det3_age50to59::EMS_2 H3_det3_age50to59::EMS_2 C2_det3_age50to59::EMS_2 C3_det3_age50to59::EMS_2))
 (func infected_cumul_age50to59_EMS_2 (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2 deaths_age50to59_EMS_2))    
 
-(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-
-(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
-
-
 (func asymptomatic_age50to59_EMS_3  (+ As_age50to59::EMS_3 As_det1_age50to59::EMS_3))
 
 (func symptomatic_mild_age50to59_EMS_3  (+ Sym_age50to59::EMS_3 Sym_det2_age50to59::EMS_3))
@@ -5924,13 +5525,6 @@
 (func infected_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 infectious_undet_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_det_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_cumul_age50to59_EMS_3 (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3 deaths_age50to59_EMS_3))    
-
-(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-
-(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
-
 
 (func asymptomatic_age50to59_EMS_4  (+ As_age50to59::EMS_4 As_det1_age50to59::EMS_4))
 
@@ -5978,13 +5572,6 @@
 (func infected_det_age50to59_EMS_4 (+ infectious_det_age50to59_EMS_4 H1_det3_age50to59::EMS_4 H2_det3_age50to59::EMS_4 H3_det3_age50to59::EMS_4 C2_det3_age50to59::EMS_4 C3_det3_age50to59::EMS_4))
 (func infected_cumul_age50to59_EMS_4 (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4 deaths_age50to59_EMS_4))    
 
-(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-
-(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
-
-
 (func asymptomatic_age50to59_EMS_5  (+ As_age50to59::EMS_5 As_det1_age50to59::EMS_5))
 
 (func symptomatic_mild_age50to59_EMS_5  (+ Sym_age50to59::EMS_5 Sym_det2_age50to59::EMS_5))
@@ -6030,13 +5617,6 @@
 (func infected_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 infectious_undet_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_det_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_cumul_age50to59_EMS_5 (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5 deaths_age50to59_EMS_5))    
-
-(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-
-(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
-
 
 (func asymptomatic_age50to59_EMS_6  (+ As_age50to59::EMS_6 As_det1_age50to59::EMS_6))
 
@@ -6084,13 +5664,6 @@
 (func infected_det_age50to59_EMS_6 (+ infectious_det_age50to59_EMS_6 H1_det3_age50to59::EMS_6 H2_det3_age50to59::EMS_6 H3_det3_age50to59::EMS_6 C2_det3_age50to59::EMS_6 C3_det3_age50to59::EMS_6))
 (func infected_cumul_age50to59_EMS_6 (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6 deaths_age50to59_EMS_6))    
 
-(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-
-(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
-
-
 (func asymptomatic_age50to59_EMS_7  (+ As_age50to59::EMS_7 As_det1_age50to59::EMS_7))
 
 (func symptomatic_mild_age50to59_EMS_7  (+ Sym_age50to59::EMS_7 Sym_det2_age50to59::EMS_7))
@@ -6136,13 +5709,6 @@
 (func infected_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 infectious_undet_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_det_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_cumul_age50to59_EMS_7 (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7 deaths_age50to59_EMS_7))    
-
-(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-
-(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
-
 
 (func asymptomatic_age50to59_EMS_8  (+ As_age50to59::EMS_8 As_det1_age50to59::EMS_8))
 
@@ -6190,13 +5756,6 @@
 (func infected_det_age50to59_EMS_8 (+ infectious_det_age50to59_EMS_8 H1_det3_age50to59::EMS_8 H2_det3_age50to59::EMS_8 H3_det3_age50to59::EMS_8 C2_det3_age50to59::EMS_8 C3_det3_age50to59::EMS_8))
 (func infected_cumul_age50to59_EMS_8 (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8 deaths_age50to59_EMS_8))    
 
-(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-
-(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
-
-
 (func asymptomatic_age50to59_EMS_9  (+ As_age50to59::EMS_9 As_det1_age50to59::EMS_9))
 
 (func symptomatic_mild_age50to59_EMS_9  (+ Sym_age50to59::EMS_9 Sym_det2_age50to59::EMS_9))
@@ -6242,13 +5801,6 @@
 (func infected_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 infectious_undet_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_det_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_cumul_age50to59_EMS_9 (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9 deaths_age50to59_EMS_9))    
-
-(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-
-(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
-
 
 (func asymptomatic_age50to59_EMS_10  (+ As_age50to59::EMS_10 As_det1_age50to59::EMS_10))
 
@@ -6296,13 +5848,6 @@
 (func infected_det_age50to59_EMS_10 (+ infectious_det_age50to59_EMS_10 H1_det3_age50to59::EMS_10 H2_det3_age50to59::EMS_10 H3_det3_age50to59::EMS_10 C2_det3_age50to59::EMS_10 C3_det3_age50to59::EMS_10))
 (func infected_cumul_age50to59_EMS_10 (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10 deaths_age50to59_EMS_10))    
 
-(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-
-(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
-
-
 (func asymptomatic_age50to59_EMS_11  (+ As_age50to59::EMS_11 As_det1_age50to59::EMS_11))
 
 (func symptomatic_mild_age50to59_EMS_11  (+ Sym_age50to59::EMS_11 Sym_det2_age50to59::EMS_11))
@@ -6348,13 +5893,6 @@
 (func infected_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 infectious_undet_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_det_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_cumul_age50to59_EMS_11 (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11 deaths_age50to59_EMS_11))    
-
-(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-
-(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
-
 
 (func asymptomatic_age60to69_EMS_1  (+ As_age60to69::EMS_1 As_det1_age60to69::EMS_1))
 
@@ -6402,13 +5940,6 @@
 (func infected_det_age60to69_EMS_1 (+ infectious_det_age60to69_EMS_1 H1_det3_age60to69::EMS_1 H2_det3_age60to69::EMS_1 H3_det3_age60to69::EMS_1 C2_det3_age60to69::EMS_1 C3_det3_age60to69::EMS_1))
 (func infected_cumul_age60to69_EMS_1 (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1 deaths_age60to69_EMS_1))    
 
-(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-
-(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
-
-
 (func asymptomatic_age60to69_EMS_2  (+ As_age60to69::EMS_2 As_det1_age60to69::EMS_2))
 
 (func symptomatic_mild_age60to69_EMS_2  (+ Sym_age60to69::EMS_2 Sym_det2_age60to69::EMS_2))
@@ -6454,13 +5985,6 @@
 (func infected_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 infectious_undet_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_det_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_cumul_age60to69_EMS_2 (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2 deaths_age60to69_EMS_2))    
-
-(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-
-(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
-
 
 (func asymptomatic_age60to69_EMS_3  (+ As_age60to69::EMS_3 As_det1_age60to69::EMS_3))
 
@@ -6508,13 +6032,6 @@
 (func infected_det_age60to69_EMS_3 (+ infectious_det_age60to69_EMS_3 H1_det3_age60to69::EMS_3 H2_det3_age60to69::EMS_3 H3_det3_age60to69::EMS_3 C2_det3_age60to69::EMS_3 C3_det3_age60to69::EMS_3))
 (func infected_cumul_age60to69_EMS_3 (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3 deaths_age60to69_EMS_3))    
 
-(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-
-(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
-
-
 (func asymptomatic_age60to69_EMS_4  (+ As_age60to69::EMS_4 As_det1_age60to69::EMS_4))
 
 (func symptomatic_mild_age60to69_EMS_4  (+ Sym_age60to69::EMS_4 Sym_det2_age60to69::EMS_4))
@@ -6560,13 +6077,6 @@
 (func infected_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 infectious_undet_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_det_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_cumul_age60to69_EMS_4 (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4 deaths_age60to69_EMS_4))    
-
-(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-
-(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
-
 
 (func asymptomatic_age60to69_EMS_5  (+ As_age60to69::EMS_5 As_det1_age60to69::EMS_5))
 
@@ -6614,13 +6124,6 @@
 (func infected_det_age60to69_EMS_5 (+ infectious_det_age60to69_EMS_5 H1_det3_age60to69::EMS_5 H2_det3_age60to69::EMS_5 H3_det3_age60to69::EMS_5 C2_det3_age60to69::EMS_5 C3_det3_age60to69::EMS_5))
 (func infected_cumul_age60to69_EMS_5 (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5 deaths_age60to69_EMS_5))    
 
-(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-
-(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
-
-
 (func asymptomatic_age60to69_EMS_6  (+ As_age60to69::EMS_6 As_det1_age60to69::EMS_6))
 
 (func symptomatic_mild_age60to69_EMS_6  (+ Sym_age60to69::EMS_6 Sym_det2_age60to69::EMS_6))
@@ -6666,13 +6169,6 @@
 (func infected_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 infectious_undet_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_det_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_cumul_age60to69_EMS_6 (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6 deaths_age60to69_EMS_6))    
-
-(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-
-(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
-
 
 (func asymptomatic_age60to69_EMS_7  (+ As_age60to69::EMS_7 As_det1_age60to69::EMS_7))
 
@@ -6720,13 +6216,6 @@
 (func infected_det_age60to69_EMS_7 (+ infectious_det_age60to69_EMS_7 H1_det3_age60to69::EMS_7 H2_det3_age60to69::EMS_7 H3_det3_age60to69::EMS_7 C2_det3_age60to69::EMS_7 C3_det3_age60to69::EMS_7))
 (func infected_cumul_age60to69_EMS_7 (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7 deaths_age60to69_EMS_7))    
 
-(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-
-(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
-
-
 (func asymptomatic_age60to69_EMS_8  (+ As_age60to69::EMS_8 As_det1_age60to69::EMS_8))
 
 (func symptomatic_mild_age60to69_EMS_8  (+ Sym_age60to69::EMS_8 Sym_det2_age60to69::EMS_8))
@@ -6772,13 +6261,6 @@
 (func infected_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 infectious_undet_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_det_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_cumul_age60to69_EMS_8 (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8 deaths_age60to69_EMS_8))    
-
-(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-
-(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
-
 
 (func asymptomatic_age60to69_EMS_9  (+ As_age60to69::EMS_9 As_det1_age60to69::EMS_9))
 
@@ -6826,13 +6308,6 @@
 (func infected_det_age60to69_EMS_9 (+ infectious_det_age60to69_EMS_9 H1_det3_age60to69::EMS_9 H2_det3_age60to69::EMS_9 H3_det3_age60to69::EMS_9 C2_det3_age60to69::EMS_9 C3_det3_age60to69::EMS_9))
 (func infected_cumul_age60to69_EMS_9 (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9 deaths_age60to69_EMS_9))    
 
-(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-
-(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
-
-
 (func asymptomatic_age60to69_EMS_10  (+ As_age60to69::EMS_10 As_det1_age60to69::EMS_10))
 
 (func symptomatic_mild_age60to69_EMS_10  (+ Sym_age60to69::EMS_10 Sym_det2_age60to69::EMS_10))
@@ -6878,13 +6353,6 @@
 (func infected_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 infectious_undet_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_det_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_cumul_age60to69_EMS_10 (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10 deaths_age60to69_EMS_10))    
-
-(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-
-(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
-
 
 (func asymptomatic_age60to69_EMS_11  (+ As_age60to69::EMS_11 As_det1_age60to69::EMS_11))
 
@@ -6932,13 +6400,6 @@
 (func infected_det_age60to69_EMS_11 (+ infectious_det_age60to69_EMS_11 H1_det3_age60to69::EMS_11 H2_det3_age60to69::EMS_11 H3_det3_age60to69::EMS_11 C2_det3_age60to69::EMS_11 C3_det3_age60to69::EMS_11))
 (func infected_cumul_age60to69_EMS_11 (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11 deaths_age60to69_EMS_11))    
 
-(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-
-(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
-
-
 (func asymptomatic_age70to100_EMS_1  (+ As_age70to100::EMS_1 As_det1_age70to100::EMS_1))
 
 (func symptomatic_mild_age70to100_EMS_1  (+ Sym_age70to100::EMS_1 Sym_det2_age70to100::EMS_1))
@@ -6984,13 +6445,6 @@
 (func infected_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 infectious_undet_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_det_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_cumul_age70to100_EMS_1 (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1 deaths_age70to100_EMS_1))    
-
-(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-
-(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
-
 
 (func asymptomatic_age70to100_EMS_2  (+ As_age70to100::EMS_2 As_det1_age70to100::EMS_2))
 
@@ -7038,13 +6492,6 @@
 (func infected_det_age70to100_EMS_2 (+ infectious_det_age70to100_EMS_2 H1_det3_age70to100::EMS_2 H2_det3_age70to100::EMS_2 H3_det3_age70to100::EMS_2 C2_det3_age70to100::EMS_2 C3_det3_age70to100::EMS_2))
 (func infected_cumul_age70to100_EMS_2 (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2 deaths_age70to100_EMS_2))    
 
-(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-
-(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
-
-
 (func asymptomatic_age70to100_EMS_3  (+ As_age70to100::EMS_3 As_det1_age70to100::EMS_3))
 
 (func symptomatic_mild_age70to100_EMS_3  (+ Sym_age70to100::EMS_3 Sym_det2_age70to100::EMS_3))
@@ -7090,13 +6537,6 @@
 (func infected_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 infectious_undet_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_det_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_cumul_age70to100_EMS_3 (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3 deaths_age70to100_EMS_3))    
-
-(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-
-(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
-
 
 (func asymptomatic_age70to100_EMS_4  (+ As_age70to100::EMS_4 As_det1_age70to100::EMS_4))
 
@@ -7144,13 +6584,6 @@
 (func infected_det_age70to100_EMS_4 (+ infectious_det_age70to100_EMS_4 H1_det3_age70to100::EMS_4 H2_det3_age70to100::EMS_4 H3_det3_age70to100::EMS_4 C2_det3_age70to100::EMS_4 C3_det3_age70to100::EMS_4))
 (func infected_cumul_age70to100_EMS_4 (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4 deaths_age70to100_EMS_4))    
 
-(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-
-(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
-
-
 (func asymptomatic_age70to100_EMS_5  (+ As_age70to100::EMS_5 As_det1_age70to100::EMS_5))
 
 (func symptomatic_mild_age70to100_EMS_5  (+ Sym_age70to100::EMS_5 Sym_det2_age70to100::EMS_5))
@@ -7196,13 +6629,6 @@
 (func infected_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 infectious_undet_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_det_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_cumul_age70to100_EMS_5 (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5 deaths_age70to100_EMS_5))    
-
-(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-
-(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
-
 
 (func asymptomatic_age70to100_EMS_6  (+ As_age70to100::EMS_6 As_det1_age70to100::EMS_6))
 
@@ -7250,13 +6676,6 @@
 (func infected_det_age70to100_EMS_6 (+ infectious_det_age70to100_EMS_6 H1_det3_age70to100::EMS_6 H2_det3_age70to100::EMS_6 H3_det3_age70to100::EMS_6 C2_det3_age70to100::EMS_6 C3_det3_age70to100::EMS_6))
 (func infected_cumul_age70to100_EMS_6 (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6 deaths_age70to100_EMS_6))    
 
-(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-
-(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
-
-
 (func asymptomatic_age70to100_EMS_7  (+ As_age70to100::EMS_7 As_det1_age70to100::EMS_7))
 
 (func symptomatic_mild_age70to100_EMS_7  (+ Sym_age70to100::EMS_7 Sym_det2_age70to100::EMS_7))
@@ -7302,13 +6721,6 @@
 (func infected_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 infectious_undet_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_det_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_cumul_age70to100_EMS_7 (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7 deaths_age70to100_EMS_7))    
-
-(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-
-(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
-
 
 (func asymptomatic_age70to100_EMS_8  (+ As_age70to100::EMS_8 As_det1_age70to100::EMS_8))
 
@@ -7356,13 +6768,6 @@
 (func infected_det_age70to100_EMS_8 (+ infectious_det_age70to100_EMS_8 H1_det3_age70to100::EMS_8 H2_det3_age70to100::EMS_8 H3_det3_age70to100::EMS_8 C2_det3_age70to100::EMS_8 C3_det3_age70to100::EMS_8))
 (func infected_cumul_age70to100_EMS_8 (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8 deaths_age70to100_EMS_8))    
 
-(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-
-(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
-
-
 (func asymptomatic_age70to100_EMS_9  (+ As_age70to100::EMS_9 As_det1_age70to100::EMS_9))
 
 (func symptomatic_mild_age70to100_EMS_9  (+ Sym_age70to100::EMS_9 Sym_det2_age70to100::EMS_9))
@@ -7408,13 +6813,6 @@
 (func infected_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 infectious_undet_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_det_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_cumul_age70to100_EMS_9 (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9 deaths_age70to100_EMS_9))    
-
-(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-
-(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
-
 
 (func asymptomatic_age70to100_EMS_10  (+ As_age70to100::EMS_10 As_det1_age70to100::EMS_10))
 
@@ -7462,13 +6860,6 @@
 (func infected_det_age70to100_EMS_10 (+ infectious_det_age70to100_EMS_10 H1_det3_age70to100::EMS_10 H2_det3_age70to100::EMS_10 H3_det3_age70to100::EMS_10 C2_det3_age70to100::EMS_10 C3_det3_age70to100::EMS_10))
 (func infected_cumul_age70to100_EMS_10 (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10 deaths_age70to100_EMS_10))    
 
-(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-
-(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
-
-
 (func asymptomatic_age70to100_EMS_11  (+ As_age70to100::EMS_11 As_det1_age70to100::EMS_11))
 
 (func symptomatic_mild_age70to100_EMS_11  (+ Sym_age70to100::EMS_11 Sym_det2_age70to100::EMS_11))
@@ -7514,13 +6905,6 @@
 (func infected_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 infectious_undet_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_det_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_cumul_age70to100_EMS_11 (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11 deaths_age70to100_EMS_11))    
-
-(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-
-(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
-
 
 (observe susceptible_All (+ S_age0to9::EMS_1 S_age0to9::EMS_2 S_age0to9::EMS_3 S_age0to9::EMS_4 S_age0to9::EMS_5 S_age0to9::EMS_6 S_age0to9::EMS_7 S_age0to9::EMS_8 S_age0to9::EMS_9 S_age0to9::EMS_10 S_age0to9::EMS_11 S_age10to19::EMS_1 S_age10to19::EMS_2 S_age10to19::EMS_3 S_age10to19::EMS_4 S_age10to19::EMS_5 S_age10to19::EMS_6 S_age10to19::EMS_7 S_age10to19::EMS_8 S_age10to19::EMS_9 S_age10to19::EMS_10 S_age10to19::EMS_11 S_age20to29::EMS_1 S_age20to29::EMS_2 S_age20to29::EMS_3 S_age20to29::EMS_4 S_age20to29::EMS_5 S_age20to29::EMS_6 S_age20to29::EMS_7 S_age20to29::EMS_8 S_age20to29::EMS_9 S_age20to29::EMS_10 S_age20to29::EMS_11 S_age30to39::EMS_1 S_age30to39::EMS_2 S_age30to39::EMS_3 S_age30to39::EMS_4 S_age30to39::EMS_5 S_age30to39::EMS_6 S_age30to39::EMS_7 S_age30to39::EMS_8 S_age30to39::EMS_9 S_age30to39::EMS_10 S_age30to39::EMS_11 S_age40to49::EMS_1 S_age40to49::EMS_2 S_age40to49::EMS_3 S_age40to49::EMS_4 S_age40to49::EMS_5 S_age40to49::EMS_6 S_age40to49::EMS_7 S_age40to49::EMS_8 S_age40to49::EMS_9 S_age40to49::EMS_10 S_age40to49::EMS_11 S_age50to59::EMS_1 S_age50to59::EMS_2 S_age50to59::EMS_3 S_age50to59::EMS_4 S_age50to59::EMS_5 S_age50to59::EMS_6 S_age50to59::EMS_7 S_age50to59::EMS_8 S_age50to59::EMS_9 S_age50to59::EMS_10 S_age50to59::EMS_11 S_age60to69::EMS_1 S_age60to69::EMS_2 S_age60to69::EMS_3 S_age60to69::EMS_4 S_age60to69::EMS_5 S_age60to69::EMS_6 S_age60to69::EMS_7 S_age60to69::EMS_8 S_age60to69::EMS_9 S_age60to69::EMS_10 S_age60to69::EMS_11 S_age70to100::EMS_1 S_age70to100::EMS_2 S_age70to100::EMS_3 S_age70to100::EMS_4 S_age70to100::EMS_5 S_age70to100::EMS_6 S_age70to100::EMS_7 S_age70to100::EMS_8 S_age70to100::EMS_9 S_age70to100::EMS_10 S_age70to100::EMS_11))
 (observe infected_All (+ infected_age0to9_EMS_1 infected_age0to9_EMS_2 infected_age0to9_EMS_3 infected_age0to9_EMS_4 infected_age0to9_EMS_5 infected_age0to9_EMS_6 infected_age0to9_EMS_7 infected_age0to9_EMS_8 infected_age0to9_EMS_9 infected_age0to9_EMS_10 infected_age0to9_EMS_11 infected_age10to19_EMS_1 infected_age10to19_EMS_2 infected_age10to19_EMS_3 infected_age10to19_EMS_4 infected_age10to19_EMS_5 infected_age10to19_EMS_6 infected_age10to19_EMS_7 infected_age10to19_EMS_8 infected_age10to19_EMS_9 infected_age10to19_EMS_10 infected_age10to19_EMS_11 infected_age20to29_EMS_1 infected_age20to29_EMS_2 infected_age20to29_EMS_3 infected_age20to29_EMS_4 infected_age20to29_EMS_5 infected_age20to29_EMS_6 infected_age20to29_EMS_7 infected_age20to29_EMS_8 infected_age20to29_EMS_9 infected_age20to29_EMS_10 infected_age20to29_EMS_11 infected_age30to39_EMS_1 infected_age30to39_EMS_2 infected_age30to39_EMS_3 infected_age30to39_EMS_4 infected_age30to39_EMS_5 infected_age30to39_EMS_6 infected_age30to39_EMS_7 infected_age30to39_EMS_8 infected_age30to39_EMS_9 infected_age30to39_EMS_10 infected_age30to39_EMS_11 infected_age40to49_EMS_1 infected_age40to49_EMS_2 infected_age40to49_EMS_3 infected_age40to49_EMS_4 infected_age40to49_EMS_5 infected_age40to49_EMS_6 infected_age40to49_EMS_7 infected_age40to49_EMS_8 infected_age40to49_EMS_9 infected_age40to49_EMS_10 infected_age40to49_EMS_11 infected_age50to59_EMS_1 infected_age50to59_EMS_2 infected_age50to59_EMS_3 infected_age50to59_EMS_4 infected_age50to59_EMS_5 infected_age50to59_EMS_6 infected_age50to59_EMS_7 infected_age50to59_EMS_8 infected_age50to59_EMS_9 infected_age50to59_EMS_10 infected_age50to59_EMS_11 infected_age60to69_EMS_1 infected_age60to69_EMS_2 infected_age60to69_EMS_3 infected_age60to69_EMS_4 infected_age60to69_EMS_5 infected_age60to69_EMS_6 infected_age60to69_EMS_7 infected_age60to69_EMS_8 infected_age60to69_EMS_9 infected_age60to69_EMS_10 infected_age60to69_EMS_11 infected_age70to100_EMS_1 infected_age70to100_EMS_2 infected_age70to100_EMS_3 infected_age70to100_EMS_4 infected_age70to100_EMS_5 infected_age70to100_EMS_6 infected_age70to100_EMS_7 infected_age70to100_EMS_8 infected_age70to100_EMS_9 infected_age70to100_EMS_10 infected_age70to100_EMS_11))

--- a/emodl/extendedmodel_agelocale_scen3.emodl
+++ b/emodl/extendedmodel_agelocale_scen3.emodl
@@ -2904,11 +2904,11 @@
 (func infected_det_age0to9_EMS_1 (+ infectious_det_age0to9_EMS_1 H1_det3_age0to9::EMS_1 H2_det3_age0to9::EMS_1 H3_det3_age0to9::EMS_1 C2_det3_age0to9::EMS_1 C3_det3_age0to9::EMS_1))
 (func infected_cumul_age0to9_EMS_1 (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1 deaths_age0to9_EMS_1))    
 
-(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 N_age0to9_EMS_1))    
-(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) N_age0to9_EMS_1))    
+(func prevalence_age0to9_EMS_1 (/ infected_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
+(func seroprevalence_age0to9_EMS_1 (/ (+ infected_age0to9_EMS_1 recovered_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
 
-(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 N_age0to9_EMS_1))    
-(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) N_age0to9_EMS_1))    
+(func prevalence_det_age0to9_EMS_1 (/ infected_det_age0to9_EMS_1 (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
+(func seroprevalence_det_age0to9_EMS_1 (/ (+ infected_det_age0to9_EMS_1 recovered_det_age0to9_EMS_1) (- N_age0to9_EMS_1 deaths_age0to9_EMS_1)))    
 
 
 (func asymptomatic_age0to9_EMS_2  (+ As_age0to9::EMS_2 As_det1_age0to9::EMS_2))
@@ -2957,11 +2957,11 @@
 (func infected_det_age0to9_EMS_2 (+ infectious_det_age0to9_EMS_2 H1_det3_age0to9::EMS_2 H2_det3_age0to9::EMS_2 H3_det3_age0to9::EMS_2 C2_det3_age0to9::EMS_2 C3_det3_age0to9::EMS_2))
 (func infected_cumul_age0to9_EMS_2 (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2 deaths_age0to9_EMS_2))    
 
-(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 N_age0to9_EMS_2))    
-(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) N_age0to9_EMS_2))    
+(func prevalence_age0to9_EMS_2 (/ infected_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
+(func seroprevalence_age0to9_EMS_2 (/ (+ infected_age0to9_EMS_2 recovered_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
 
-(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 N_age0to9_EMS_2))    
-(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) N_age0to9_EMS_2))    
+(func prevalence_det_age0to9_EMS_2 (/ infected_det_age0to9_EMS_2 (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
+(func seroprevalence_det_age0to9_EMS_2 (/ (+ infected_det_age0to9_EMS_2 recovered_det_age0to9_EMS_2) (- N_age0to9_EMS_2 deaths_age0to9_EMS_2)))    
 
 
 (func asymptomatic_age0to9_EMS_3  (+ As_age0to9::EMS_3 As_det1_age0to9::EMS_3))
@@ -3010,11 +3010,11 @@
 (func infected_det_age0to9_EMS_3 (+ infectious_det_age0to9_EMS_3 H1_det3_age0to9::EMS_3 H2_det3_age0to9::EMS_3 H3_det3_age0to9::EMS_3 C2_det3_age0to9::EMS_3 C3_det3_age0to9::EMS_3))
 (func infected_cumul_age0to9_EMS_3 (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3 deaths_age0to9_EMS_3))    
 
-(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 N_age0to9_EMS_3))    
-(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) N_age0to9_EMS_3))    
+(func prevalence_age0to9_EMS_3 (/ infected_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
+(func seroprevalence_age0to9_EMS_3 (/ (+ infected_age0to9_EMS_3 recovered_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
 
-(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 N_age0to9_EMS_3))    
-(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) N_age0to9_EMS_3))    
+(func prevalence_det_age0to9_EMS_3 (/ infected_det_age0to9_EMS_3 (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
+(func seroprevalence_det_age0to9_EMS_3 (/ (+ infected_det_age0to9_EMS_3 recovered_det_age0to9_EMS_3) (- N_age0to9_EMS_3 deaths_age0to9_EMS_3)))    
 
 
 (func asymptomatic_age0to9_EMS_4  (+ As_age0to9::EMS_4 As_det1_age0to9::EMS_4))
@@ -3063,11 +3063,11 @@
 (func infected_det_age0to9_EMS_4 (+ infectious_det_age0to9_EMS_4 H1_det3_age0to9::EMS_4 H2_det3_age0to9::EMS_4 H3_det3_age0to9::EMS_4 C2_det3_age0to9::EMS_4 C3_det3_age0to9::EMS_4))
 (func infected_cumul_age0to9_EMS_4 (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4 deaths_age0to9_EMS_4))    
 
-(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 N_age0to9_EMS_4))    
-(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) N_age0to9_EMS_4))    
+(func prevalence_age0to9_EMS_4 (/ infected_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
+(func seroprevalence_age0to9_EMS_4 (/ (+ infected_age0to9_EMS_4 recovered_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
 
-(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 N_age0to9_EMS_4))    
-(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) N_age0to9_EMS_4))    
+(func prevalence_det_age0to9_EMS_4 (/ infected_det_age0to9_EMS_4 (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
+(func seroprevalence_det_age0to9_EMS_4 (/ (+ infected_det_age0to9_EMS_4 recovered_det_age0to9_EMS_4) (- N_age0to9_EMS_4 deaths_age0to9_EMS_4)))    
 
 
 (func asymptomatic_age0to9_EMS_5  (+ As_age0to9::EMS_5 As_det1_age0to9::EMS_5))
@@ -3116,11 +3116,11 @@
 (func infected_det_age0to9_EMS_5 (+ infectious_det_age0to9_EMS_5 H1_det3_age0to9::EMS_5 H2_det3_age0to9::EMS_5 H3_det3_age0to9::EMS_5 C2_det3_age0to9::EMS_5 C3_det3_age0to9::EMS_5))
 (func infected_cumul_age0to9_EMS_5 (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5 deaths_age0to9_EMS_5))    
 
-(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 N_age0to9_EMS_5))    
-(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) N_age0to9_EMS_5))    
+(func prevalence_age0to9_EMS_5 (/ infected_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
+(func seroprevalence_age0to9_EMS_5 (/ (+ infected_age0to9_EMS_5 recovered_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
 
-(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 N_age0to9_EMS_5))    
-(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) N_age0to9_EMS_5))    
+(func prevalence_det_age0to9_EMS_5 (/ infected_det_age0to9_EMS_5 (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
+(func seroprevalence_det_age0to9_EMS_5 (/ (+ infected_det_age0to9_EMS_5 recovered_det_age0to9_EMS_5) (- N_age0to9_EMS_5 deaths_age0to9_EMS_5)))    
 
 
 (func asymptomatic_age0to9_EMS_6  (+ As_age0to9::EMS_6 As_det1_age0to9::EMS_6))
@@ -3169,11 +3169,11 @@
 (func infected_det_age0to9_EMS_6 (+ infectious_det_age0to9_EMS_6 H1_det3_age0to9::EMS_6 H2_det3_age0to9::EMS_6 H3_det3_age0to9::EMS_6 C2_det3_age0to9::EMS_6 C3_det3_age0to9::EMS_6))
 (func infected_cumul_age0to9_EMS_6 (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6 deaths_age0to9_EMS_6))    
 
-(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 N_age0to9_EMS_6))    
-(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) N_age0to9_EMS_6))    
+(func prevalence_age0to9_EMS_6 (/ infected_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
+(func seroprevalence_age0to9_EMS_6 (/ (+ infected_age0to9_EMS_6 recovered_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
 
-(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 N_age0to9_EMS_6))    
-(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) N_age0to9_EMS_6))    
+(func prevalence_det_age0to9_EMS_6 (/ infected_det_age0to9_EMS_6 (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
+(func seroprevalence_det_age0to9_EMS_6 (/ (+ infected_det_age0to9_EMS_6 recovered_det_age0to9_EMS_6) (- N_age0to9_EMS_6 deaths_age0to9_EMS_6)))    
 
 
 (func asymptomatic_age0to9_EMS_7  (+ As_age0to9::EMS_7 As_det1_age0to9::EMS_7))
@@ -3222,11 +3222,11 @@
 (func infected_det_age0to9_EMS_7 (+ infectious_det_age0to9_EMS_7 H1_det3_age0to9::EMS_7 H2_det3_age0to9::EMS_7 H3_det3_age0to9::EMS_7 C2_det3_age0to9::EMS_7 C3_det3_age0to9::EMS_7))
 (func infected_cumul_age0to9_EMS_7 (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7 deaths_age0to9_EMS_7))    
 
-(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 N_age0to9_EMS_7))    
-(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) N_age0to9_EMS_7))    
+(func prevalence_age0to9_EMS_7 (/ infected_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
+(func seroprevalence_age0to9_EMS_7 (/ (+ infected_age0to9_EMS_7 recovered_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
 
-(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 N_age0to9_EMS_7))    
-(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) N_age0to9_EMS_7))    
+(func prevalence_det_age0to9_EMS_7 (/ infected_det_age0to9_EMS_7 (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
+(func seroprevalence_det_age0to9_EMS_7 (/ (+ infected_det_age0to9_EMS_7 recovered_det_age0to9_EMS_7) (- N_age0to9_EMS_7 deaths_age0to9_EMS_7)))    
 
 
 (func asymptomatic_age0to9_EMS_8  (+ As_age0to9::EMS_8 As_det1_age0to9::EMS_8))
@@ -3275,11 +3275,11 @@
 (func infected_det_age0to9_EMS_8 (+ infectious_det_age0to9_EMS_8 H1_det3_age0to9::EMS_8 H2_det3_age0to9::EMS_8 H3_det3_age0to9::EMS_8 C2_det3_age0to9::EMS_8 C3_det3_age0to9::EMS_8))
 (func infected_cumul_age0to9_EMS_8 (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8 deaths_age0to9_EMS_8))    
 
-(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 N_age0to9_EMS_8))    
-(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) N_age0to9_EMS_8))    
+(func prevalence_age0to9_EMS_8 (/ infected_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
+(func seroprevalence_age0to9_EMS_8 (/ (+ infected_age0to9_EMS_8 recovered_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
 
-(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 N_age0to9_EMS_8))    
-(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) N_age0to9_EMS_8))    
+(func prevalence_det_age0to9_EMS_8 (/ infected_det_age0to9_EMS_8 (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
+(func seroprevalence_det_age0to9_EMS_8 (/ (+ infected_det_age0to9_EMS_8 recovered_det_age0to9_EMS_8) (- N_age0to9_EMS_8 deaths_age0to9_EMS_8)))    
 
 
 (func asymptomatic_age0to9_EMS_9  (+ As_age0to9::EMS_9 As_det1_age0to9::EMS_9))
@@ -3328,11 +3328,11 @@
 (func infected_det_age0to9_EMS_9 (+ infectious_det_age0to9_EMS_9 H1_det3_age0to9::EMS_9 H2_det3_age0to9::EMS_9 H3_det3_age0to9::EMS_9 C2_det3_age0to9::EMS_9 C3_det3_age0to9::EMS_9))
 (func infected_cumul_age0to9_EMS_9 (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9 deaths_age0to9_EMS_9))    
 
-(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 N_age0to9_EMS_9))    
-(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) N_age0to9_EMS_9))    
+(func prevalence_age0to9_EMS_9 (/ infected_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
+(func seroprevalence_age0to9_EMS_9 (/ (+ infected_age0to9_EMS_9 recovered_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
 
-(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 N_age0to9_EMS_9))    
-(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) N_age0to9_EMS_9))    
+(func prevalence_det_age0to9_EMS_9 (/ infected_det_age0to9_EMS_9 (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
+(func seroprevalence_det_age0to9_EMS_9 (/ (+ infected_det_age0to9_EMS_9 recovered_det_age0to9_EMS_9) (- N_age0to9_EMS_9 deaths_age0to9_EMS_9)))    
 
 
 (func asymptomatic_age0to9_EMS_10  (+ As_age0to9::EMS_10 As_det1_age0to9::EMS_10))
@@ -3381,11 +3381,11 @@
 (func infected_det_age0to9_EMS_10 (+ infectious_det_age0to9_EMS_10 H1_det3_age0to9::EMS_10 H2_det3_age0to9::EMS_10 H3_det3_age0to9::EMS_10 C2_det3_age0to9::EMS_10 C3_det3_age0to9::EMS_10))
 (func infected_cumul_age0to9_EMS_10 (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10 deaths_age0to9_EMS_10))    
 
-(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 N_age0to9_EMS_10))    
-(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) N_age0to9_EMS_10))    
+(func prevalence_age0to9_EMS_10 (/ infected_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
+(func seroprevalence_age0to9_EMS_10 (/ (+ infected_age0to9_EMS_10 recovered_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
 
-(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 N_age0to9_EMS_10))    
-(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) N_age0to9_EMS_10))    
+(func prevalence_det_age0to9_EMS_10 (/ infected_det_age0to9_EMS_10 (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
+(func seroprevalence_det_age0to9_EMS_10 (/ (+ infected_det_age0to9_EMS_10 recovered_det_age0to9_EMS_10) (- N_age0to9_EMS_10 deaths_age0to9_EMS_10)))    
 
 
 (func asymptomatic_age0to9_EMS_11  (+ As_age0to9::EMS_11 As_det1_age0to9::EMS_11))
@@ -3434,11 +3434,11 @@
 (func infected_det_age0to9_EMS_11 (+ infectious_det_age0to9_EMS_11 H1_det3_age0to9::EMS_11 H2_det3_age0to9::EMS_11 H3_det3_age0to9::EMS_11 C2_det3_age0to9::EMS_11 C3_det3_age0to9::EMS_11))
 (func infected_cumul_age0to9_EMS_11 (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11 deaths_age0to9_EMS_11))    
 
-(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 N_age0to9_EMS_11))    
-(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) N_age0to9_EMS_11))    
+(func prevalence_age0to9_EMS_11 (/ infected_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
+(func seroprevalence_age0to9_EMS_11 (/ (+ infected_age0to9_EMS_11 recovered_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
 
-(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 N_age0to9_EMS_11))    
-(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) N_age0to9_EMS_11))    
+(func prevalence_det_age0to9_EMS_11 (/ infected_det_age0to9_EMS_11 (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
+(func seroprevalence_det_age0to9_EMS_11 (/ (+ infected_det_age0to9_EMS_11 recovered_det_age0to9_EMS_11) (- N_age0to9_EMS_11 deaths_age0to9_EMS_11)))    
 
 
 (func asymptomatic_age10to19_EMS_1  (+ As_age10to19::EMS_1 As_det1_age10to19::EMS_1))
@@ -3487,11 +3487,11 @@
 (func infected_det_age10to19_EMS_1 (+ infectious_det_age10to19_EMS_1 H1_det3_age10to19::EMS_1 H2_det3_age10to19::EMS_1 H3_det3_age10to19::EMS_1 C2_det3_age10to19::EMS_1 C3_det3_age10to19::EMS_1))
 (func infected_cumul_age10to19_EMS_1 (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1 deaths_age10to19_EMS_1))    
 
-(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 N_age10to19_EMS_1))    
-(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) N_age10to19_EMS_1))    
+(func prevalence_age10to19_EMS_1 (/ infected_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
+(func seroprevalence_age10to19_EMS_1 (/ (+ infected_age10to19_EMS_1 recovered_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
 
-(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 N_age10to19_EMS_1))    
-(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) N_age10to19_EMS_1))    
+(func prevalence_det_age10to19_EMS_1 (/ infected_det_age10to19_EMS_1 (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
+(func seroprevalence_det_age10to19_EMS_1 (/ (+ infected_det_age10to19_EMS_1 recovered_det_age10to19_EMS_1) (- N_age10to19_EMS_1 deaths_age10to19_EMS_1)))    
 
 
 (func asymptomatic_age10to19_EMS_2  (+ As_age10to19::EMS_2 As_det1_age10to19::EMS_2))
@@ -3540,11 +3540,11 @@
 (func infected_det_age10to19_EMS_2 (+ infectious_det_age10to19_EMS_2 H1_det3_age10to19::EMS_2 H2_det3_age10to19::EMS_2 H3_det3_age10to19::EMS_2 C2_det3_age10to19::EMS_2 C3_det3_age10to19::EMS_2))
 (func infected_cumul_age10to19_EMS_2 (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2 deaths_age10to19_EMS_2))    
 
-(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 N_age10to19_EMS_2))    
-(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) N_age10to19_EMS_2))    
+(func prevalence_age10to19_EMS_2 (/ infected_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
+(func seroprevalence_age10to19_EMS_2 (/ (+ infected_age10to19_EMS_2 recovered_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
 
-(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 N_age10to19_EMS_2))    
-(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) N_age10to19_EMS_2))    
+(func prevalence_det_age10to19_EMS_2 (/ infected_det_age10to19_EMS_2 (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
+(func seroprevalence_det_age10to19_EMS_2 (/ (+ infected_det_age10to19_EMS_2 recovered_det_age10to19_EMS_2) (- N_age10to19_EMS_2 deaths_age10to19_EMS_2)))    
 
 
 (func asymptomatic_age10to19_EMS_3  (+ As_age10to19::EMS_3 As_det1_age10to19::EMS_3))
@@ -3593,11 +3593,11 @@
 (func infected_det_age10to19_EMS_3 (+ infectious_det_age10to19_EMS_3 H1_det3_age10to19::EMS_3 H2_det3_age10to19::EMS_3 H3_det3_age10to19::EMS_3 C2_det3_age10to19::EMS_3 C3_det3_age10to19::EMS_3))
 (func infected_cumul_age10to19_EMS_3 (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3 deaths_age10to19_EMS_3))    
 
-(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 N_age10to19_EMS_3))    
-(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) N_age10to19_EMS_3))    
+(func prevalence_age10to19_EMS_3 (/ infected_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
+(func seroprevalence_age10to19_EMS_3 (/ (+ infected_age10to19_EMS_3 recovered_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
 
-(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 N_age10to19_EMS_3))    
-(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) N_age10to19_EMS_3))    
+(func prevalence_det_age10to19_EMS_3 (/ infected_det_age10to19_EMS_3 (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
+(func seroprevalence_det_age10to19_EMS_3 (/ (+ infected_det_age10to19_EMS_3 recovered_det_age10to19_EMS_3) (- N_age10to19_EMS_3 deaths_age10to19_EMS_3)))    
 
 
 (func asymptomatic_age10to19_EMS_4  (+ As_age10to19::EMS_4 As_det1_age10to19::EMS_4))
@@ -3646,11 +3646,11 @@
 (func infected_det_age10to19_EMS_4 (+ infectious_det_age10to19_EMS_4 H1_det3_age10to19::EMS_4 H2_det3_age10to19::EMS_4 H3_det3_age10to19::EMS_4 C2_det3_age10to19::EMS_4 C3_det3_age10to19::EMS_4))
 (func infected_cumul_age10to19_EMS_4 (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4 deaths_age10to19_EMS_4))    
 
-(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 N_age10to19_EMS_4))    
-(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) N_age10to19_EMS_4))    
+(func prevalence_age10to19_EMS_4 (/ infected_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
+(func seroprevalence_age10to19_EMS_4 (/ (+ infected_age10to19_EMS_4 recovered_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
 
-(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 N_age10to19_EMS_4))    
-(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) N_age10to19_EMS_4))    
+(func prevalence_det_age10to19_EMS_4 (/ infected_det_age10to19_EMS_4 (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
+(func seroprevalence_det_age10to19_EMS_4 (/ (+ infected_det_age10to19_EMS_4 recovered_det_age10to19_EMS_4) (- N_age10to19_EMS_4 deaths_age10to19_EMS_4)))    
 
 
 (func asymptomatic_age10to19_EMS_5  (+ As_age10to19::EMS_5 As_det1_age10to19::EMS_5))
@@ -3699,11 +3699,11 @@
 (func infected_det_age10to19_EMS_5 (+ infectious_det_age10to19_EMS_5 H1_det3_age10to19::EMS_5 H2_det3_age10to19::EMS_5 H3_det3_age10to19::EMS_5 C2_det3_age10to19::EMS_5 C3_det3_age10to19::EMS_5))
 (func infected_cumul_age10to19_EMS_5 (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5 deaths_age10to19_EMS_5))    
 
-(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 N_age10to19_EMS_5))    
-(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) N_age10to19_EMS_5))    
+(func prevalence_age10to19_EMS_5 (/ infected_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
+(func seroprevalence_age10to19_EMS_5 (/ (+ infected_age10to19_EMS_5 recovered_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
 
-(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 N_age10to19_EMS_5))    
-(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) N_age10to19_EMS_5))    
+(func prevalence_det_age10to19_EMS_5 (/ infected_det_age10to19_EMS_5 (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
+(func seroprevalence_det_age10to19_EMS_5 (/ (+ infected_det_age10to19_EMS_5 recovered_det_age10to19_EMS_5) (- N_age10to19_EMS_5 deaths_age10to19_EMS_5)))    
 
 
 (func asymptomatic_age10to19_EMS_6  (+ As_age10to19::EMS_6 As_det1_age10to19::EMS_6))
@@ -3752,11 +3752,11 @@
 (func infected_det_age10to19_EMS_6 (+ infectious_det_age10to19_EMS_6 H1_det3_age10to19::EMS_6 H2_det3_age10to19::EMS_6 H3_det3_age10to19::EMS_6 C2_det3_age10to19::EMS_6 C3_det3_age10to19::EMS_6))
 (func infected_cumul_age10to19_EMS_6 (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6 deaths_age10to19_EMS_6))    
 
-(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 N_age10to19_EMS_6))    
-(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) N_age10to19_EMS_6))    
+(func prevalence_age10to19_EMS_6 (/ infected_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
+(func seroprevalence_age10to19_EMS_6 (/ (+ infected_age10to19_EMS_6 recovered_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
 
-(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 N_age10to19_EMS_6))    
-(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) N_age10to19_EMS_6))    
+(func prevalence_det_age10to19_EMS_6 (/ infected_det_age10to19_EMS_6 (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
+(func seroprevalence_det_age10to19_EMS_6 (/ (+ infected_det_age10to19_EMS_6 recovered_det_age10to19_EMS_6) (- N_age10to19_EMS_6 deaths_age10to19_EMS_6)))    
 
 
 (func asymptomatic_age10to19_EMS_7  (+ As_age10to19::EMS_7 As_det1_age10to19::EMS_7))
@@ -3805,11 +3805,11 @@
 (func infected_det_age10to19_EMS_7 (+ infectious_det_age10to19_EMS_7 H1_det3_age10to19::EMS_7 H2_det3_age10to19::EMS_7 H3_det3_age10to19::EMS_7 C2_det3_age10to19::EMS_7 C3_det3_age10to19::EMS_7))
 (func infected_cumul_age10to19_EMS_7 (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7 deaths_age10to19_EMS_7))    
 
-(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 N_age10to19_EMS_7))    
-(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) N_age10to19_EMS_7))    
+(func prevalence_age10to19_EMS_7 (/ infected_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
+(func seroprevalence_age10to19_EMS_7 (/ (+ infected_age10to19_EMS_7 recovered_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
 
-(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 N_age10to19_EMS_7))    
-(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) N_age10to19_EMS_7))    
+(func prevalence_det_age10to19_EMS_7 (/ infected_det_age10to19_EMS_7 (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
+(func seroprevalence_det_age10to19_EMS_7 (/ (+ infected_det_age10to19_EMS_7 recovered_det_age10to19_EMS_7) (- N_age10to19_EMS_7 deaths_age10to19_EMS_7)))    
 
 
 (func asymptomatic_age10to19_EMS_8  (+ As_age10to19::EMS_8 As_det1_age10to19::EMS_8))
@@ -3858,11 +3858,11 @@
 (func infected_det_age10to19_EMS_8 (+ infectious_det_age10to19_EMS_8 H1_det3_age10to19::EMS_8 H2_det3_age10to19::EMS_8 H3_det3_age10to19::EMS_8 C2_det3_age10to19::EMS_8 C3_det3_age10to19::EMS_8))
 (func infected_cumul_age10to19_EMS_8 (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8 deaths_age10to19_EMS_8))    
 
-(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 N_age10to19_EMS_8))    
-(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) N_age10to19_EMS_8))    
+(func prevalence_age10to19_EMS_8 (/ infected_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
+(func seroprevalence_age10to19_EMS_8 (/ (+ infected_age10to19_EMS_8 recovered_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
 
-(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 N_age10to19_EMS_8))    
-(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) N_age10to19_EMS_8))    
+(func prevalence_det_age10to19_EMS_8 (/ infected_det_age10to19_EMS_8 (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
+(func seroprevalence_det_age10to19_EMS_8 (/ (+ infected_det_age10to19_EMS_8 recovered_det_age10to19_EMS_8) (- N_age10to19_EMS_8 deaths_age10to19_EMS_8)))    
 
 
 (func asymptomatic_age10to19_EMS_9  (+ As_age10to19::EMS_9 As_det1_age10to19::EMS_9))
@@ -3911,11 +3911,11 @@
 (func infected_det_age10to19_EMS_9 (+ infectious_det_age10to19_EMS_9 H1_det3_age10to19::EMS_9 H2_det3_age10to19::EMS_9 H3_det3_age10to19::EMS_9 C2_det3_age10to19::EMS_9 C3_det3_age10to19::EMS_9))
 (func infected_cumul_age10to19_EMS_9 (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9 deaths_age10to19_EMS_9))    
 
-(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 N_age10to19_EMS_9))    
-(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) N_age10to19_EMS_9))    
+(func prevalence_age10to19_EMS_9 (/ infected_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
+(func seroprevalence_age10to19_EMS_9 (/ (+ infected_age10to19_EMS_9 recovered_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
 
-(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 N_age10to19_EMS_9))    
-(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) N_age10to19_EMS_9))    
+(func prevalence_det_age10to19_EMS_9 (/ infected_det_age10to19_EMS_9 (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
+(func seroprevalence_det_age10to19_EMS_9 (/ (+ infected_det_age10to19_EMS_9 recovered_det_age10to19_EMS_9) (- N_age10to19_EMS_9 deaths_age10to19_EMS_9)))    
 
 
 (func asymptomatic_age10to19_EMS_10  (+ As_age10to19::EMS_10 As_det1_age10to19::EMS_10))
@@ -3964,11 +3964,11 @@
 (func infected_det_age10to19_EMS_10 (+ infectious_det_age10to19_EMS_10 H1_det3_age10to19::EMS_10 H2_det3_age10to19::EMS_10 H3_det3_age10to19::EMS_10 C2_det3_age10to19::EMS_10 C3_det3_age10to19::EMS_10))
 (func infected_cumul_age10to19_EMS_10 (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10 deaths_age10to19_EMS_10))    
 
-(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 N_age10to19_EMS_10))    
-(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) N_age10to19_EMS_10))    
+(func prevalence_age10to19_EMS_10 (/ infected_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
+(func seroprevalence_age10to19_EMS_10 (/ (+ infected_age10to19_EMS_10 recovered_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
 
-(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 N_age10to19_EMS_10))    
-(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) N_age10to19_EMS_10))    
+(func prevalence_det_age10to19_EMS_10 (/ infected_det_age10to19_EMS_10 (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
+(func seroprevalence_det_age10to19_EMS_10 (/ (+ infected_det_age10to19_EMS_10 recovered_det_age10to19_EMS_10) (- N_age10to19_EMS_10 deaths_age10to19_EMS_10)))    
 
 
 (func asymptomatic_age10to19_EMS_11  (+ As_age10to19::EMS_11 As_det1_age10to19::EMS_11))
@@ -4017,11 +4017,11 @@
 (func infected_det_age10to19_EMS_11 (+ infectious_det_age10to19_EMS_11 H1_det3_age10to19::EMS_11 H2_det3_age10to19::EMS_11 H3_det3_age10to19::EMS_11 C2_det3_age10to19::EMS_11 C3_det3_age10to19::EMS_11))
 (func infected_cumul_age10to19_EMS_11 (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11 deaths_age10to19_EMS_11))    
 
-(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 N_age10to19_EMS_11))    
-(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) N_age10to19_EMS_11))    
+(func prevalence_age10to19_EMS_11 (/ infected_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
+(func seroprevalence_age10to19_EMS_11 (/ (+ infected_age10to19_EMS_11 recovered_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
 
-(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 N_age10to19_EMS_11))    
-(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) N_age10to19_EMS_11))    
+(func prevalence_det_age10to19_EMS_11 (/ infected_det_age10to19_EMS_11 (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
+(func seroprevalence_det_age10to19_EMS_11 (/ (+ infected_det_age10to19_EMS_11 recovered_det_age10to19_EMS_11) (- N_age10to19_EMS_11 deaths_age10to19_EMS_11)))    
 
 
 (func asymptomatic_age20to29_EMS_1  (+ As_age20to29::EMS_1 As_det1_age20to29::EMS_1))
@@ -4070,11 +4070,11 @@
 (func infected_det_age20to29_EMS_1 (+ infectious_det_age20to29_EMS_1 H1_det3_age20to29::EMS_1 H2_det3_age20to29::EMS_1 H3_det3_age20to29::EMS_1 C2_det3_age20to29::EMS_1 C3_det3_age20to29::EMS_1))
 (func infected_cumul_age20to29_EMS_1 (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1 deaths_age20to29_EMS_1))    
 
-(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 N_age20to29_EMS_1))    
-(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) N_age20to29_EMS_1))    
+(func prevalence_age20to29_EMS_1 (/ infected_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
+(func seroprevalence_age20to29_EMS_1 (/ (+ infected_age20to29_EMS_1 recovered_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
 
-(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 N_age20to29_EMS_1))    
-(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) N_age20to29_EMS_1))    
+(func prevalence_det_age20to29_EMS_1 (/ infected_det_age20to29_EMS_1 (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
+(func seroprevalence_det_age20to29_EMS_1 (/ (+ infected_det_age20to29_EMS_1 recovered_det_age20to29_EMS_1) (- N_age20to29_EMS_1 deaths_age20to29_EMS_1)))    
 
 
 (func asymptomatic_age20to29_EMS_2  (+ As_age20to29::EMS_2 As_det1_age20to29::EMS_2))
@@ -4123,11 +4123,11 @@
 (func infected_det_age20to29_EMS_2 (+ infectious_det_age20to29_EMS_2 H1_det3_age20to29::EMS_2 H2_det3_age20to29::EMS_2 H3_det3_age20to29::EMS_2 C2_det3_age20to29::EMS_2 C3_det3_age20to29::EMS_2))
 (func infected_cumul_age20to29_EMS_2 (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2 deaths_age20to29_EMS_2))    
 
-(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 N_age20to29_EMS_2))    
-(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) N_age20to29_EMS_2))    
+(func prevalence_age20to29_EMS_2 (/ infected_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
+(func seroprevalence_age20to29_EMS_2 (/ (+ infected_age20to29_EMS_2 recovered_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
 
-(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 N_age20to29_EMS_2))    
-(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) N_age20to29_EMS_2))    
+(func prevalence_det_age20to29_EMS_2 (/ infected_det_age20to29_EMS_2 (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
+(func seroprevalence_det_age20to29_EMS_2 (/ (+ infected_det_age20to29_EMS_2 recovered_det_age20to29_EMS_2) (- N_age20to29_EMS_2 deaths_age20to29_EMS_2)))    
 
 
 (func asymptomatic_age20to29_EMS_3  (+ As_age20to29::EMS_3 As_det1_age20to29::EMS_3))
@@ -4176,11 +4176,11 @@
 (func infected_det_age20to29_EMS_3 (+ infectious_det_age20to29_EMS_3 H1_det3_age20to29::EMS_3 H2_det3_age20to29::EMS_3 H3_det3_age20to29::EMS_3 C2_det3_age20to29::EMS_3 C3_det3_age20to29::EMS_3))
 (func infected_cumul_age20to29_EMS_3 (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3 deaths_age20to29_EMS_3))    
 
-(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 N_age20to29_EMS_3))    
-(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) N_age20to29_EMS_3))    
+(func prevalence_age20to29_EMS_3 (/ infected_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
+(func seroprevalence_age20to29_EMS_3 (/ (+ infected_age20to29_EMS_3 recovered_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
 
-(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 N_age20to29_EMS_3))    
-(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) N_age20to29_EMS_3))    
+(func prevalence_det_age20to29_EMS_3 (/ infected_det_age20to29_EMS_3 (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
+(func seroprevalence_det_age20to29_EMS_3 (/ (+ infected_det_age20to29_EMS_3 recovered_det_age20to29_EMS_3) (- N_age20to29_EMS_3 deaths_age20to29_EMS_3)))    
 
 
 (func asymptomatic_age20to29_EMS_4  (+ As_age20to29::EMS_4 As_det1_age20to29::EMS_4))
@@ -4229,11 +4229,11 @@
 (func infected_det_age20to29_EMS_4 (+ infectious_det_age20to29_EMS_4 H1_det3_age20to29::EMS_4 H2_det3_age20to29::EMS_4 H3_det3_age20to29::EMS_4 C2_det3_age20to29::EMS_4 C3_det3_age20to29::EMS_4))
 (func infected_cumul_age20to29_EMS_4 (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4 deaths_age20to29_EMS_4))    
 
-(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 N_age20to29_EMS_4))    
-(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) N_age20to29_EMS_4))    
+(func prevalence_age20to29_EMS_4 (/ infected_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
+(func seroprevalence_age20to29_EMS_4 (/ (+ infected_age20to29_EMS_4 recovered_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
 
-(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 N_age20to29_EMS_4))    
-(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) N_age20to29_EMS_4))    
+(func prevalence_det_age20to29_EMS_4 (/ infected_det_age20to29_EMS_4 (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
+(func seroprevalence_det_age20to29_EMS_4 (/ (+ infected_det_age20to29_EMS_4 recovered_det_age20to29_EMS_4) (- N_age20to29_EMS_4 deaths_age20to29_EMS_4)))    
 
 
 (func asymptomatic_age20to29_EMS_5  (+ As_age20to29::EMS_5 As_det1_age20to29::EMS_5))
@@ -4282,11 +4282,11 @@
 (func infected_det_age20to29_EMS_5 (+ infectious_det_age20to29_EMS_5 H1_det3_age20to29::EMS_5 H2_det3_age20to29::EMS_5 H3_det3_age20to29::EMS_5 C2_det3_age20to29::EMS_5 C3_det3_age20to29::EMS_5))
 (func infected_cumul_age20to29_EMS_5 (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5 deaths_age20to29_EMS_5))    
 
-(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 N_age20to29_EMS_5))    
-(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) N_age20to29_EMS_5))    
+(func prevalence_age20to29_EMS_5 (/ infected_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
+(func seroprevalence_age20to29_EMS_5 (/ (+ infected_age20to29_EMS_5 recovered_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
 
-(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 N_age20to29_EMS_5))    
-(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) N_age20to29_EMS_5))    
+(func prevalence_det_age20to29_EMS_5 (/ infected_det_age20to29_EMS_5 (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
+(func seroprevalence_det_age20to29_EMS_5 (/ (+ infected_det_age20to29_EMS_5 recovered_det_age20to29_EMS_5) (- N_age20to29_EMS_5 deaths_age20to29_EMS_5)))    
 
 
 (func asymptomatic_age20to29_EMS_6  (+ As_age20to29::EMS_6 As_det1_age20to29::EMS_6))
@@ -4335,11 +4335,11 @@
 (func infected_det_age20to29_EMS_6 (+ infectious_det_age20to29_EMS_6 H1_det3_age20to29::EMS_6 H2_det3_age20to29::EMS_6 H3_det3_age20to29::EMS_6 C2_det3_age20to29::EMS_6 C3_det3_age20to29::EMS_6))
 (func infected_cumul_age20to29_EMS_6 (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6 deaths_age20to29_EMS_6))    
 
-(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 N_age20to29_EMS_6))    
-(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) N_age20to29_EMS_6))    
+(func prevalence_age20to29_EMS_6 (/ infected_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
+(func seroprevalence_age20to29_EMS_6 (/ (+ infected_age20to29_EMS_6 recovered_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
 
-(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 N_age20to29_EMS_6))    
-(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) N_age20to29_EMS_6))    
+(func prevalence_det_age20to29_EMS_6 (/ infected_det_age20to29_EMS_6 (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
+(func seroprevalence_det_age20to29_EMS_6 (/ (+ infected_det_age20to29_EMS_6 recovered_det_age20to29_EMS_6) (- N_age20to29_EMS_6 deaths_age20to29_EMS_6)))    
 
 
 (func asymptomatic_age20to29_EMS_7  (+ As_age20to29::EMS_7 As_det1_age20to29::EMS_7))
@@ -4388,11 +4388,11 @@
 (func infected_det_age20to29_EMS_7 (+ infectious_det_age20to29_EMS_7 H1_det3_age20to29::EMS_7 H2_det3_age20to29::EMS_7 H3_det3_age20to29::EMS_7 C2_det3_age20to29::EMS_7 C3_det3_age20to29::EMS_7))
 (func infected_cumul_age20to29_EMS_7 (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7 deaths_age20to29_EMS_7))    
 
-(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 N_age20to29_EMS_7))    
-(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) N_age20to29_EMS_7))    
+(func prevalence_age20to29_EMS_7 (/ infected_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
+(func seroprevalence_age20to29_EMS_7 (/ (+ infected_age20to29_EMS_7 recovered_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
 
-(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 N_age20to29_EMS_7))    
-(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) N_age20to29_EMS_7))    
+(func prevalence_det_age20to29_EMS_7 (/ infected_det_age20to29_EMS_7 (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
+(func seroprevalence_det_age20to29_EMS_7 (/ (+ infected_det_age20to29_EMS_7 recovered_det_age20to29_EMS_7) (- N_age20to29_EMS_7 deaths_age20to29_EMS_7)))    
 
 
 (func asymptomatic_age20to29_EMS_8  (+ As_age20to29::EMS_8 As_det1_age20to29::EMS_8))
@@ -4441,11 +4441,11 @@
 (func infected_det_age20to29_EMS_8 (+ infectious_det_age20to29_EMS_8 H1_det3_age20to29::EMS_8 H2_det3_age20to29::EMS_8 H3_det3_age20to29::EMS_8 C2_det3_age20to29::EMS_8 C3_det3_age20to29::EMS_8))
 (func infected_cumul_age20to29_EMS_8 (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8 deaths_age20to29_EMS_8))    
 
-(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 N_age20to29_EMS_8))    
-(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) N_age20to29_EMS_8))    
+(func prevalence_age20to29_EMS_8 (/ infected_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
+(func seroprevalence_age20to29_EMS_8 (/ (+ infected_age20to29_EMS_8 recovered_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
 
-(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 N_age20to29_EMS_8))    
-(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) N_age20to29_EMS_8))    
+(func prevalence_det_age20to29_EMS_8 (/ infected_det_age20to29_EMS_8 (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
+(func seroprevalence_det_age20to29_EMS_8 (/ (+ infected_det_age20to29_EMS_8 recovered_det_age20to29_EMS_8) (- N_age20to29_EMS_8 deaths_age20to29_EMS_8)))    
 
 
 (func asymptomatic_age20to29_EMS_9  (+ As_age20to29::EMS_9 As_det1_age20to29::EMS_9))
@@ -4494,11 +4494,11 @@
 (func infected_det_age20to29_EMS_9 (+ infectious_det_age20to29_EMS_9 H1_det3_age20to29::EMS_9 H2_det3_age20to29::EMS_9 H3_det3_age20to29::EMS_9 C2_det3_age20to29::EMS_9 C3_det3_age20to29::EMS_9))
 (func infected_cumul_age20to29_EMS_9 (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9 deaths_age20to29_EMS_9))    
 
-(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 N_age20to29_EMS_9))    
-(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) N_age20to29_EMS_9))    
+(func prevalence_age20to29_EMS_9 (/ infected_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
+(func seroprevalence_age20to29_EMS_9 (/ (+ infected_age20to29_EMS_9 recovered_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
 
-(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 N_age20to29_EMS_9))    
-(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) N_age20to29_EMS_9))    
+(func prevalence_det_age20to29_EMS_9 (/ infected_det_age20to29_EMS_9 (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
+(func seroprevalence_det_age20to29_EMS_9 (/ (+ infected_det_age20to29_EMS_9 recovered_det_age20to29_EMS_9) (- N_age20to29_EMS_9 deaths_age20to29_EMS_9)))    
 
 
 (func asymptomatic_age20to29_EMS_10  (+ As_age20to29::EMS_10 As_det1_age20to29::EMS_10))
@@ -4547,11 +4547,11 @@
 (func infected_det_age20to29_EMS_10 (+ infectious_det_age20to29_EMS_10 H1_det3_age20to29::EMS_10 H2_det3_age20to29::EMS_10 H3_det3_age20to29::EMS_10 C2_det3_age20to29::EMS_10 C3_det3_age20to29::EMS_10))
 (func infected_cumul_age20to29_EMS_10 (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10 deaths_age20to29_EMS_10))    
 
-(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 N_age20to29_EMS_10))    
-(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) N_age20to29_EMS_10))    
+(func prevalence_age20to29_EMS_10 (/ infected_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
+(func seroprevalence_age20to29_EMS_10 (/ (+ infected_age20to29_EMS_10 recovered_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
 
-(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 N_age20to29_EMS_10))    
-(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) N_age20to29_EMS_10))    
+(func prevalence_det_age20to29_EMS_10 (/ infected_det_age20to29_EMS_10 (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
+(func seroprevalence_det_age20to29_EMS_10 (/ (+ infected_det_age20to29_EMS_10 recovered_det_age20to29_EMS_10) (- N_age20to29_EMS_10 deaths_age20to29_EMS_10)))    
 
 
 (func asymptomatic_age20to29_EMS_11  (+ As_age20to29::EMS_11 As_det1_age20to29::EMS_11))
@@ -4600,11 +4600,11 @@
 (func infected_det_age20to29_EMS_11 (+ infectious_det_age20to29_EMS_11 H1_det3_age20to29::EMS_11 H2_det3_age20to29::EMS_11 H3_det3_age20to29::EMS_11 C2_det3_age20to29::EMS_11 C3_det3_age20to29::EMS_11))
 (func infected_cumul_age20to29_EMS_11 (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11 deaths_age20to29_EMS_11))    
 
-(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 N_age20to29_EMS_11))    
-(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) N_age20to29_EMS_11))    
+(func prevalence_age20to29_EMS_11 (/ infected_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
+(func seroprevalence_age20to29_EMS_11 (/ (+ infected_age20to29_EMS_11 recovered_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
 
-(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 N_age20to29_EMS_11))    
-(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) N_age20to29_EMS_11))    
+(func prevalence_det_age20to29_EMS_11 (/ infected_det_age20to29_EMS_11 (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
+(func seroprevalence_det_age20to29_EMS_11 (/ (+ infected_det_age20to29_EMS_11 recovered_det_age20to29_EMS_11) (- N_age20to29_EMS_11 deaths_age20to29_EMS_11)))    
 
 
 (func asymptomatic_age30to39_EMS_1  (+ As_age30to39::EMS_1 As_det1_age30to39::EMS_1))
@@ -4653,11 +4653,11 @@
 (func infected_det_age30to39_EMS_1 (+ infectious_det_age30to39_EMS_1 H1_det3_age30to39::EMS_1 H2_det3_age30to39::EMS_1 H3_det3_age30to39::EMS_1 C2_det3_age30to39::EMS_1 C3_det3_age30to39::EMS_1))
 (func infected_cumul_age30to39_EMS_1 (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1 deaths_age30to39_EMS_1))    
 
-(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 N_age30to39_EMS_1))    
-(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) N_age30to39_EMS_1))    
+(func prevalence_age30to39_EMS_1 (/ infected_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
+(func seroprevalence_age30to39_EMS_1 (/ (+ infected_age30to39_EMS_1 recovered_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
 
-(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 N_age30to39_EMS_1))    
-(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) N_age30to39_EMS_1))    
+(func prevalence_det_age30to39_EMS_1 (/ infected_det_age30to39_EMS_1 (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
+(func seroprevalence_det_age30to39_EMS_1 (/ (+ infected_det_age30to39_EMS_1 recovered_det_age30to39_EMS_1) (- N_age30to39_EMS_1 deaths_age30to39_EMS_1)))    
 
 
 (func asymptomatic_age30to39_EMS_2  (+ As_age30to39::EMS_2 As_det1_age30to39::EMS_2))
@@ -4706,11 +4706,11 @@
 (func infected_det_age30to39_EMS_2 (+ infectious_det_age30to39_EMS_2 H1_det3_age30to39::EMS_2 H2_det3_age30to39::EMS_2 H3_det3_age30to39::EMS_2 C2_det3_age30to39::EMS_2 C3_det3_age30to39::EMS_2))
 (func infected_cumul_age30to39_EMS_2 (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2 deaths_age30to39_EMS_2))    
 
-(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 N_age30to39_EMS_2))    
-(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) N_age30to39_EMS_2))    
+(func prevalence_age30to39_EMS_2 (/ infected_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
+(func seroprevalence_age30to39_EMS_2 (/ (+ infected_age30to39_EMS_2 recovered_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
 
-(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 N_age30to39_EMS_2))    
-(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) N_age30to39_EMS_2))    
+(func prevalence_det_age30to39_EMS_2 (/ infected_det_age30to39_EMS_2 (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
+(func seroprevalence_det_age30to39_EMS_2 (/ (+ infected_det_age30to39_EMS_2 recovered_det_age30to39_EMS_2) (- N_age30to39_EMS_2 deaths_age30to39_EMS_2)))    
 
 
 (func asymptomatic_age30to39_EMS_3  (+ As_age30to39::EMS_3 As_det1_age30to39::EMS_3))
@@ -4759,11 +4759,11 @@
 (func infected_det_age30to39_EMS_3 (+ infectious_det_age30to39_EMS_3 H1_det3_age30to39::EMS_3 H2_det3_age30to39::EMS_3 H3_det3_age30to39::EMS_3 C2_det3_age30to39::EMS_3 C3_det3_age30to39::EMS_3))
 (func infected_cumul_age30to39_EMS_3 (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3 deaths_age30to39_EMS_3))    
 
-(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 N_age30to39_EMS_3))    
-(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) N_age30to39_EMS_3))    
+(func prevalence_age30to39_EMS_3 (/ infected_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
+(func seroprevalence_age30to39_EMS_3 (/ (+ infected_age30to39_EMS_3 recovered_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
 
-(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 N_age30to39_EMS_3))    
-(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) N_age30to39_EMS_3))    
+(func prevalence_det_age30to39_EMS_3 (/ infected_det_age30to39_EMS_3 (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
+(func seroprevalence_det_age30to39_EMS_3 (/ (+ infected_det_age30to39_EMS_3 recovered_det_age30to39_EMS_3) (- N_age30to39_EMS_3 deaths_age30to39_EMS_3)))    
 
 
 (func asymptomatic_age30to39_EMS_4  (+ As_age30to39::EMS_4 As_det1_age30to39::EMS_4))
@@ -4812,11 +4812,11 @@
 (func infected_det_age30to39_EMS_4 (+ infectious_det_age30to39_EMS_4 H1_det3_age30to39::EMS_4 H2_det3_age30to39::EMS_4 H3_det3_age30to39::EMS_4 C2_det3_age30to39::EMS_4 C3_det3_age30to39::EMS_4))
 (func infected_cumul_age30to39_EMS_4 (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4 deaths_age30to39_EMS_4))    
 
-(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 N_age30to39_EMS_4))    
-(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) N_age30to39_EMS_4))    
+(func prevalence_age30to39_EMS_4 (/ infected_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
+(func seroprevalence_age30to39_EMS_4 (/ (+ infected_age30to39_EMS_4 recovered_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
 
-(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 N_age30to39_EMS_4))    
-(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) N_age30to39_EMS_4))    
+(func prevalence_det_age30to39_EMS_4 (/ infected_det_age30to39_EMS_4 (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
+(func seroprevalence_det_age30to39_EMS_4 (/ (+ infected_det_age30to39_EMS_4 recovered_det_age30to39_EMS_4) (- N_age30to39_EMS_4 deaths_age30to39_EMS_4)))    
 
 
 (func asymptomatic_age30to39_EMS_5  (+ As_age30to39::EMS_5 As_det1_age30to39::EMS_5))
@@ -4865,11 +4865,11 @@
 (func infected_det_age30to39_EMS_5 (+ infectious_det_age30to39_EMS_5 H1_det3_age30to39::EMS_5 H2_det3_age30to39::EMS_5 H3_det3_age30to39::EMS_5 C2_det3_age30to39::EMS_5 C3_det3_age30to39::EMS_5))
 (func infected_cumul_age30to39_EMS_5 (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5 deaths_age30to39_EMS_5))    
 
-(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 N_age30to39_EMS_5))    
-(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) N_age30to39_EMS_5))    
+(func prevalence_age30to39_EMS_5 (/ infected_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
+(func seroprevalence_age30to39_EMS_5 (/ (+ infected_age30to39_EMS_5 recovered_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
 
-(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 N_age30to39_EMS_5))    
-(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) N_age30to39_EMS_5))    
+(func prevalence_det_age30to39_EMS_5 (/ infected_det_age30to39_EMS_5 (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
+(func seroprevalence_det_age30to39_EMS_5 (/ (+ infected_det_age30to39_EMS_5 recovered_det_age30to39_EMS_5) (- N_age30to39_EMS_5 deaths_age30to39_EMS_5)))    
 
 
 (func asymptomatic_age30to39_EMS_6  (+ As_age30to39::EMS_6 As_det1_age30to39::EMS_6))
@@ -4918,11 +4918,11 @@
 (func infected_det_age30to39_EMS_6 (+ infectious_det_age30to39_EMS_6 H1_det3_age30to39::EMS_6 H2_det3_age30to39::EMS_6 H3_det3_age30to39::EMS_6 C2_det3_age30to39::EMS_6 C3_det3_age30to39::EMS_6))
 (func infected_cumul_age30to39_EMS_6 (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6 deaths_age30to39_EMS_6))    
 
-(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 N_age30to39_EMS_6))    
-(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) N_age30to39_EMS_6))    
+(func prevalence_age30to39_EMS_6 (/ infected_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
+(func seroprevalence_age30to39_EMS_6 (/ (+ infected_age30to39_EMS_6 recovered_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
 
-(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 N_age30to39_EMS_6))    
-(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) N_age30to39_EMS_6))    
+(func prevalence_det_age30to39_EMS_6 (/ infected_det_age30to39_EMS_6 (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
+(func seroprevalence_det_age30to39_EMS_6 (/ (+ infected_det_age30to39_EMS_6 recovered_det_age30to39_EMS_6) (- N_age30to39_EMS_6 deaths_age30to39_EMS_6)))    
 
 
 (func asymptomatic_age30to39_EMS_7  (+ As_age30to39::EMS_7 As_det1_age30to39::EMS_7))
@@ -4971,11 +4971,11 @@
 (func infected_det_age30to39_EMS_7 (+ infectious_det_age30to39_EMS_7 H1_det3_age30to39::EMS_7 H2_det3_age30to39::EMS_7 H3_det3_age30to39::EMS_7 C2_det3_age30to39::EMS_7 C3_det3_age30to39::EMS_7))
 (func infected_cumul_age30to39_EMS_7 (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7 deaths_age30to39_EMS_7))    
 
-(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 N_age30to39_EMS_7))    
-(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) N_age30to39_EMS_7))    
+(func prevalence_age30to39_EMS_7 (/ infected_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
+(func seroprevalence_age30to39_EMS_7 (/ (+ infected_age30to39_EMS_7 recovered_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
 
-(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 N_age30to39_EMS_7))    
-(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) N_age30to39_EMS_7))    
+(func prevalence_det_age30to39_EMS_7 (/ infected_det_age30to39_EMS_7 (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
+(func seroprevalence_det_age30to39_EMS_7 (/ (+ infected_det_age30to39_EMS_7 recovered_det_age30to39_EMS_7) (- N_age30to39_EMS_7 deaths_age30to39_EMS_7)))    
 
 
 (func asymptomatic_age30to39_EMS_8  (+ As_age30to39::EMS_8 As_det1_age30to39::EMS_8))
@@ -5024,11 +5024,11 @@
 (func infected_det_age30to39_EMS_8 (+ infectious_det_age30to39_EMS_8 H1_det3_age30to39::EMS_8 H2_det3_age30to39::EMS_8 H3_det3_age30to39::EMS_8 C2_det3_age30to39::EMS_8 C3_det3_age30to39::EMS_8))
 (func infected_cumul_age30to39_EMS_8 (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8 deaths_age30to39_EMS_8))    
 
-(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 N_age30to39_EMS_8))    
-(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) N_age30to39_EMS_8))    
+(func prevalence_age30to39_EMS_8 (/ infected_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
+(func seroprevalence_age30to39_EMS_8 (/ (+ infected_age30to39_EMS_8 recovered_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
 
-(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 N_age30to39_EMS_8))    
-(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) N_age30to39_EMS_8))    
+(func prevalence_det_age30to39_EMS_8 (/ infected_det_age30to39_EMS_8 (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
+(func seroprevalence_det_age30to39_EMS_8 (/ (+ infected_det_age30to39_EMS_8 recovered_det_age30to39_EMS_8) (- N_age30to39_EMS_8 deaths_age30to39_EMS_8)))    
 
 
 (func asymptomatic_age30to39_EMS_9  (+ As_age30to39::EMS_9 As_det1_age30to39::EMS_9))
@@ -5077,11 +5077,11 @@
 (func infected_det_age30to39_EMS_9 (+ infectious_det_age30to39_EMS_9 H1_det3_age30to39::EMS_9 H2_det3_age30to39::EMS_9 H3_det3_age30to39::EMS_9 C2_det3_age30to39::EMS_9 C3_det3_age30to39::EMS_9))
 (func infected_cumul_age30to39_EMS_9 (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9 deaths_age30to39_EMS_9))    
 
-(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 N_age30to39_EMS_9))    
-(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) N_age30to39_EMS_9))    
+(func prevalence_age30to39_EMS_9 (/ infected_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
+(func seroprevalence_age30to39_EMS_9 (/ (+ infected_age30to39_EMS_9 recovered_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
 
-(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 N_age30to39_EMS_9))    
-(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) N_age30to39_EMS_9))    
+(func prevalence_det_age30to39_EMS_9 (/ infected_det_age30to39_EMS_9 (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
+(func seroprevalence_det_age30to39_EMS_9 (/ (+ infected_det_age30to39_EMS_9 recovered_det_age30to39_EMS_9) (- N_age30to39_EMS_9 deaths_age30to39_EMS_9)))    
 
 
 (func asymptomatic_age30to39_EMS_10  (+ As_age30to39::EMS_10 As_det1_age30to39::EMS_10))
@@ -5130,11 +5130,11 @@
 (func infected_det_age30to39_EMS_10 (+ infectious_det_age30to39_EMS_10 H1_det3_age30to39::EMS_10 H2_det3_age30to39::EMS_10 H3_det3_age30to39::EMS_10 C2_det3_age30to39::EMS_10 C3_det3_age30to39::EMS_10))
 (func infected_cumul_age30to39_EMS_10 (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10 deaths_age30to39_EMS_10))    
 
-(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 N_age30to39_EMS_10))    
-(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) N_age30to39_EMS_10))    
+(func prevalence_age30to39_EMS_10 (/ infected_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
+(func seroprevalence_age30to39_EMS_10 (/ (+ infected_age30to39_EMS_10 recovered_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
 
-(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 N_age30to39_EMS_10))    
-(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) N_age30to39_EMS_10))    
+(func prevalence_det_age30to39_EMS_10 (/ infected_det_age30to39_EMS_10 (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
+(func seroprevalence_det_age30to39_EMS_10 (/ (+ infected_det_age30to39_EMS_10 recovered_det_age30to39_EMS_10) (- N_age30to39_EMS_10 deaths_age30to39_EMS_10)))    
 
 
 (func asymptomatic_age30to39_EMS_11  (+ As_age30to39::EMS_11 As_det1_age30to39::EMS_11))
@@ -5183,11 +5183,11 @@
 (func infected_det_age30to39_EMS_11 (+ infectious_det_age30to39_EMS_11 H1_det3_age30to39::EMS_11 H2_det3_age30to39::EMS_11 H3_det3_age30to39::EMS_11 C2_det3_age30to39::EMS_11 C3_det3_age30to39::EMS_11))
 (func infected_cumul_age30to39_EMS_11 (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11 deaths_age30to39_EMS_11))    
 
-(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 N_age30to39_EMS_11))    
-(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) N_age30to39_EMS_11))    
+(func prevalence_age30to39_EMS_11 (/ infected_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
+(func seroprevalence_age30to39_EMS_11 (/ (+ infected_age30to39_EMS_11 recovered_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
 
-(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 N_age30to39_EMS_11))    
-(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) N_age30to39_EMS_11))    
+(func prevalence_det_age30to39_EMS_11 (/ infected_det_age30to39_EMS_11 (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
+(func seroprevalence_det_age30to39_EMS_11 (/ (+ infected_det_age30to39_EMS_11 recovered_det_age30to39_EMS_11) (- N_age30to39_EMS_11 deaths_age30to39_EMS_11)))    
 
 
 (func asymptomatic_age40to49_EMS_1  (+ As_age40to49::EMS_1 As_det1_age40to49::EMS_1))
@@ -5236,11 +5236,11 @@
 (func infected_det_age40to49_EMS_1 (+ infectious_det_age40to49_EMS_1 H1_det3_age40to49::EMS_1 H2_det3_age40to49::EMS_1 H3_det3_age40to49::EMS_1 C2_det3_age40to49::EMS_1 C3_det3_age40to49::EMS_1))
 (func infected_cumul_age40to49_EMS_1 (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1 deaths_age40to49_EMS_1))    
 
-(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 N_age40to49_EMS_1))    
-(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) N_age40to49_EMS_1))    
+(func prevalence_age40to49_EMS_1 (/ infected_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
+(func seroprevalence_age40to49_EMS_1 (/ (+ infected_age40to49_EMS_1 recovered_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
 
-(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 N_age40to49_EMS_1))    
-(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) N_age40to49_EMS_1))    
+(func prevalence_det_age40to49_EMS_1 (/ infected_det_age40to49_EMS_1 (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
+(func seroprevalence_det_age40to49_EMS_1 (/ (+ infected_det_age40to49_EMS_1 recovered_det_age40to49_EMS_1) (- N_age40to49_EMS_1 deaths_age40to49_EMS_1)))    
 
 
 (func asymptomatic_age40to49_EMS_2  (+ As_age40to49::EMS_2 As_det1_age40to49::EMS_2))
@@ -5289,11 +5289,11 @@
 (func infected_det_age40to49_EMS_2 (+ infectious_det_age40to49_EMS_2 H1_det3_age40to49::EMS_2 H2_det3_age40to49::EMS_2 H3_det3_age40to49::EMS_2 C2_det3_age40to49::EMS_2 C3_det3_age40to49::EMS_2))
 (func infected_cumul_age40to49_EMS_2 (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2 deaths_age40to49_EMS_2))    
 
-(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 N_age40to49_EMS_2))    
-(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) N_age40to49_EMS_2))    
+(func prevalence_age40to49_EMS_2 (/ infected_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
+(func seroprevalence_age40to49_EMS_2 (/ (+ infected_age40to49_EMS_2 recovered_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
 
-(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 N_age40to49_EMS_2))    
-(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) N_age40to49_EMS_2))    
+(func prevalence_det_age40to49_EMS_2 (/ infected_det_age40to49_EMS_2 (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
+(func seroprevalence_det_age40to49_EMS_2 (/ (+ infected_det_age40to49_EMS_2 recovered_det_age40to49_EMS_2) (- N_age40to49_EMS_2 deaths_age40to49_EMS_2)))    
 
 
 (func asymptomatic_age40to49_EMS_3  (+ As_age40to49::EMS_3 As_det1_age40to49::EMS_3))
@@ -5342,11 +5342,11 @@
 (func infected_det_age40to49_EMS_3 (+ infectious_det_age40to49_EMS_3 H1_det3_age40to49::EMS_3 H2_det3_age40to49::EMS_3 H3_det3_age40to49::EMS_3 C2_det3_age40to49::EMS_3 C3_det3_age40to49::EMS_3))
 (func infected_cumul_age40to49_EMS_3 (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3 deaths_age40to49_EMS_3))    
 
-(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 N_age40to49_EMS_3))    
-(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) N_age40to49_EMS_3))    
+(func prevalence_age40to49_EMS_3 (/ infected_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
+(func seroprevalence_age40to49_EMS_3 (/ (+ infected_age40to49_EMS_3 recovered_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
 
-(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 N_age40to49_EMS_3))    
-(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) N_age40to49_EMS_3))    
+(func prevalence_det_age40to49_EMS_3 (/ infected_det_age40to49_EMS_3 (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
+(func seroprevalence_det_age40to49_EMS_3 (/ (+ infected_det_age40to49_EMS_3 recovered_det_age40to49_EMS_3) (- N_age40to49_EMS_3 deaths_age40to49_EMS_3)))    
 
 
 (func asymptomatic_age40to49_EMS_4  (+ As_age40to49::EMS_4 As_det1_age40to49::EMS_4))
@@ -5395,11 +5395,11 @@
 (func infected_det_age40to49_EMS_4 (+ infectious_det_age40to49_EMS_4 H1_det3_age40to49::EMS_4 H2_det3_age40to49::EMS_4 H3_det3_age40to49::EMS_4 C2_det3_age40to49::EMS_4 C3_det3_age40to49::EMS_4))
 (func infected_cumul_age40to49_EMS_4 (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4 deaths_age40to49_EMS_4))    
 
-(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 N_age40to49_EMS_4))    
-(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) N_age40to49_EMS_4))    
+(func prevalence_age40to49_EMS_4 (/ infected_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
+(func seroprevalence_age40to49_EMS_4 (/ (+ infected_age40to49_EMS_4 recovered_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
 
-(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 N_age40to49_EMS_4))    
-(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) N_age40to49_EMS_4))    
+(func prevalence_det_age40to49_EMS_4 (/ infected_det_age40to49_EMS_4 (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
+(func seroprevalence_det_age40to49_EMS_4 (/ (+ infected_det_age40to49_EMS_4 recovered_det_age40to49_EMS_4) (- N_age40to49_EMS_4 deaths_age40to49_EMS_4)))    
 
 
 (func asymptomatic_age40to49_EMS_5  (+ As_age40to49::EMS_5 As_det1_age40to49::EMS_5))
@@ -5448,11 +5448,11 @@
 (func infected_det_age40to49_EMS_5 (+ infectious_det_age40to49_EMS_5 H1_det3_age40to49::EMS_5 H2_det3_age40to49::EMS_5 H3_det3_age40to49::EMS_5 C2_det3_age40to49::EMS_5 C3_det3_age40to49::EMS_5))
 (func infected_cumul_age40to49_EMS_5 (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5 deaths_age40to49_EMS_5))    
 
-(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 N_age40to49_EMS_5))    
-(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) N_age40to49_EMS_5))    
+(func prevalence_age40to49_EMS_5 (/ infected_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
+(func seroprevalence_age40to49_EMS_5 (/ (+ infected_age40to49_EMS_5 recovered_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
 
-(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 N_age40to49_EMS_5))    
-(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) N_age40to49_EMS_5))    
+(func prevalence_det_age40to49_EMS_5 (/ infected_det_age40to49_EMS_5 (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
+(func seroprevalence_det_age40to49_EMS_5 (/ (+ infected_det_age40to49_EMS_5 recovered_det_age40to49_EMS_5) (- N_age40to49_EMS_5 deaths_age40to49_EMS_5)))    
 
 
 (func asymptomatic_age40to49_EMS_6  (+ As_age40to49::EMS_6 As_det1_age40to49::EMS_6))
@@ -5501,11 +5501,11 @@
 (func infected_det_age40to49_EMS_6 (+ infectious_det_age40to49_EMS_6 H1_det3_age40to49::EMS_6 H2_det3_age40to49::EMS_6 H3_det3_age40to49::EMS_6 C2_det3_age40to49::EMS_6 C3_det3_age40to49::EMS_6))
 (func infected_cumul_age40to49_EMS_6 (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6 deaths_age40to49_EMS_6))    
 
-(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 N_age40to49_EMS_6))    
-(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) N_age40to49_EMS_6))    
+(func prevalence_age40to49_EMS_6 (/ infected_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
+(func seroprevalence_age40to49_EMS_6 (/ (+ infected_age40to49_EMS_6 recovered_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
 
-(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 N_age40to49_EMS_6))    
-(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) N_age40to49_EMS_6))    
+(func prevalence_det_age40to49_EMS_6 (/ infected_det_age40to49_EMS_6 (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
+(func seroprevalence_det_age40to49_EMS_6 (/ (+ infected_det_age40to49_EMS_6 recovered_det_age40to49_EMS_6) (- N_age40to49_EMS_6 deaths_age40to49_EMS_6)))    
 
 
 (func asymptomatic_age40to49_EMS_7  (+ As_age40to49::EMS_7 As_det1_age40to49::EMS_7))
@@ -5554,11 +5554,11 @@
 (func infected_det_age40to49_EMS_7 (+ infectious_det_age40to49_EMS_7 H1_det3_age40to49::EMS_7 H2_det3_age40to49::EMS_7 H3_det3_age40to49::EMS_7 C2_det3_age40to49::EMS_7 C3_det3_age40to49::EMS_7))
 (func infected_cumul_age40to49_EMS_7 (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7 deaths_age40to49_EMS_7))    
 
-(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 N_age40to49_EMS_7))    
-(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) N_age40to49_EMS_7))    
+(func prevalence_age40to49_EMS_7 (/ infected_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
+(func seroprevalence_age40to49_EMS_7 (/ (+ infected_age40to49_EMS_7 recovered_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
 
-(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 N_age40to49_EMS_7))    
-(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) N_age40to49_EMS_7))    
+(func prevalence_det_age40to49_EMS_7 (/ infected_det_age40to49_EMS_7 (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
+(func seroprevalence_det_age40to49_EMS_7 (/ (+ infected_det_age40to49_EMS_7 recovered_det_age40to49_EMS_7) (- N_age40to49_EMS_7 deaths_age40to49_EMS_7)))    
 
 
 (func asymptomatic_age40to49_EMS_8  (+ As_age40to49::EMS_8 As_det1_age40to49::EMS_8))
@@ -5607,11 +5607,11 @@
 (func infected_det_age40to49_EMS_8 (+ infectious_det_age40to49_EMS_8 H1_det3_age40to49::EMS_8 H2_det3_age40to49::EMS_8 H3_det3_age40to49::EMS_8 C2_det3_age40to49::EMS_8 C3_det3_age40to49::EMS_8))
 (func infected_cumul_age40to49_EMS_8 (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8 deaths_age40to49_EMS_8))    
 
-(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 N_age40to49_EMS_8))    
-(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) N_age40to49_EMS_8))    
+(func prevalence_age40to49_EMS_8 (/ infected_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
+(func seroprevalence_age40to49_EMS_8 (/ (+ infected_age40to49_EMS_8 recovered_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
 
-(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 N_age40to49_EMS_8))    
-(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) N_age40to49_EMS_8))    
+(func prevalence_det_age40to49_EMS_8 (/ infected_det_age40to49_EMS_8 (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
+(func seroprevalence_det_age40to49_EMS_8 (/ (+ infected_det_age40to49_EMS_8 recovered_det_age40to49_EMS_8) (- N_age40to49_EMS_8 deaths_age40to49_EMS_8)))    
 
 
 (func asymptomatic_age40to49_EMS_9  (+ As_age40to49::EMS_9 As_det1_age40to49::EMS_9))
@@ -5660,11 +5660,11 @@
 (func infected_det_age40to49_EMS_9 (+ infectious_det_age40to49_EMS_9 H1_det3_age40to49::EMS_9 H2_det3_age40to49::EMS_9 H3_det3_age40to49::EMS_9 C2_det3_age40to49::EMS_9 C3_det3_age40to49::EMS_9))
 (func infected_cumul_age40to49_EMS_9 (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9 deaths_age40to49_EMS_9))    
 
-(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 N_age40to49_EMS_9))    
-(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) N_age40to49_EMS_9))    
+(func prevalence_age40to49_EMS_9 (/ infected_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
+(func seroprevalence_age40to49_EMS_9 (/ (+ infected_age40to49_EMS_9 recovered_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
 
-(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 N_age40to49_EMS_9))    
-(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) N_age40to49_EMS_9))    
+(func prevalence_det_age40to49_EMS_9 (/ infected_det_age40to49_EMS_9 (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
+(func seroprevalence_det_age40to49_EMS_9 (/ (+ infected_det_age40to49_EMS_9 recovered_det_age40to49_EMS_9) (- N_age40to49_EMS_9 deaths_age40to49_EMS_9)))    
 
 
 (func asymptomatic_age40to49_EMS_10  (+ As_age40to49::EMS_10 As_det1_age40to49::EMS_10))
@@ -5713,11 +5713,11 @@
 (func infected_det_age40to49_EMS_10 (+ infectious_det_age40to49_EMS_10 H1_det3_age40to49::EMS_10 H2_det3_age40to49::EMS_10 H3_det3_age40to49::EMS_10 C2_det3_age40to49::EMS_10 C3_det3_age40to49::EMS_10))
 (func infected_cumul_age40to49_EMS_10 (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10 deaths_age40to49_EMS_10))    
 
-(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 N_age40to49_EMS_10))    
-(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) N_age40to49_EMS_10))    
+(func prevalence_age40to49_EMS_10 (/ infected_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
+(func seroprevalence_age40to49_EMS_10 (/ (+ infected_age40to49_EMS_10 recovered_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
 
-(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 N_age40to49_EMS_10))    
-(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) N_age40to49_EMS_10))    
+(func prevalence_det_age40to49_EMS_10 (/ infected_det_age40to49_EMS_10 (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
+(func seroprevalence_det_age40to49_EMS_10 (/ (+ infected_det_age40to49_EMS_10 recovered_det_age40to49_EMS_10) (- N_age40to49_EMS_10 deaths_age40to49_EMS_10)))    
 
 
 (func asymptomatic_age40to49_EMS_11  (+ As_age40to49::EMS_11 As_det1_age40to49::EMS_11))
@@ -5766,11 +5766,11 @@
 (func infected_det_age40to49_EMS_11 (+ infectious_det_age40to49_EMS_11 H1_det3_age40to49::EMS_11 H2_det3_age40to49::EMS_11 H3_det3_age40to49::EMS_11 C2_det3_age40to49::EMS_11 C3_det3_age40to49::EMS_11))
 (func infected_cumul_age40to49_EMS_11 (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11 deaths_age40to49_EMS_11))    
 
-(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 N_age40to49_EMS_11))    
-(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) N_age40to49_EMS_11))    
+(func prevalence_age40to49_EMS_11 (/ infected_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
+(func seroprevalence_age40to49_EMS_11 (/ (+ infected_age40to49_EMS_11 recovered_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
 
-(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 N_age40to49_EMS_11))    
-(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) N_age40to49_EMS_11))    
+(func prevalence_det_age40to49_EMS_11 (/ infected_det_age40to49_EMS_11 (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
+(func seroprevalence_det_age40to49_EMS_11 (/ (+ infected_det_age40to49_EMS_11 recovered_det_age40to49_EMS_11) (- N_age40to49_EMS_11 deaths_age40to49_EMS_11)))    
 
 
 (func asymptomatic_age50to59_EMS_1  (+ As_age50to59::EMS_1 As_det1_age50to59::EMS_1))
@@ -5819,11 +5819,11 @@
 (func infected_det_age50to59_EMS_1 (+ infectious_det_age50to59_EMS_1 H1_det3_age50to59::EMS_1 H2_det3_age50to59::EMS_1 H3_det3_age50to59::EMS_1 C2_det3_age50to59::EMS_1 C3_det3_age50to59::EMS_1))
 (func infected_cumul_age50to59_EMS_1 (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1 deaths_age50to59_EMS_1))    
 
-(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 N_age50to59_EMS_1))    
-(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) N_age50to59_EMS_1))    
+(func prevalence_age50to59_EMS_1 (/ infected_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
+(func seroprevalence_age50to59_EMS_1 (/ (+ infected_age50to59_EMS_1 recovered_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
 
-(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 N_age50to59_EMS_1))    
-(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) N_age50to59_EMS_1))    
+(func prevalence_det_age50to59_EMS_1 (/ infected_det_age50to59_EMS_1 (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
+(func seroprevalence_det_age50to59_EMS_1 (/ (+ infected_det_age50to59_EMS_1 recovered_det_age50to59_EMS_1) (- N_age50to59_EMS_1 deaths_age50to59_EMS_1)))    
 
 
 (func asymptomatic_age50to59_EMS_2  (+ As_age50to59::EMS_2 As_det1_age50to59::EMS_2))
@@ -5872,11 +5872,11 @@
 (func infected_det_age50to59_EMS_2 (+ infectious_det_age50to59_EMS_2 H1_det3_age50to59::EMS_2 H2_det3_age50to59::EMS_2 H3_det3_age50to59::EMS_2 C2_det3_age50to59::EMS_2 C3_det3_age50to59::EMS_2))
 (func infected_cumul_age50to59_EMS_2 (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2 deaths_age50to59_EMS_2))    
 
-(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 N_age50to59_EMS_2))    
-(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) N_age50to59_EMS_2))    
+(func prevalence_age50to59_EMS_2 (/ infected_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
+(func seroprevalence_age50to59_EMS_2 (/ (+ infected_age50to59_EMS_2 recovered_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
 
-(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 N_age50to59_EMS_2))    
-(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) N_age50to59_EMS_2))    
+(func prevalence_det_age50to59_EMS_2 (/ infected_det_age50to59_EMS_2 (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
+(func seroprevalence_det_age50to59_EMS_2 (/ (+ infected_det_age50to59_EMS_2 recovered_det_age50to59_EMS_2) (- N_age50to59_EMS_2 deaths_age50to59_EMS_2)))    
 
 
 (func asymptomatic_age50to59_EMS_3  (+ As_age50to59::EMS_3 As_det1_age50to59::EMS_3))
@@ -5925,11 +5925,11 @@
 (func infected_det_age50to59_EMS_3 (+ infectious_det_age50to59_EMS_3 H1_det3_age50to59::EMS_3 H2_det3_age50to59::EMS_3 H3_det3_age50to59::EMS_3 C2_det3_age50to59::EMS_3 C3_det3_age50to59::EMS_3))
 (func infected_cumul_age50to59_EMS_3 (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3 deaths_age50to59_EMS_3))    
 
-(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 N_age50to59_EMS_3))    
-(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) N_age50to59_EMS_3))    
+(func prevalence_age50to59_EMS_3 (/ infected_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
+(func seroprevalence_age50to59_EMS_3 (/ (+ infected_age50to59_EMS_3 recovered_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
 
-(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 N_age50to59_EMS_3))    
-(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) N_age50to59_EMS_3))    
+(func prevalence_det_age50to59_EMS_3 (/ infected_det_age50to59_EMS_3 (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
+(func seroprevalence_det_age50to59_EMS_3 (/ (+ infected_det_age50to59_EMS_3 recovered_det_age50to59_EMS_3) (- N_age50to59_EMS_3 deaths_age50to59_EMS_3)))    
 
 
 (func asymptomatic_age50to59_EMS_4  (+ As_age50to59::EMS_4 As_det1_age50to59::EMS_4))
@@ -5978,11 +5978,11 @@
 (func infected_det_age50to59_EMS_4 (+ infectious_det_age50to59_EMS_4 H1_det3_age50to59::EMS_4 H2_det3_age50to59::EMS_4 H3_det3_age50to59::EMS_4 C2_det3_age50to59::EMS_4 C3_det3_age50to59::EMS_4))
 (func infected_cumul_age50to59_EMS_4 (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4 deaths_age50to59_EMS_4))    
 
-(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 N_age50to59_EMS_4))    
-(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) N_age50to59_EMS_4))    
+(func prevalence_age50to59_EMS_4 (/ infected_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
+(func seroprevalence_age50to59_EMS_4 (/ (+ infected_age50to59_EMS_4 recovered_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
 
-(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 N_age50to59_EMS_4))    
-(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) N_age50to59_EMS_4))    
+(func prevalence_det_age50to59_EMS_4 (/ infected_det_age50to59_EMS_4 (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
+(func seroprevalence_det_age50to59_EMS_4 (/ (+ infected_det_age50to59_EMS_4 recovered_det_age50to59_EMS_4) (- N_age50to59_EMS_4 deaths_age50to59_EMS_4)))    
 
 
 (func asymptomatic_age50to59_EMS_5  (+ As_age50to59::EMS_5 As_det1_age50to59::EMS_5))
@@ -6031,11 +6031,11 @@
 (func infected_det_age50to59_EMS_5 (+ infectious_det_age50to59_EMS_5 H1_det3_age50to59::EMS_5 H2_det3_age50to59::EMS_5 H3_det3_age50to59::EMS_5 C2_det3_age50to59::EMS_5 C3_det3_age50to59::EMS_5))
 (func infected_cumul_age50to59_EMS_5 (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5 deaths_age50to59_EMS_5))    
 
-(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 N_age50to59_EMS_5))    
-(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) N_age50to59_EMS_5))    
+(func prevalence_age50to59_EMS_5 (/ infected_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
+(func seroprevalence_age50to59_EMS_5 (/ (+ infected_age50to59_EMS_5 recovered_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
 
-(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 N_age50to59_EMS_5))    
-(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) N_age50to59_EMS_5))    
+(func prevalence_det_age50to59_EMS_5 (/ infected_det_age50to59_EMS_5 (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
+(func seroprevalence_det_age50to59_EMS_5 (/ (+ infected_det_age50to59_EMS_5 recovered_det_age50to59_EMS_5) (- N_age50to59_EMS_5 deaths_age50to59_EMS_5)))    
 
 
 (func asymptomatic_age50to59_EMS_6  (+ As_age50to59::EMS_6 As_det1_age50to59::EMS_6))
@@ -6084,11 +6084,11 @@
 (func infected_det_age50to59_EMS_6 (+ infectious_det_age50to59_EMS_6 H1_det3_age50to59::EMS_6 H2_det3_age50to59::EMS_6 H3_det3_age50to59::EMS_6 C2_det3_age50to59::EMS_6 C3_det3_age50to59::EMS_6))
 (func infected_cumul_age50to59_EMS_6 (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6 deaths_age50to59_EMS_6))    
 
-(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 N_age50to59_EMS_6))    
-(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) N_age50to59_EMS_6))    
+(func prevalence_age50to59_EMS_6 (/ infected_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
+(func seroprevalence_age50to59_EMS_6 (/ (+ infected_age50to59_EMS_6 recovered_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
 
-(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 N_age50to59_EMS_6))    
-(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) N_age50to59_EMS_6))    
+(func prevalence_det_age50to59_EMS_6 (/ infected_det_age50to59_EMS_6 (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
+(func seroprevalence_det_age50to59_EMS_6 (/ (+ infected_det_age50to59_EMS_6 recovered_det_age50to59_EMS_6) (- N_age50to59_EMS_6 deaths_age50to59_EMS_6)))    
 
 
 (func asymptomatic_age50to59_EMS_7  (+ As_age50to59::EMS_7 As_det1_age50to59::EMS_7))
@@ -6137,11 +6137,11 @@
 (func infected_det_age50to59_EMS_7 (+ infectious_det_age50to59_EMS_7 H1_det3_age50to59::EMS_7 H2_det3_age50to59::EMS_7 H3_det3_age50to59::EMS_7 C2_det3_age50to59::EMS_7 C3_det3_age50to59::EMS_7))
 (func infected_cumul_age50to59_EMS_7 (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7 deaths_age50to59_EMS_7))    
 
-(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 N_age50to59_EMS_7))    
-(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) N_age50to59_EMS_7))    
+(func prevalence_age50to59_EMS_7 (/ infected_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
+(func seroprevalence_age50to59_EMS_7 (/ (+ infected_age50to59_EMS_7 recovered_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
 
-(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 N_age50to59_EMS_7))    
-(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) N_age50to59_EMS_7))    
+(func prevalence_det_age50to59_EMS_7 (/ infected_det_age50to59_EMS_7 (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
+(func seroprevalence_det_age50to59_EMS_7 (/ (+ infected_det_age50to59_EMS_7 recovered_det_age50to59_EMS_7) (- N_age50to59_EMS_7 deaths_age50to59_EMS_7)))    
 
 
 (func asymptomatic_age50to59_EMS_8  (+ As_age50to59::EMS_8 As_det1_age50to59::EMS_8))
@@ -6190,11 +6190,11 @@
 (func infected_det_age50to59_EMS_8 (+ infectious_det_age50to59_EMS_8 H1_det3_age50to59::EMS_8 H2_det3_age50to59::EMS_8 H3_det3_age50to59::EMS_8 C2_det3_age50to59::EMS_8 C3_det3_age50to59::EMS_8))
 (func infected_cumul_age50to59_EMS_8 (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8 deaths_age50to59_EMS_8))    
 
-(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 N_age50to59_EMS_8))    
-(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) N_age50to59_EMS_8))    
+(func prevalence_age50to59_EMS_8 (/ infected_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
+(func seroprevalence_age50to59_EMS_8 (/ (+ infected_age50to59_EMS_8 recovered_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
 
-(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 N_age50to59_EMS_8))    
-(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) N_age50to59_EMS_8))    
+(func prevalence_det_age50to59_EMS_8 (/ infected_det_age50to59_EMS_8 (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
+(func seroprevalence_det_age50to59_EMS_8 (/ (+ infected_det_age50to59_EMS_8 recovered_det_age50to59_EMS_8) (- N_age50to59_EMS_8 deaths_age50to59_EMS_8)))    
 
 
 (func asymptomatic_age50to59_EMS_9  (+ As_age50to59::EMS_9 As_det1_age50to59::EMS_9))
@@ -6243,11 +6243,11 @@
 (func infected_det_age50to59_EMS_9 (+ infectious_det_age50to59_EMS_9 H1_det3_age50to59::EMS_9 H2_det3_age50to59::EMS_9 H3_det3_age50to59::EMS_9 C2_det3_age50to59::EMS_9 C3_det3_age50to59::EMS_9))
 (func infected_cumul_age50to59_EMS_9 (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9 deaths_age50to59_EMS_9))    
 
-(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 N_age50to59_EMS_9))    
-(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) N_age50to59_EMS_9))    
+(func prevalence_age50to59_EMS_9 (/ infected_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
+(func seroprevalence_age50to59_EMS_9 (/ (+ infected_age50to59_EMS_9 recovered_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
 
-(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 N_age50to59_EMS_9))    
-(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) N_age50to59_EMS_9))    
+(func prevalence_det_age50to59_EMS_9 (/ infected_det_age50to59_EMS_9 (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
+(func seroprevalence_det_age50to59_EMS_9 (/ (+ infected_det_age50to59_EMS_9 recovered_det_age50to59_EMS_9) (- N_age50to59_EMS_9 deaths_age50to59_EMS_9)))    
 
 
 (func asymptomatic_age50to59_EMS_10  (+ As_age50to59::EMS_10 As_det1_age50to59::EMS_10))
@@ -6296,11 +6296,11 @@
 (func infected_det_age50to59_EMS_10 (+ infectious_det_age50to59_EMS_10 H1_det3_age50to59::EMS_10 H2_det3_age50to59::EMS_10 H3_det3_age50to59::EMS_10 C2_det3_age50to59::EMS_10 C3_det3_age50to59::EMS_10))
 (func infected_cumul_age50to59_EMS_10 (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10 deaths_age50to59_EMS_10))    
 
-(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 N_age50to59_EMS_10))    
-(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) N_age50to59_EMS_10))    
+(func prevalence_age50to59_EMS_10 (/ infected_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
+(func seroprevalence_age50to59_EMS_10 (/ (+ infected_age50to59_EMS_10 recovered_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
 
-(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 N_age50to59_EMS_10))    
-(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) N_age50to59_EMS_10))    
+(func prevalence_det_age50to59_EMS_10 (/ infected_det_age50to59_EMS_10 (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
+(func seroprevalence_det_age50to59_EMS_10 (/ (+ infected_det_age50to59_EMS_10 recovered_det_age50to59_EMS_10) (- N_age50to59_EMS_10 deaths_age50to59_EMS_10)))    
 
 
 (func asymptomatic_age50to59_EMS_11  (+ As_age50to59::EMS_11 As_det1_age50to59::EMS_11))
@@ -6349,11 +6349,11 @@
 (func infected_det_age50to59_EMS_11 (+ infectious_det_age50to59_EMS_11 H1_det3_age50to59::EMS_11 H2_det3_age50to59::EMS_11 H3_det3_age50to59::EMS_11 C2_det3_age50to59::EMS_11 C3_det3_age50to59::EMS_11))
 (func infected_cumul_age50to59_EMS_11 (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11 deaths_age50to59_EMS_11))    
 
-(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 N_age50to59_EMS_11))    
-(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) N_age50to59_EMS_11))    
+(func prevalence_age50to59_EMS_11 (/ infected_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
+(func seroprevalence_age50to59_EMS_11 (/ (+ infected_age50to59_EMS_11 recovered_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
 
-(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 N_age50to59_EMS_11))    
-(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) N_age50to59_EMS_11))    
+(func prevalence_det_age50to59_EMS_11 (/ infected_det_age50to59_EMS_11 (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
+(func seroprevalence_det_age50to59_EMS_11 (/ (+ infected_det_age50to59_EMS_11 recovered_det_age50to59_EMS_11) (- N_age50to59_EMS_11 deaths_age50to59_EMS_11)))    
 
 
 (func asymptomatic_age60to69_EMS_1  (+ As_age60to69::EMS_1 As_det1_age60to69::EMS_1))
@@ -6402,11 +6402,11 @@
 (func infected_det_age60to69_EMS_1 (+ infectious_det_age60to69_EMS_1 H1_det3_age60to69::EMS_1 H2_det3_age60to69::EMS_1 H3_det3_age60to69::EMS_1 C2_det3_age60to69::EMS_1 C3_det3_age60to69::EMS_1))
 (func infected_cumul_age60to69_EMS_1 (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1 deaths_age60to69_EMS_1))    
 
-(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 N_age60to69_EMS_1))    
-(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) N_age60to69_EMS_1))    
+(func prevalence_age60to69_EMS_1 (/ infected_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
+(func seroprevalence_age60to69_EMS_1 (/ (+ infected_age60to69_EMS_1 recovered_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
 
-(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 N_age60to69_EMS_1))    
-(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) N_age60to69_EMS_1))    
+(func prevalence_det_age60to69_EMS_1 (/ infected_det_age60to69_EMS_1 (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
+(func seroprevalence_det_age60to69_EMS_1 (/ (+ infected_det_age60to69_EMS_1 recovered_det_age60to69_EMS_1) (- N_age60to69_EMS_1 deaths_age60to69_EMS_1)))    
 
 
 (func asymptomatic_age60to69_EMS_2  (+ As_age60to69::EMS_2 As_det1_age60to69::EMS_2))
@@ -6455,11 +6455,11 @@
 (func infected_det_age60to69_EMS_2 (+ infectious_det_age60to69_EMS_2 H1_det3_age60to69::EMS_2 H2_det3_age60to69::EMS_2 H3_det3_age60to69::EMS_2 C2_det3_age60to69::EMS_2 C3_det3_age60to69::EMS_2))
 (func infected_cumul_age60to69_EMS_2 (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2 deaths_age60to69_EMS_2))    
 
-(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 N_age60to69_EMS_2))    
-(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) N_age60to69_EMS_2))    
+(func prevalence_age60to69_EMS_2 (/ infected_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
+(func seroprevalence_age60to69_EMS_2 (/ (+ infected_age60to69_EMS_2 recovered_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
 
-(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 N_age60to69_EMS_2))    
-(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) N_age60to69_EMS_2))    
+(func prevalence_det_age60to69_EMS_2 (/ infected_det_age60to69_EMS_2 (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
+(func seroprevalence_det_age60to69_EMS_2 (/ (+ infected_det_age60to69_EMS_2 recovered_det_age60to69_EMS_2) (- N_age60to69_EMS_2 deaths_age60to69_EMS_2)))    
 
 
 (func asymptomatic_age60to69_EMS_3  (+ As_age60to69::EMS_3 As_det1_age60to69::EMS_3))
@@ -6508,11 +6508,11 @@
 (func infected_det_age60to69_EMS_3 (+ infectious_det_age60to69_EMS_3 H1_det3_age60to69::EMS_3 H2_det3_age60to69::EMS_3 H3_det3_age60to69::EMS_3 C2_det3_age60to69::EMS_3 C3_det3_age60to69::EMS_3))
 (func infected_cumul_age60to69_EMS_3 (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3 deaths_age60to69_EMS_3))    
 
-(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 N_age60to69_EMS_3))    
-(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) N_age60to69_EMS_3))    
+(func prevalence_age60to69_EMS_3 (/ infected_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
+(func seroprevalence_age60to69_EMS_3 (/ (+ infected_age60to69_EMS_3 recovered_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
 
-(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 N_age60to69_EMS_3))    
-(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) N_age60to69_EMS_3))    
+(func prevalence_det_age60to69_EMS_3 (/ infected_det_age60to69_EMS_3 (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
+(func seroprevalence_det_age60to69_EMS_3 (/ (+ infected_det_age60to69_EMS_3 recovered_det_age60to69_EMS_3) (- N_age60to69_EMS_3 deaths_age60to69_EMS_3)))    
 
 
 (func asymptomatic_age60to69_EMS_4  (+ As_age60to69::EMS_4 As_det1_age60to69::EMS_4))
@@ -6561,11 +6561,11 @@
 (func infected_det_age60to69_EMS_4 (+ infectious_det_age60to69_EMS_4 H1_det3_age60to69::EMS_4 H2_det3_age60to69::EMS_4 H3_det3_age60to69::EMS_4 C2_det3_age60to69::EMS_4 C3_det3_age60to69::EMS_4))
 (func infected_cumul_age60to69_EMS_4 (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4 deaths_age60to69_EMS_4))    
 
-(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 N_age60to69_EMS_4))    
-(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) N_age60to69_EMS_4))    
+(func prevalence_age60to69_EMS_4 (/ infected_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
+(func seroprevalence_age60to69_EMS_4 (/ (+ infected_age60to69_EMS_4 recovered_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
 
-(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 N_age60to69_EMS_4))    
-(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) N_age60to69_EMS_4))    
+(func prevalence_det_age60to69_EMS_4 (/ infected_det_age60to69_EMS_4 (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
+(func seroprevalence_det_age60to69_EMS_4 (/ (+ infected_det_age60to69_EMS_4 recovered_det_age60to69_EMS_4) (- N_age60to69_EMS_4 deaths_age60to69_EMS_4)))    
 
 
 (func asymptomatic_age60to69_EMS_5  (+ As_age60to69::EMS_5 As_det1_age60to69::EMS_5))
@@ -6614,11 +6614,11 @@
 (func infected_det_age60to69_EMS_5 (+ infectious_det_age60to69_EMS_5 H1_det3_age60to69::EMS_5 H2_det3_age60to69::EMS_5 H3_det3_age60to69::EMS_5 C2_det3_age60to69::EMS_5 C3_det3_age60to69::EMS_5))
 (func infected_cumul_age60to69_EMS_5 (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5 deaths_age60to69_EMS_5))    
 
-(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 N_age60to69_EMS_5))    
-(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) N_age60to69_EMS_5))    
+(func prevalence_age60to69_EMS_5 (/ infected_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
+(func seroprevalence_age60to69_EMS_5 (/ (+ infected_age60to69_EMS_5 recovered_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
 
-(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 N_age60to69_EMS_5))    
-(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) N_age60to69_EMS_5))    
+(func prevalence_det_age60to69_EMS_5 (/ infected_det_age60to69_EMS_5 (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
+(func seroprevalence_det_age60to69_EMS_5 (/ (+ infected_det_age60to69_EMS_5 recovered_det_age60to69_EMS_5) (- N_age60to69_EMS_5 deaths_age60to69_EMS_5)))    
 
 
 (func asymptomatic_age60to69_EMS_6  (+ As_age60to69::EMS_6 As_det1_age60to69::EMS_6))
@@ -6667,11 +6667,11 @@
 (func infected_det_age60to69_EMS_6 (+ infectious_det_age60to69_EMS_6 H1_det3_age60to69::EMS_6 H2_det3_age60to69::EMS_6 H3_det3_age60to69::EMS_6 C2_det3_age60to69::EMS_6 C3_det3_age60to69::EMS_6))
 (func infected_cumul_age60to69_EMS_6 (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6 deaths_age60to69_EMS_6))    
 
-(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 N_age60to69_EMS_6))    
-(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) N_age60to69_EMS_6))    
+(func prevalence_age60to69_EMS_6 (/ infected_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
+(func seroprevalence_age60to69_EMS_6 (/ (+ infected_age60to69_EMS_6 recovered_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
 
-(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 N_age60to69_EMS_6))    
-(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) N_age60to69_EMS_6))    
+(func prevalence_det_age60to69_EMS_6 (/ infected_det_age60to69_EMS_6 (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
+(func seroprevalence_det_age60to69_EMS_6 (/ (+ infected_det_age60to69_EMS_6 recovered_det_age60to69_EMS_6) (- N_age60to69_EMS_6 deaths_age60to69_EMS_6)))    
 
 
 (func asymptomatic_age60to69_EMS_7  (+ As_age60to69::EMS_7 As_det1_age60to69::EMS_7))
@@ -6720,11 +6720,11 @@
 (func infected_det_age60to69_EMS_7 (+ infectious_det_age60to69_EMS_7 H1_det3_age60to69::EMS_7 H2_det3_age60to69::EMS_7 H3_det3_age60to69::EMS_7 C2_det3_age60to69::EMS_7 C3_det3_age60to69::EMS_7))
 (func infected_cumul_age60to69_EMS_7 (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7 deaths_age60to69_EMS_7))    
 
-(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 N_age60to69_EMS_7))    
-(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) N_age60to69_EMS_7))    
+(func prevalence_age60to69_EMS_7 (/ infected_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
+(func seroprevalence_age60to69_EMS_7 (/ (+ infected_age60to69_EMS_7 recovered_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
 
-(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 N_age60to69_EMS_7))    
-(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) N_age60to69_EMS_7))    
+(func prevalence_det_age60to69_EMS_7 (/ infected_det_age60to69_EMS_7 (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
+(func seroprevalence_det_age60to69_EMS_7 (/ (+ infected_det_age60to69_EMS_7 recovered_det_age60to69_EMS_7) (- N_age60to69_EMS_7 deaths_age60to69_EMS_7)))    
 
 
 (func asymptomatic_age60to69_EMS_8  (+ As_age60to69::EMS_8 As_det1_age60to69::EMS_8))
@@ -6773,11 +6773,11 @@
 (func infected_det_age60to69_EMS_8 (+ infectious_det_age60to69_EMS_8 H1_det3_age60to69::EMS_8 H2_det3_age60to69::EMS_8 H3_det3_age60to69::EMS_8 C2_det3_age60to69::EMS_8 C3_det3_age60to69::EMS_8))
 (func infected_cumul_age60to69_EMS_8 (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8 deaths_age60to69_EMS_8))    
 
-(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 N_age60to69_EMS_8))    
-(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) N_age60to69_EMS_8))    
+(func prevalence_age60to69_EMS_8 (/ infected_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
+(func seroprevalence_age60to69_EMS_8 (/ (+ infected_age60to69_EMS_8 recovered_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
 
-(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 N_age60to69_EMS_8))    
-(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) N_age60to69_EMS_8))    
+(func prevalence_det_age60to69_EMS_8 (/ infected_det_age60to69_EMS_8 (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
+(func seroprevalence_det_age60to69_EMS_8 (/ (+ infected_det_age60to69_EMS_8 recovered_det_age60to69_EMS_8) (- N_age60to69_EMS_8 deaths_age60to69_EMS_8)))    
 
 
 (func asymptomatic_age60to69_EMS_9  (+ As_age60to69::EMS_9 As_det1_age60to69::EMS_9))
@@ -6826,11 +6826,11 @@
 (func infected_det_age60to69_EMS_9 (+ infectious_det_age60to69_EMS_9 H1_det3_age60to69::EMS_9 H2_det3_age60to69::EMS_9 H3_det3_age60to69::EMS_9 C2_det3_age60to69::EMS_9 C3_det3_age60to69::EMS_9))
 (func infected_cumul_age60to69_EMS_9 (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9 deaths_age60to69_EMS_9))    
 
-(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 N_age60to69_EMS_9))    
-(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) N_age60to69_EMS_9))    
+(func prevalence_age60to69_EMS_9 (/ infected_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
+(func seroprevalence_age60to69_EMS_9 (/ (+ infected_age60to69_EMS_9 recovered_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
 
-(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 N_age60to69_EMS_9))    
-(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) N_age60to69_EMS_9))    
+(func prevalence_det_age60to69_EMS_9 (/ infected_det_age60to69_EMS_9 (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
+(func seroprevalence_det_age60to69_EMS_9 (/ (+ infected_det_age60to69_EMS_9 recovered_det_age60to69_EMS_9) (- N_age60to69_EMS_9 deaths_age60to69_EMS_9)))    
 
 
 (func asymptomatic_age60to69_EMS_10  (+ As_age60to69::EMS_10 As_det1_age60to69::EMS_10))
@@ -6879,11 +6879,11 @@
 (func infected_det_age60to69_EMS_10 (+ infectious_det_age60to69_EMS_10 H1_det3_age60to69::EMS_10 H2_det3_age60to69::EMS_10 H3_det3_age60to69::EMS_10 C2_det3_age60to69::EMS_10 C3_det3_age60to69::EMS_10))
 (func infected_cumul_age60to69_EMS_10 (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10 deaths_age60to69_EMS_10))    
 
-(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 N_age60to69_EMS_10))    
-(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) N_age60to69_EMS_10))    
+(func prevalence_age60to69_EMS_10 (/ infected_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
+(func seroprevalence_age60to69_EMS_10 (/ (+ infected_age60to69_EMS_10 recovered_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
 
-(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 N_age60to69_EMS_10))    
-(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) N_age60to69_EMS_10))    
+(func prevalence_det_age60to69_EMS_10 (/ infected_det_age60to69_EMS_10 (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
+(func seroprevalence_det_age60to69_EMS_10 (/ (+ infected_det_age60to69_EMS_10 recovered_det_age60to69_EMS_10) (- N_age60to69_EMS_10 deaths_age60to69_EMS_10)))    
 
 
 (func asymptomatic_age60to69_EMS_11  (+ As_age60to69::EMS_11 As_det1_age60to69::EMS_11))
@@ -6932,11 +6932,11 @@
 (func infected_det_age60to69_EMS_11 (+ infectious_det_age60to69_EMS_11 H1_det3_age60to69::EMS_11 H2_det3_age60to69::EMS_11 H3_det3_age60to69::EMS_11 C2_det3_age60to69::EMS_11 C3_det3_age60to69::EMS_11))
 (func infected_cumul_age60to69_EMS_11 (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11 deaths_age60to69_EMS_11))    
 
-(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 N_age60to69_EMS_11))    
-(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) N_age60to69_EMS_11))    
+(func prevalence_age60to69_EMS_11 (/ infected_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
+(func seroprevalence_age60to69_EMS_11 (/ (+ infected_age60to69_EMS_11 recovered_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
 
-(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 N_age60to69_EMS_11))    
-(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) N_age60to69_EMS_11))    
+(func prevalence_det_age60to69_EMS_11 (/ infected_det_age60to69_EMS_11 (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
+(func seroprevalence_det_age60to69_EMS_11 (/ (+ infected_det_age60to69_EMS_11 recovered_det_age60to69_EMS_11) (- N_age60to69_EMS_11 deaths_age60to69_EMS_11)))    
 
 
 (func asymptomatic_age70to100_EMS_1  (+ As_age70to100::EMS_1 As_det1_age70to100::EMS_1))
@@ -6985,11 +6985,11 @@
 (func infected_det_age70to100_EMS_1 (+ infectious_det_age70to100_EMS_1 H1_det3_age70to100::EMS_1 H2_det3_age70to100::EMS_1 H3_det3_age70to100::EMS_1 C2_det3_age70to100::EMS_1 C3_det3_age70to100::EMS_1))
 (func infected_cumul_age70to100_EMS_1 (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1 deaths_age70to100_EMS_1))    
 
-(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 N_age70to100_EMS_1))    
-(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) N_age70to100_EMS_1))    
+(func prevalence_age70to100_EMS_1 (/ infected_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
+(func seroprevalence_age70to100_EMS_1 (/ (+ infected_age70to100_EMS_1 recovered_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
 
-(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 N_age70to100_EMS_1))    
-(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) N_age70to100_EMS_1))    
+(func prevalence_det_age70to100_EMS_1 (/ infected_det_age70to100_EMS_1 (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
+(func seroprevalence_det_age70to100_EMS_1 (/ (+ infected_det_age70to100_EMS_1 recovered_det_age70to100_EMS_1) (- N_age70to100_EMS_1 deaths_age70to100_EMS_1)))    
 
 
 (func asymptomatic_age70to100_EMS_2  (+ As_age70to100::EMS_2 As_det1_age70to100::EMS_2))
@@ -7038,11 +7038,11 @@
 (func infected_det_age70to100_EMS_2 (+ infectious_det_age70to100_EMS_2 H1_det3_age70to100::EMS_2 H2_det3_age70to100::EMS_2 H3_det3_age70to100::EMS_2 C2_det3_age70to100::EMS_2 C3_det3_age70to100::EMS_2))
 (func infected_cumul_age70to100_EMS_2 (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2 deaths_age70to100_EMS_2))    
 
-(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 N_age70to100_EMS_2))    
-(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) N_age70to100_EMS_2))    
+(func prevalence_age70to100_EMS_2 (/ infected_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
+(func seroprevalence_age70to100_EMS_2 (/ (+ infected_age70to100_EMS_2 recovered_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
 
-(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 N_age70to100_EMS_2))    
-(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) N_age70to100_EMS_2))    
+(func prevalence_det_age70to100_EMS_2 (/ infected_det_age70to100_EMS_2 (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
+(func seroprevalence_det_age70to100_EMS_2 (/ (+ infected_det_age70to100_EMS_2 recovered_det_age70to100_EMS_2) (- N_age70to100_EMS_2 deaths_age70to100_EMS_2)))    
 
 
 (func asymptomatic_age70to100_EMS_3  (+ As_age70to100::EMS_3 As_det1_age70to100::EMS_3))
@@ -7091,11 +7091,11 @@
 (func infected_det_age70to100_EMS_3 (+ infectious_det_age70to100_EMS_3 H1_det3_age70to100::EMS_3 H2_det3_age70to100::EMS_3 H3_det3_age70to100::EMS_3 C2_det3_age70to100::EMS_3 C3_det3_age70to100::EMS_3))
 (func infected_cumul_age70to100_EMS_3 (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3 deaths_age70to100_EMS_3))    
 
-(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 N_age70to100_EMS_3))    
-(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) N_age70to100_EMS_3))    
+(func prevalence_age70to100_EMS_3 (/ infected_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
+(func seroprevalence_age70to100_EMS_3 (/ (+ infected_age70to100_EMS_3 recovered_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
 
-(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 N_age70to100_EMS_3))    
-(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) N_age70to100_EMS_3))    
+(func prevalence_det_age70to100_EMS_3 (/ infected_det_age70to100_EMS_3 (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
+(func seroprevalence_det_age70to100_EMS_3 (/ (+ infected_det_age70to100_EMS_3 recovered_det_age70to100_EMS_3) (- N_age70to100_EMS_3 deaths_age70to100_EMS_3)))    
 
 
 (func asymptomatic_age70to100_EMS_4  (+ As_age70to100::EMS_4 As_det1_age70to100::EMS_4))
@@ -7144,11 +7144,11 @@
 (func infected_det_age70to100_EMS_4 (+ infectious_det_age70to100_EMS_4 H1_det3_age70to100::EMS_4 H2_det3_age70to100::EMS_4 H3_det3_age70to100::EMS_4 C2_det3_age70to100::EMS_4 C3_det3_age70to100::EMS_4))
 (func infected_cumul_age70to100_EMS_4 (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4 deaths_age70to100_EMS_4))    
 
-(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 N_age70to100_EMS_4))    
-(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) N_age70to100_EMS_4))    
+(func prevalence_age70to100_EMS_4 (/ infected_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
+(func seroprevalence_age70to100_EMS_4 (/ (+ infected_age70to100_EMS_4 recovered_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
 
-(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 N_age70to100_EMS_4))    
-(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) N_age70to100_EMS_4))    
+(func prevalence_det_age70to100_EMS_4 (/ infected_det_age70to100_EMS_4 (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
+(func seroprevalence_det_age70to100_EMS_4 (/ (+ infected_det_age70to100_EMS_4 recovered_det_age70to100_EMS_4) (- N_age70to100_EMS_4 deaths_age70to100_EMS_4)))    
 
 
 (func asymptomatic_age70to100_EMS_5  (+ As_age70to100::EMS_5 As_det1_age70to100::EMS_5))
@@ -7197,11 +7197,11 @@
 (func infected_det_age70to100_EMS_5 (+ infectious_det_age70to100_EMS_5 H1_det3_age70to100::EMS_5 H2_det3_age70to100::EMS_5 H3_det3_age70to100::EMS_5 C2_det3_age70to100::EMS_5 C3_det3_age70to100::EMS_5))
 (func infected_cumul_age70to100_EMS_5 (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5 deaths_age70to100_EMS_5))    
 
-(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 N_age70to100_EMS_5))    
-(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) N_age70to100_EMS_5))    
+(func prevalence_age70to100_EMS_5 (/ infected_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
+(func seroprevalence_age70to100_EMS_5 (/ (+ infected_age70to100_EMS_5 recovered_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
 
-(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 N_age70to100_EMS_5))    
-(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) N_age70to100_EMS_5))    
+(func prevalence_det_age70to100_EMS_5 (/ infected_det_age70to100_EMS_5 (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
+(func seroprevalence_det_age70to100_EMS_5 (/ (+ infected_det_age70to100_EMS_5 recovered_det_age70to100_EMS_5) (- N_age70to100_EMS_5 deaths_age70to100_EMS_5)))    
 
 
 (func asymptomatic_age70to100_EMS_6  (+ As_age70to100::EMS_6 As_det1_age70to100::EMS_6))
@@ -7250,11 +7250,11 @@
 (func infected_det_age70to100_EMS_6 (+ infectious_det_age70to100_EMS_6 H1_det3_age70to100::EMS_6 H2_det3_age70to100::EMS_6 H3_det3_age70to100::EMS_6 C2_det3_age70to100::EMS_6 C3_det3_age70to100::EMS_6))
 (func infected_cumul_age70to100_EMS_6 (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6 deaths_age70to100_EMS_6))    
 
-(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 N_age70to100_EMS_6))    
-(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) N_age70to100_EMS_6))    
+(func prevalence_age70to100_EMS_6 (/ infected_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
+(func seroprevalence_age70to100_EMS_6 (/ (+ infected_age70to100_EMS_6 recovered_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
 
-(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 N_age70to100_EMS_6))    
-(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) N_age70to100_EMS_6))    
+(func prevalence_det_age70to100_EMS_6 (/ infected_det_age70to100_EMS_6 (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
+(func seroprevalence_det_age70to100_EMS_6 (/ (+ infected_det_age70to100_EMS_6 recovered_det_age70to100_EMS_6) (- N_age70to100_EMS_6 deaths_age70to100_EMS_6)))    
 
 
 (func asymptomatic_age70to100_EMS_7  (+ As_age70to100::EMS_7 As_det1_age70to100::EMS_7))
@@ -7303,11 +7303,11 @@
 (func infected_det_age70to100_EMS_7 (+ infectious_det_age70to100_EMS_7 H1_det3_age70to100::EMS_7 H2_det3_age70to100::EMS_7 H3_det3_age70to100::EMS_7 C2_det3_age70to100::EMS_7 C3_det3_age70to100::EMS_7))
 (func infected_cumul_age70to100_EMS_7 (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7 deaths_age70to100_EMS_7))    
 
-(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 N_age70to100_EMS_7))    
-(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) N_age70to100_EMS_7))    
+(func prevalence_age70to100_EMS_7 (/ infected_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
+(func seroprevalence_age70to100_EMS_7 (/ (+ infected_age70to100_EMS_7 recovered_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
 
-(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 N_age70to100_EMS_7))    
-(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) N_age70to100_EMS_7))    
+(func prevalence_det_age70to100_EMS_7 (/ infected_det_age70to100_EMS_7 (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
+(func seroprevalence_det_age70to100_EMS_7 (/ (+ infected_det_age70to100_EMS_7 recovered_det_age70to100_EMS_7) (- N_age70to100_EMS_7 deaths_age70to100_EMS_7)))    
 
 
 (func asymptomatic_age70to100_EMS_8  (+ As_age70to100::EMS_8 As_det1_age70to100::EMS_8))
@@ -7356,11 +7356,11 @@
 (func infected_det_age70to100_EMS_8 (+ infectious_det_age70to100_EMS_8 H1_det3_age70to100::EMS_8 H2_det3_age70to100::EMS_8 H3_det3_age70to100::EMS_8 C2_det3_age70to100::EMS_8 C3_det3_age70to100::EMS_8))
 (func infected_cumul_age70to100_EMS_8 (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8 deaths_age70to100_EMS_8))    
 
-(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 N_age70to100_EMS_8))    
-(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) N_age70to100_EMS_8))    
+(func prevalence_age70to100_EMS_8 (/ infected_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
+(func seroprevalence_age70to100_EMS_8 (/ (+ infected_age70to100_EMS_8 recovered_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
 
-(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 N_age70to100_EMS_8))    
-(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) N_age70to100_EMS_8))    
+(func prevalence_det_age70to100_EMS_8 (/ infected_det_age70to100_EMS_8 (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
+(func seroprevalence_det_age70to100_EMS_8 (/ (+ infected_det_age70to100_EMS_8 recovered_det_age70to100_EMS_8) (- N_age70to100_EMS_8 deaths_age70to100_EMS_8)))    
 
 
 (func asymptomatic_age70to100_EMS_9  (+ As_age70to100::EMS_9 As_det1_age70to100::EMS_9))
@@ -7409,11 +7409,11 @@
 (func infected_det_age70to100_EMS_9 (+ infectious_det_age70to100_EMS_9 H1_det3_age70to100::EMS_9 H2_det3_age70to100::EMS_9 H3_det3_age70to100::EMS_9 C2_det3_age70to100::EMS_9 C3_det3_age70to100::EMS_9))
 (func infected_cumul_age70to100_EMS_9 (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9 deaths_age70to100_EMS_9))    
 
-(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 N_age70to100_EMS_9))    
-(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) N_age70to100_EMS_9))    
+(func prevalence_age70to100_EMS_9 (/ infected_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
+(func seroprevalence_age70to100_EMS_9 (/ (+ infected_age70to100_EMS_9 recovered_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
 
-(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 N_age70to100_EMS_9))    
-(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) N_age70to100_EMS_9))    
+(func prevalence_det_age70to100_EMS_9 (/ infected_det_age70to100_EMS_9 (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
+(func seroprevalence_det_age70to100_EMS_9 (/ (+ infected_det_age70to100_EMS_9 recovered_det_age70to100_EMS_9) (- N_age70to100_EMS_9 deaths_age70to100_EMS_9)))    
 
 
 (func asymptomatic_age70to100_EMS_10  (+ As_age70to100::EMS_10 As_det1_age70to100::EMS_10))
@@ -7462,11 +7462,11 @@
 (func infected_det_age70to100_EMS_10 (+ infectious_det_age70to100_EMS_10 H1_det3_age70to100::EMS_10 H2_det3_age70to100::EMS_10 H3_det3_age70to100::EMS_10 C2_det3_age70to100::EMS_10 C3_det3_age70to100::EMS_10))
 (func infected_cumul_age70to100_EMS_10 (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10 deaths_age70to100_EMS_10))    
 
-(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 N_age70to100_EMS_10))    
-(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) N_age70to100_EMS_10))    
+(func prevalence_age70to100_EMS_10 (/ infected_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
+(func seroprevalence_age70to100_EMS_10 (/ (+ infected_age70to100_EMS_10 recovered_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
 
-(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 N_age70to100_EMS_10))    
-(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) N_age70to100_EMS_10))    
+(func prevalence_det_age70to100_EMS_10 (/ infected_det_age70to100_EMS_10 (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
+(func seroprevalence_det_age70to100_EMS_10 (/ (+ infected_det_age70to100_EMS_10 recovered_det_age70to100_EMS_10) (- N_age70to100_EMS_10 deaths_age70to100_EMS_10)))    
 
 
 (func asymptomatic_age70to100_EMS_11  (+ As_age70to100::EMS_11 As_det1_age70to100::EMS_11))
@@ -7515,11 +7515,11 @@
 (func infected_det_age70to100_EMS_11 (+ infectious_det_age70to100_EMS_11 H1_det3_age70to100::EMS_11 H2_det3_age70to100::EMS_11 H3_det3_age70to100::EMS_11 C2_det3_age70to100::EMS_11 C3_det3_age70to100::EMS_11))
 (func infected_cumul_age70to100_EMS_11 (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11 deaths_age70to100_EMS_11))    
 
-(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 N_age70to100_EMS_11))    
-(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) N_age70to100_EMS_11))    
+(func prevalence_age70to100_EMS_11 (/ infected_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
+(func seroprevalence_age70to100_EMS_11 (/ (+ infected_age70to100_EMS_11 recovered_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
 
-(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 N_age70to100_EMS_11))    
-(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) N_age70to100_EMS_11))    
+(func prevalence_det_age70to100_EMS_11 (/ infected_det_age70to100_EMS_11 (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
+(func seroprevalence_det_age70to100_EMS_11 (/ (+ infected_det_age70to100_EMS_11 recovered_det_age70to100_EMS_11) (- N_age70to100_EMS_11 deaths_age70to100_EMS_11)))    
 
 
 (observe susceptible_All (+ S_age0to9::EMS_1 S_age0to9::EMS_2 S_age0to9::EMS_3 S_age0to9::EMS_4 S_age0to9::EMS_5 S_age0to9::EMS_6 S_age0to9::EMS_7 S_age0to9::EMS_8 S_age0to9::EMS_9 S_age0to9::EMS_10 S_age0to9::EMS_11 S_age10to19::EMS_1 S_age10to19::EMS_2 S_age10to19::EMS_3 S_age10to19::EMS_4 S_age10to19::EMS_5 S_age10to19::EMS_6 S_age10to19::EMS_7 S_age10to19::EMS_8 S_age10to19::EMS_9 S_age10to19::EMS_10 S_age10to19::EMS_11 S_age20to29::EMS_1 S_age20to29::EMS_2 S_age20to29::EMS_3 S_age20to29::EMS_4 S_age20to29::EMS_5 S_age20to29::EMS_6 S_age20to29::EMS_7 S_age20to29::EMS_8 S_age20to29::EMS_9 S_age20to29::EMS_10 S_age20to29::EMS_11 S_age30to39::EMS_1 S_age30to39::EMS_2 S_age30to39::EMS_3 S_age30to39::EMS_4 S_age30to39::EMS_5 S_age30to39::EMS_6 S_age30to39::EMS_7 S_age30to39::EMS_8 S_age30to39::EMS_9 S_age30to39::EMS_10 S_age30to39::EMS_11 S_age40to49::EMS_1 S_age40to49::EMS_2 S_age40to49::EMS_3 S_age40to49::EMS_4 S_age40to49::EMS_5 S_age40to49::EMS_6 S_age40to49::EMS_7 S_age40to49::EMS_8 S_age40to49::EMS_9 S_age40to49::EMS_10 S_age40to49::EMS_11 S_age50to59::EMS_1 S_age50to59::EMS_2 S_age50to59::EMS_3 S_age50to59::EMS_4 S_age50to59::EMS_5 S_age50to59::EMS_6 S_age50to59::EMS_7 S_age50to59::EMS_8 S_age50to59::EMS_9 S_age50to59::EMS_10 S_age50to59::EMS_11 S_age60to69::EMS_1 S_age60to69::EMS_2 S_age60to69::EMS_3 S_age60to69::EMS_4 S_age60to69::EMS_5 S_age60to69::EMS_6 S_age60to69::EMS_7 S_age60to69::EMS_8 S_age60to69::EMS_9 S_age60to69::EMS_10 S_age60to69::EMS_11 S_age70to100::EMS_1 S_age70to100::EMS_2 S_age70to100::EMS_3 S_age70to100::EMS_4 S_age70to100::EMS_5 S_age70to100::EMS_6 S_age70to100::EMS_7 S_age70to100::EMS_8 S_age70to100::EMS_9 S_age70to100::EMS_10 S_age70to100::EMS_11))
@@ -12087,12 +12087,14 @@
 (param Ki_red3b_EMS_1 (* Ki_EMS_1 @ki_multiplier_3b_EMS_1@))
 (param Ki_red3c_EMS_1 (* Ki_EMS_1 @ki_multiplier_3c_EMS_1@))
 (param Ki_red4_EMS_1 (* Ki_EMS_1 @ki_multiplier_4_EMS_1@))
+(param Ki_red5_EMS_1 (* Ki_EMS_1 @ki_multiplier_5_EMS_1@))
 (param Ki_red6_EMS_1 (* Ki_EMS_1 @ki_multiplier_6_EMS_1@))
 (param Ki_red7_EMS_1 (* Ki_EMS_1 @ki_multiplier_7_EMS_1@))
 (param Ki_red8_EMS_1 (* Ki_EMS_1 @ki_multiplier_8_EMS_1@))
 (param Ki_red9_EMS_1 (* Ki_EMS_1 @ki_multiplier_9_EMS_1@))
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
+(param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
 
 (param backtonormal_multiplier_1_EMS_1  (/ (- Ki_red6_EMS_1  Ki_red4_EMS_1 ) (- Ki_EMS_1 Ki_red4_EMS_1 ) ) )  
 (observe backtonormal_multiplier_1_EMS_1 backtonormal_multiplier_1_EMS_1)
@@ -12101,23 +12103,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_1 Ki_red3c_EMS_1)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_1 Ki_red4_EMS_1)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_1 Ki_red5_EMS_1)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_1 Ki_red6_EMS_1)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_1 Ki_red7_EMS_1)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_1 Ki_red8_EMS_1)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_1 Ki_red9_EMS_1)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
 (param Ki_red3c_EMS_2 (* Ki_EMS_2 @ki_multiplier_3c_EMS_2@))
 (param Ki_red4_EMS_2 (* Ki_EMS_2 @ki_multiplier_4_EMS_2@))
+(param Ki_red5_EMS_2 (* Ki_EMS_2 @ki_multiplier_5_EMS_2@))
 (param Ki_red6_EMS_2 (* Ki_EMS_2 @ki_multiplier_6_EMS_2@))
 (param Ki_red7_EMS_2 (* Ki_EMS_2 @ki_multiplier_7_EMS_2@))
 (param Ki_red8_EMS_2 (* Ki_EMS_2 @ki_multiplier_8_EMS_2@))
 (param Ki_red9_EMS_2 (* Ki_EMS_2 @ki_multiplier_9_EMS_2@))
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
+(param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
 
 (param backtonormal_multiplier_1_EMS_2  (/ (- Ki_red6_EMS_2  Ki_red4_EMS_2 ) (- Ki_EMS_2 Ki_red4_EMS_2 ) ) )  
 (observe backtonormal_multiplier_1_EMS_2 backtonormal_multiplier_1_EMS_2)
@@ -12126,23 +12132,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_2 Ki_red3c_EMS_2)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_2 Ki_red4_EMS_2)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_2 Ki_red5_EMS_2)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_2 Ki_red6_EMS_2)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_2 Ki_red7_EMS_2)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_2 Ki_red8_EMS_2)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_2 Ki_red9_EMS_2)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
 (param Ki_red3c_EMS_3 (* Ki_EMS_3 @ki_multiplier_3c_EMS_3@))
 (param Ki_red4_EMS_3 (* Ki_EMS_3 @ki_multiplier_4_EMS_3@))
+(param Ki_red5_EMS_3 (* Ki_EMS_3 @ki_multiplier_5_EMS_3@))
 (param Ki_red6_EMS_3 (* Ki_EMS_3 @ki_multiplier_6_EMS_3@))
 (param Ki_red7_EMS_3 (* Ki_EMS_3 @ki_multiplier_7_EMS_3@))
 (param Ki_red8_EMS_3 (* Ki_EMS_3 @ki_multiplier_8_EMS_3@))
 (param Ki_red9_EMS_3 (* Ki_EMS_3 @ki_multiplier_9_EMS_3@))
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
+(param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
 
 (param backtonormal_multiplier_1_EMS_3  (/ (- Ki_red6_EMS_3  Ki_red4_EMS_3 ) (- Ki_EMS_3 Ki_red4_EMS_3 ) ) )  
 (observe backtonormal_multiplier_1_EMS_3 backtonormal_multiplier_1_EMS_3)
@@ -12151,23 +12161,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_3 Ki_red3c_EMS_3)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_3 Ki_red4_EMS_3)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_3 Ki_red5_EMS_3)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_3 Ki_red6_EMS_3)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_3 Ki_red7_EMS_3)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_3 Ki_red8_EMS_3)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_3 Ki_red9_EMS_3)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
 (param Ki_red3c_EMS_4 (* Ki_EMS_4 @ki_multiplier_3c_EMS_4@))
 (param Ki_red4_EMS_4 (* Ki_EMS_4 @ki_multiplier_4_EMS_4@))
+(param Ki_red5_EMS_4 (* Ki_EMS_4 @ki_multiplier_5_EMS_4@))
 (param Ki_red6_EMS_4 (* Ki_EMS_4 @ki_multiplier_6_EMS_4@))
 (param Ki_red7_EMS_4 (* Ki_EMS_4 @ki_multiplier_7_EMS_4@))
 (param Ki_red8_EMS_4 (* Ki_EMS_4 @ki_multiplier_8_EMS_4@))
 (param Ki_red9_EMS_4 (* Ki_EMS_4 @ki_multiplier_9_EMS_4@))
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
+(param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
 
 (param backtonormal_multiplier_1_EMS_4  (/ (- Ki_red6_EMS_4  Ki_red4_EMS_4 ) (- Ki_EMS_4 Ki_red4_EMS_4 ) ) )  
 (observe backtonormal_multiplier_1_EMS_4 backtonormal_multiplier_1_EMS_4)
@@ -12176,23 +12190,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_4 Ki_red3c_EMS_4)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_4 Ki_red4_EMS_4)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_4 Ki_red5_EMS_4)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_4 Ki_red6_EMS_4)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_4 Ki_red7_EMS_4)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_4 Ki_red8_EMS_4)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_4 Ki_red9_EMS_4)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
 (param Ki_red3c_EMS_5 (* Ki_EMS_5 @ki_multiplier_3c_EMS_5@))
 (param Ki_red4_EMS_5 (* Ki_EMS_5 @ki_multiplier_4_EMS_5@))
+(param Ki_red5_EMS_5 (* Ki_EMS_5 @ki_multiplier_5_EMS_5@))
 (param Ki_red6_EMS_5 (* Ki_EMS_5 @ki_multiplier_6_EMS_5@))
 (param Ki_red7_EMS_5 (* Ki_EMS_5 @ki_multiplier_7_EMS_5@))
 (param Ki_red8_EMS_5 (* Ki_EMS_5 @ki_multiplier_8_EMS_5@))
 (param Ki_red9_EMS_5 (* Ki_EMS_5 @ki_multiplier_9_EMS_5@))
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
+(param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
 
 (param backtonormal_multiplier_1_EMS_5  (/ (- Ki_red6_EMS_5  Ki_red4_EMS_5 ) (- Ki_EMS_5 Ki_red4_EMS_5 ) ) )  
 (observe backtonormal_multiplier_1_EMS_5 backtonormal_multiplier_1_EMS_5)
@@ -12201,23 +12219,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_5 Ki_red3c_EMS_5)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_5 Ki_red4_EMS_5)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_5 Ki_red5_EMS_5)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_5 Ki_red6_EMS_5)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_5 Ki_red7_EMS_5)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_5 Ki_red8_EMS_5)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_5 Ki_red9_EMS_5)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
 (param Ki_red3c_EMS_6 (* Ki_EMS_6 @ki_multiplier_3c_EMS_6@))
 (param Ki_red4_EMS_6 (* Ki_EMS_6 @ki_multiplier_4_EMS_6@))
+(param Ki_red5_EMS_6 (* Ki_EMS_6 @ki_multiplier_5_EMS_6@))
 (param Ki_red6_EMS_6 (* Ki_EMS_6 @ki_multiplier_6_EMS_6@))
 (param Ki_red7_EMS_6 (* Ki_EMS_6 @ki_multiplier_7_EMS_6@))
 (param Ki_red8_EMS_6 (* Ki_EMS_6 @ki_multiplier_8_EMS_6@))
 (param Ki_red9_EMS_6 (* Ki_EMS_6 @ki_multiplier_9_EMS_6@))
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
+(param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
 
 (param backtonormal_multiplier_1_EMS_6  (/ (- Ki_red6_EMS_6  Ki_red4_EMS_6 ) (- Ki_EMS_6 Ki_red4_EMS_6 ) ) )  
 (observe backtonormal_multiplier_1_EMS_6 backtonormal_multiplier_1_EMS_6)
@@ -12226,23 +12248,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_6 Ki_red3c_EMS_6)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_6 Ki_red4_EMS_6)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_6 Ki_red5_EMS_6)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_6 Ki_red6_EMS_6)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_6 Ki_red7_EMS_6)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_6 Ki_red8_EMS_6)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_6 Ki_red9_EMS_6)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
 (param Ki_red3c_EMS_7 (* Ki_EMS_7 @ki_multiplier_3c_EMS_7@))
 (param Ki_red4_EMS_7 (* Ki_EMS_7 @ki_multiplier_4_EMS_7@))
+(param Ki_red5_EMS_7 (* Ki_EMS_7 @ki_multiplier_5_EMS_7@))
 (param Ki_red6_EMS_7 (* Ki_EMS_7 @ki_multiplier_6_EMS_7@))
 (param Ki_red7_EMS_7 (* Ki_EMS_7 @ki_multiplier_7_EMS_7@))
 (param Ki_red8_EMS_7 (* Ki_EMS_7 @ki_multiplier_8_EMS_7@))
 (param Ki_red9_EMS_7 (* Ki_EMS_7 @ki_multiplier_9_EMS_7@))
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
+(param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
 
 (param backtonormal_multiplier_1_EMS_7  (/ (- Ki_red6_EMS_7  Ki_red4_EMS_7 ) (- Ki_EMS_7 Ki_red4_EMS_7 ) ) )  
 (observe backtonormal_multiplier_1_EMS_7 backtonormal_multiplier_1_EMS_7)
@@ -12251,23 +12277,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_7 Ki_red3c_EMS_7)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_7 Ki_red4_EMS_7)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_7 Ki_red5_EMS_7)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_7 Ki_red6_EMS_7)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_7 Ki_red7_EMS_7)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_7 Ki_red8_EMS_7)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_7 Ki_red9_EMS_7)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
 (param Ki_red3c_EMS_8 (* Ki_EMS_8 @ki_multiplier_3c_EMS_8@))
 (param Ki_red4_EMS_8 (* Ki_EMS_8 @ki_multiplier_4_EMS_8@))
+(param Ki_red5_EMS_8 (* Ki_EMS_8 @ki_multiplier_5_EMS_8@))
 (param Ki_red6_EMS_8 (* Ki_EMS_8 @ki_multiplier_6_EMS_8@))
 (param Ki_red7_EMS_8 (* Ki_EMS_8 @ki_multiplier_7_EMS_8@))
 (param Ki_red8_EMS_8 (* Ki_EMS_8 @ki_multiplier_8_EMS_8@))
 (param Ki_red9_EMS_8 (* Ki_EMS_8 @ki_multiplier_9_EMS_8@))
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
+(param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
 
 (param backtonormal_multiplier_1_EMS_8  (/ (- Ki_red6_EMS_8  Ki_red4_EMS_8 ) (- Ki_EMS_8 Ki_red4_EMS_8 ) ) )  
 (observe backtonormal_multiplier_1_EMS_8 backtonormal_multiplier_1_EMS_8)
@@ -12276,23 +12306,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_8 Ki_red3c_EMS_8)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_8 Ki_red4_EMS_8)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_8 Ki_red5_EMS_8)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_8 Ki_red6_EMS_8)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_8 Ki_red7_EMS_8)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_8 Ki_red8_EMS_8)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_8 Ki_red9_EMS_8)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
 (param Ki_red3c_EMS_9 (* Ki_EMS_9 @ki_multiplier_3c_EMS_9@))
 (param Ki_red4_EMS_9 (* Ki_EMS_9 @ki_multiplier_4_EMS_9@))
+(param Ki_red5_EMS_9 (* Ki_EMS_9 @ki_multiplier_5_EMS_9@))
 (param Ki_red6_EMS_9 (* Ki_EMS_9 @ki_multiplier_6_EMS_9@))
 (param Ki_red7_EMS_9 (* Ki_EMS_9 @ki_multiplier_7_EMS_9@))
 (param Ki_red8_EMS_9 (* Ki_EMS_9 @ki_multiplier_8_EMS_9@))
 (param Ki_red9_EMS_9 (* Ki_EMS_9 @ki_multiplier_9_EMS_9@))
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
+(param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
 
 (param backtonormal_multiplier_1_EMS_9  (/ (- Ki_red6_EMS_9  Ki_red4_EMS_9 ) (- Ki_EMS_9 Ki_red4_EMS_9 ) ) )  
 (observe backtonormal_multiplier_1_EMS_9 backtonormal_multiplier_1_EMS_9)
@@ -12301,23 +12335,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_9 Ki_red3c_EMS_9)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_9 Ki_red4_EMS_9)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_9 Ki_red5_EMS_9)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_9 Ki_red6_EMS_9)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_9 Ki_red7_EMS_9)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_9 Ki_red8_EMS_9)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_9 Ki_red9_EMS_9)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
 (param Ki_red3c_EMS_10 (* Ki_EMS_10 @ki_multiplier_3c_EMS_10@))
 (param Ki_red4_EMS_10 (* Ki_EMS_10 @ki_multiplier_4_EMS_10@))
+(param Ki_red5_EMS_10 (* Ki_EMS_10 @ki_multiplier_5_EMS_10@))
 (param Ki_red6_EMS_10 (* Ki_EMS_10 @ki_multiplier_6_EMS_10@))
 (param Ki_red7_EMS_10 (* Ki_EMS_10 @ki_multiplier_7_EMS_10@))
 (param Ki_red8_EMS_10 (* Ki_EMS_10 @ki_multiplier_8_EMS_10@))
 (param Ki_red9_EMS_10 (* Ki_EMS_10 @ki_multiplier_9_EMS_10@))
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
+(param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
 
 (param backtonormal_multiplier_1_EMS_10  (/ (- Ki_red6_EMS_10  Ki_red4_EMS_10 ) (- Ki_EMS_10 Ki_red4_EMS_10 ) ) )  
 (observe backtonormal_multiplier_1_EMS_10 backtonormal_multiplier_1_EMS_10)
@@ -12326,23 +12364,27 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_10 Ki_red3c_EMS_10)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_10 Ki_red4_EMS_10)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_10 Ki_red5_EMS_10)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_10 Ki_red6_EMS_10)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_10 Ki_red7_EMS_10)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_10 Ki_red8_EMS_10)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_10 Ki_red9_EMS_10)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
 (param Ki_red3c_EMS_11 (* Ki_EMS_11 @ki_multiplier_3c_EMS_11@))
 (param Ki_red4_EMS_11 (* Ki_EMS_11 @ki_multiplier_4_EMS_11@))
+(param Ki_red5_EMS_11 (* Ki_EMS_11 @ki_multiplier_5_EMS_11@))
 (param Ki_red6_EMS_11 (* Ki_EMS_11 @ki_multiplier_6_EMS_11@))
 (param Ki_red7_EMS_11 (* Ki_EMS_11 @ki_multiplier_7_EMS_11@))
 (param Ki_red8_EMS_11 (* Ki_EMS_11 @ki_multiplier_8_EMS_11@))
 (param Ki_red9_EMS_11 (* Ki_EMS_11 @ki_multiplier_9_EMS_11@))
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
+(param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
 
 (param backtonormal_multiplier_1_EMS_11  (/ (- Ki_red6_EMS_11  Ki_red4_EMS_11 ) (- Ki_EMS_11 Ki_red4_EMS_11 ) ) )  
 (observe backtonormal_multiplier_1_EMS_11 backtonormal_multiplier_1_EMS_11)
@@ -12351,12 +12393,14 @@
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
 (time-event ki_multiplier_change_3c @ki_multiplier_time_3c@ ((Ki_EMS_11 Ki_red3c_EMS_11)))
 (time-event ki_multiplier_change_4 @ki_multiplier_time_4@ ((Ki_EMS_11 Ki_red4_EMS_11)))
+(time-event ki_multiplier_change_5 @ki_multiplier_time_5@ ((Ki_EMS_11 Ki_red5_EMS_11)))
 (time-event ki_multiplier_change_6 @ki_multiplier_time_6@ ((Ki_EMS_11 Ki_red6_EMS_11)))
 (time-event ki_multiplier_change_7 @ki_multiplier_time_7@ ((Ki_EMS_11 Ki_red7_EMS_11)))
 (time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki_EMS_11 Ki_red8_EMS_11)))
 (time-event ki_multiplier_change_9 @ki_multiplier_time_9@ ((Ki_EMS_11 Ki_red9_EMS_11)))
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
+(time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl_generators/emodl_generator_age.py
+++ b/emodl_generators/emodl_generator_age.py
@@ -131,11 +131,6 @@ def write_observe(grp, observeLevel='primary'):
 (observe infectious_det_{grp} infectious_det_{grp})
 (observe infectious_det_symp_{grp} infectious_det_symp_{grp})
 (observe infectious_det_AsP_{grp} infectious_det_AsP_{grp})
-
-(observe prevalence_{grp} prevalence_{grp})    
-(observe seroprevalence_{grp} seroprevalence_{grp} )
-(observe prevalence_det_{grp} prevalence_det_{grp})    
-(observe seroprevalence_det_{grp} seroprevalence_det_{grp} )
 """.format(grp=grp)
 
     if observeLevel == 'primary' :
@@ -182,13 +177,6 @@ def write_functions(grp, expandModel=None):
 (func infected_{grp} (+ infectious_det_{grp} infectious_undet_{grp} H1_det3_{grp} H2_det3_{grp} H3_det3_{grp} C2_det3_{grp} C3_det3_{grp}))
 (func infected_det_{grp} (+ infectious_det_{grp} H1_det3_{grp} H2_det3_{grp} H3_det3_{grp} C2_det3_{grp} C3_det3_{grp}))
 (func infected_cumul_{grp} (+ infected_{grp} recovered_{grp} deaths_{grp}))    
-
-(func prevalence_{grp} (/ infected_{grp} (- N_{grp} deaths_{grp} )))    
-(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) (- N_{grp} deaths_{grp} )))    
-
-(func prevalence_det_{grp} (/ infected_det_{grp} (- N_{grp} deaths_{grp} )))    
-(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) (- N_{grp} deaths_{grp} )))    
-
 """.format(grp=grp)
 
 
@@ -611,18 +599,12 @@ def write_All(grpList, observeLevel='primary'):
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe symptomatic_mild_det_All (+ " + repeat_string_by_grp(  'symptomatic_mild_det_', grpList) + "))"
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe symptomatic_severe_det_All (+ " + repeat_string_by_grp( 'symptomatic_severe_det_', grpList) + "))"
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe recovered_det_All (+ " + repeat_string_by_grp('recovered_det_',    grpList) + "))"   
-    
-    
+
     obs_tertiary_All_str = ""
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_All (+ " + repeat_string_by_grp('infectious_det_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_undet_All (+ " + repeat_string_by_grp( 'infectious_undet_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_symp_All (+ " + repeat_string_by_grp('infectious_det_symp_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_AsP_All (+ " + repeat_string_by_grp( 'infectious_det_AsP_', grpList) + "))"
-   
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_All (+ " + repeat_string_by_grp( 'prevalence_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_All (+ " + repeat_string_by_grp( 'seroprevalence_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_det_All (+ " + repeat_string_by_grp( 'prevalence_det_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_det_All (+ " + repeat_string_by_grp( 'seroprevalence_det_', grpList) + "))"
 
     if observeLevel == 'primary' :
         obs_All_str = obs_primary_All_str

--- a/emodl_generators/emodl_generator_age.py
+++ b/emodl_generators/emodl_generator_age.py
@@ -183,11 +183,11 @@ def write_functions(grp, expandModel=None):
 (func infected_det_{grp} (+ infectious_det_{grp} H1_det3_{grp} H2_det3_{grp} H3_det3_{grp} C2_det3_{grp} C3_det3_{grp}))
 (func infected_cumul_{grp} (+ infected_{grp} recovered_{grp} deaths_{grp}))    
 
-(func prevalence_{grp} (/ infected_{grp} N_{grp}))    
-(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) N_{grp}))    
+(func prevalence_{grp} (/ infected_{grp} (- N_{grp} deaths_{grp} )))    
+(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) (- N_{grp} deaths_{grp} )))    
 
-(func prevalence_det_{grp} (/ infected_det_{grp} N_{grp}))    
-(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) N_{grp}))    
+(func prevalence_det_{grp} (/ infected_det_{grp} (- N_{grp} deaths_{grp} )))    
+(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) (- N_{grp} deaths_{grp} )))    
 
 """.format(grp=grp)
 

--- a/emodl_generators/emodl_generator_age_locale.py
+++ b/emodl_generators/emodl_generator_age_locale.py
@@ -178,11 +178,6 @@ def write_observe(age, region, observeLevel='primary'):
 (observe infectious_det_{age}_{grpout} infectious_det_{age}_{region})
 (observe infectious_det_symp_{age}_{grpout} infectious_det_symp_{age}_{region})
 (observe infectious_det_AsP_{age}_{grpout} infectious_det_AsP_{age}_{region})
-
-(observe prevalence_{age}_{grpout} prevalence_{age}_{region})    
-(observe seroprevalence_{age}_{grpout} seroprevalence_{age}_{region} )
-(observe prevalence_det_{age}_{grpout} prevalence_det_{age}_{region})    
-(observe seroprevalence_det_{age}_{grpout} seroprevalence_det_{age}_{region} )
 """.format(grpout=grpout, age=age, region=region)
 
     if observeLevel == 'primary' :
@@ -248,13 +243,6 @@ def write_functions(age, region, expandModel=None):
 (func infected_{age}_{region} (+ infectious_det_{age}_{region} infectious_undet_{age}_{region} H1_det3_{age}::{region} H2_det3_{age}::{region} H3_det3_{age}::{region} C2_det3_{age}::{region} C3_det3_{age}::{region}))
 (func infected_det_{age}_{region} (+ infectious_det_{age}_{region} H1_det3_{age}::{region} H2_det3_{age}::{region} H3_det3_{age}::{region} C2_det3_{age}::{region} C3_det3_{age}::{region}))
 (func infected_cumul_{age}_{region} (+ infected_{age}_{region} recovered_{age}_{region} deaths_{age}_{region}))    
-
-(func prevalence_{age}_{region} (/ infected_{age}_{region} (- N_{age}_{region} deaths_{age}_{region})))    
-(func seroprevalence_{age}_{region} (/ (+ infected_{age}_{region} recovered_{age}_{region}) (- N_{age}_{region} deaths_{age}_{region})))    
-
-(func prevalence_det_{age}_{region} (/ infected_det_{age}_{region} (- N_{age}_{region} deaths_{age}_{region})))    
-(func seroprevalence_det_{age}_{region} (/ (+ infected_det_{age}_{region} recovered_det_{age}_{region}) (- N_{age}_{region} deaths_{age}_{region})))    
-
 """.format(age=age, region=region)
     
 
@@ -537,11 +525,6 @@ def write_All(ageList, regionList, observeLevel='primary'):
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_undet_All (+ " + repeat_string_by_grp( 'infectious_undet_',  ageList, regionList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_symp_All (+ " + repeat_string_by_grp('infectious_det_symp_',  ageList, regionList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_AsP_All (+ " + repeat_string_by_grp( 'infectious_det_AsP_',  ageList, regionList) + "))"
-   
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_All (+ " + repeat_string_by_grp( 'prevalence_',  ageList, regionList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_All (+ " + repeat_string_by_grp( 'seroprevalence_',  ageList, regionList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_det_All (+ " + repeat_string_by_grp( 'prevalence_det_',  ageList, regionList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_det_All (+ " + repeat_string_by_grp( 'seroprevalence_det_',  ageList, regionList) + "))"
 
     if observeLevel == 'primary' :
         obs_All_str = obs_primary_All_str

--- a/emodl_generators/emodl_generator_age_locale.py
+++ b/emodl_generators/emodl_generator_age_locale.py
@@ -249,11 +249,11 @@ def write_functions(age, region, expandModel=None):
 (func infected_det_{age}_{region} (+ infectious_det_{age}_{region} H1_det3_{age}::{region} H2_det3_{age}::{region} H3_det3_{age}::{region} C2_det3_{age}::{region} C3_det3_{age}::{region}))
 (func infected_cumul_{age}_{region} (+ infected_{age}_{region} recovered_{age}_{region} deaths_{age}_{region}))    
 
-(func prevalence_{age}_{region} (/ infected_{age}_{region} N_{age}_{region}))    
-(func seroprevalence_{age}_{region} (/ (+ infected_{age}_{region} recovered_{age}_{region}) N_{age}_{region}))    
+(func prevalence_{age}_{region} (/ infected_{age}_{region} (- N_{age}_{region} deaths_{age}_{region})))    
+(func seroprevalence_{age}_{region} (/ (+ infected_{age}_{region} recovered_{age}_{region}) (- N_{age}_{region} deaths_{age}_{region})))    
 
-(func prevalence_det_{age}_{region} (/ infected_det_{age}_{region} N_{age}_{region}))    
-(func seroprevalence_det_{age}_{region} (/ (+ infected_det_{age}_{region} recovered_det_{age}_{region}) N_{age}_{region}))    
+(func prevalence_det_{age}_{region} (/ infected_det_{age}_{region} (- N_{age}_{region} deaths_{age}_{region})))    
+(func seroprevalence_det_{age}_{region} (/ (+ infected_det_{age}_{region} recovered_det_{age}_{region}) (- N_{age}_{region} deaths_{age}_{region})))    
 
 """.format(age=age, region=region)
     

--- a/emodl_generators/emodl_generator_base.py
+++ b/emodl_generators/emodl_generator_base.py
@@ -177,12 +177,11 @@ def write_functions(expandModel=None):
 (func infected_det (+ infectious_det H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
 (func infected_cumul (+ infected recovered deaths))    
 
-(func prevalence (/ infected N))    
-(func seroprevalence (/ (+ infected recovered) N))    
+(func prevalence (/ infected (- N deaths)))    
+(func seroprevalence (/ (+ infected recovered) (- N deaths)))    
 
-(func prevalence_det (/ infected_det N))    
-(func seroprevalence_det (/ (+ infected_det recovered_det) N))    
-
+(func prevalence_det (/ infected_det (- N deaths)))    
+(func seroprevalence_det (/ (+ infected_det recovered_det) (- N deaths)))    
 """
 
 

--- a/emodl_generators/emodl_generator_base.py
+++ b/emodl_generators/emodl_generator_base.py
@@ -125,10 +125,6 @@ def write_observe(observeLevel='primary'):
 (observe infectious_det infectious_det)
 (observe infectious_det_symp infectious_det_symp)
 (observe infectious_det_AsP infectious_det_AsP)
-(observe prevalence prevalence)    
-(observe seroprevalence seroprevalence )
-(observe prevalence_det prevalence_det)    
-(observe seroprevalence_det seroprevalence_det )
 """
 
     if observeLevel == 'primary' :
@@ -175,13 +171,7 @@ def write_functions(expandModel=None):
 
 (func infected (+ infectious_det infectious_undet H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
 (func infected_det (+ infectious_det H1_det3 H2_det3 H3_det3 C2_det3 C3_det3))
-(func infected_cumul (+ infected recovered deaths))    
-
-(func prevalence (/ infected (- N deaths)))    
-(func seroprevalence (/ (+ infected recovered) (- N deaths)))    
-
-(func prevalence_det (/ infected_det (- N deaths)))    
-(func seroprevalence_det (/ (+ infected_det recovered_det) (- N deaths)))    
+(func infected_cumul (+ infected recovered deaths))      
 """
 
 
@@ -794,7 +784,7 @@ def write_interventions( total_string, scenarioName, change_testDelay=None, trig
 
 ###stringing all of my functions together to make the file:
 
-def generate_emodl( file_output, expandModel, add_interventions, observeLevel='secondary', trigger_channel=None, change_testDelay =None):
+def generate_emodl( file_output, expandModel, add_interventions, observeLevel='all', trigger_channel=None, change_testDelay =None):
     if (os.path.exists(file_output)):
         os.remove(file_output)
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -84,8 +84,10 @@ def write_observe(grp, observeLevel='primary'):
     observe_primary_channels_str = """
 (observe susceptible_{grpout} S::{grp})
 (observe infected_{grpout} infected_{grp})
+(observe infected_det_{grpout} infected_det_{grp})
 (observe recovered_{grpout} recovered_{grp})
 (observe infected_cumul_{grpout} infected_cumul_{grp})
+(observe infected_det_cumul_{grpout} infected_det_cumul_{grp})
 
 (observe asymp_cumul_{grpout} asymp_cumul_{grp} )
 (observe asymp_det_cumul_{grpout} asymp_det_cumul_{grp})
@@ -135,11 +137,6 @@ def write_observe(grp, observeLevel='primary'):
 (observe infectious_det_{grpout} infectious_det_{grp})
 (observe infectious_det_symp_{grpout} infectious_det_symp_{grp})
 (observe infectious_det_AsP_{grpout} infectious_det_AsP_{grp})
-
-(observe prevalence_{grpout} prevalence_{grp})    
-(observe seroprevalence_{grpout} seroprevalence_{grp} )
-(observe prevalence_det_{grpout} prevalence_det_{grp})    
-(observe seroprevalence_det_{grpout} seroprevalence_det_{grp} )
 """.format(grpout=grpout, grp=grp)
 
     if observeLevel == 'primary' :
@@ -186,14 +183,8 @@ def write_functions(grp, expandModel=None):
 
 (func infected_{grp} (+ infectious_det_{grp} infectious_undet_{grp} H1_det3::{grp} H2_det3::{grp} H3_det3::{grp} C2_det3::{grp} C3_det3::{grp}))
 (func infected_det_{grp} (+ infectious_det_{grp} H1_det3::{grp} H2_det3::{grp} H3_det3::{grp} C2_det3::{grp} C3_det3::{grp}))
-(func infected_cumul_{grp} (+ infected_{grp} recovered_{grp} deaths_{grp}))    
-
-(func prevalence_{grp} (/ infected_{grp} (- N_{grp} deaths_{grp} )))    
-(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) (- N_{grp} deaths_{grp} )))    
-
-(func prevalence_det_{grp} (/ infected_det_{grp} (- N_{grp} deaths_{grp} )))    
-(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) (- N_{grp} deaths_{grp} )))    
-
+(func infected_cumul_{grp} (+ infected_{grp} recovered_{grp} deaths_{grp}))   
+(func infected_det_cumul_{grp} (+ infected_det_{grp} recovered_det_{grp} D3_det3::{grp}))    
 """.format(grp=grp)
     
 
@@ -424,7 +415,8 @@ def write_N_population(grpList):
         stringAll = stringAll + string1
 
     string2 = "\n(param N_All (+ " + repeat_string_by_grp('N_', grpList) + "))"
-    stringAll = stringAll + string2
+    string3 = "\n(observe N_All N_All)"
+    stringAll = stringAll + string2 + string3
 
     return (stringAll)
 
@@ -439,13 +431,18 @@ def repeat_string_by_grp(fixedstring, grpList):
 
 
 def write_All(grpList, observeLevel='primary'):
-    
+
+    obs_primary_All_str = ""
+
     obs_primary_All_str = ""
     obs_primary_All_str = obs_primary_All_str + "\n(observe susceptible_All (+ " + repeat_string_by_grp('S::', grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe infected_All (+ " + repeat_string_by_grp('infected_', grpList) + "))"
+    obs_primary_All_str = obs_primary_All_str + "\n(observe infected_det_All (+ " + repeat_string_by_grp( 'infected_det_', grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe recovered_All (+ " + repeat_string_by_grp('recovered_',    grpList) + "))"
+    obs_primary_All_str = obs_primary_All_str + "\n(observe recovered_det_All (+ " + repeat_string_by_grp('recovered_det_',    grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe infected_cumul_All (+ " + repeat_string_by_grp('infected_cumul_', grpList) + "))"
- 
+    obs_primary_All_str = obs_primary_All_str + "\n(observe infected_det_cumul_All (+ " + repeat_string_by_grp('infected_det_cumul_', grpList) + "))"
+
     obs_primary_All_str = obs_primary_All_str + "\n(observe asymp_cumul_All (+ " + repeat_string_by_grp( 'asymp_cumul_', grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe asymp_det_cumul_All (+ " + repeat_string_by_grp( 'asymp_det_cumul_', grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe symptomatic_mild_All (+ " + repeat_string_by_grp(  'symptomatic_mild_', grpList) + "))"
@@ -471,7 +468,7 @@ def write_All(grpList, observeLevel='primary'):
     obs_primary_All_str = obs_primary_All_str + "\n(observe hosp_det_All (+ " + repeat_string_by_grp('hosp_det_', grpList) + "))"
     obs_primary_All_str = obs_primary_All_str + "\n(observe hospitalized_All (+ " + repeat_string_by_grp('hospitalized_', grpList) + "))"    
     
-    
+
     obs_secondary_All_str = ""
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe exposed_All (+ " + repeat_string_by_grp('E::',  grpList) + "))"
     
@@ -485,19 +482,14 @@ def write_All(grpList, observeLevel='primary'):
     
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe symptomatic_mild_det_All (+ " + repeat_string_by_grp(  'symptomatic_mild_det_', grpList) + "))"
     obs_secondary_All_str = obs_secondary_All_str + "\n(observe symptomatic_severe_det_All (+ " + repeat_string_by_grp( 'symptomatic_severe_det_', grpList) + "))"
-    obs_secondary_All_str = obs_secondary_All_str + "\n(observe recovered_det_All (+ " + repeat_string_by_grp('recovered_det_',    grpList) + "))"   
-    
+
     
     obs_tertiary_All_str = ""
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_All (+ " + repeat_string_by_grp('infectious_det_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_undet_All (+ " + repeat_string_by_grp( 'infectious_undet_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_symp_All (+ " + repeat_string_by_grp('infectious_det_symp_', grpList) + "))"
     obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe infectious_det_AsP_All (+ " + repeat_string_by_grp( 'infectious_det_AsP_', grpList) + "))"
-   
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_All (+ " + repeat_string_by_grp( 'prevalence_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_All (+ " + repeat_string_by_grp( 'seroprevalence_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe prevalence_det_All (+ " + repeat_string_by_grp( 'prevalence_det_', grpList) + "))"
-    obs_tertiary_All_str = obs_tertiary_All_str + "\n(observe seroprevalence_det_All (+ " + repeat_string_by_grp( 'seroprevalence_det_', grpList) + "))"
+
 
     if observeLevel == 'primary' :
         obs_All_str = obs_primary_All_str
@@ -521,6 +513,7 @@ def write_Custom_Groups(grpDic,observeLevel):
         obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe infected_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp('infected_', grpList) + "))"
         obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe recovered_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp('recovered_',    grpList) + "))"
         obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe infected_cumul_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp('infected_cumul_', grpList) + "))"
+        obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe infected_det_cumul_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp('infected_det_cumul_', grpList) + "))"
 
         obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe asymp_cumul_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'asymp_cumul_', grpList) + "))"
         obs_customGrp_primary_str = obs_customGrp_primary_str + """\n(observe asymp_det_cumul_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'asymp_det_cumul_', grpList) + "))"
@@ -570,11 +563,6 @@ def write_Custom_Groups(grpDic,observeLevel):
         obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe infectious_det_symp_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp('infectious_det_symp_', grpList) + "))"
         obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe infectious_det_AsP_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'infectious_det_AsP_', grpList) + "))"
 
-        obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe prevalence_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'prevalence_', grpList) + "))"
-        obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe seroprevalence_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'seroprevalence_', grpList) + "))"
-        obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe prevalence_det_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'prevalence_det_', grpList) + "))"
-        obs_customGrp_tertiary_str = obs_customGrp_tertiary_str + """\n(observe seroprevalence_det_{obs_customGrp} (+ """.format(obs_customGrp=obs_customGrp) + repeat_string_by_grp( 'seroprevalence_det_', grpList) + "))"
-    
         if observeLevel == 'primary' :
             obs_customGrp_str = obs_customGrp_primary_str
         if observeLevel == 'secondary' :
@@ -1211,6 +1199,7 @@ if __name__ == '__main__':
     ### Emodls without migration between EMS areas
     generateBaselineReopeningEmodls = True
     if generateBaselineReopeningEmodls:
+        generate_emodl(grpList=ems_grp, expandModel="testDelay_AsSymSys", add_interventions='continuedSIP', observeLevel='all',  add_migration=False, observe_customGroups = False, file_output=os.path.join(emodl_dir, 'extendedmodel_obsall_EMS.emodl'))
         generate_emodl(grpList=ems_grp, expandModel="testDelay_AsSymSys", add_interventions='continuedSIP', add_migration=False, observe_customGroups = False, file_output=os.path.join(emodl_dir, 'extendedmodel_EMS.emodl'))
         generate_emodl(grpList=ems_grp, expandModel="testDelay_AsSymSys", add_interventions='rollback', add_migration=False, observe_customGroups = False, file_output=os.path.join(emodl_dir, 'extendedmodel_EMS_rollback.emodl'))
         generate_emodl(grpList=ems_grp, expandModel="testDelay_AsSymSys", add_interventions='reopen_rollback', add_migration=False, observe_customGroups = False, file_output=os.path.join(emodl_dir, 'extendedmodel_EMS_reopen_rollback.emodl'))

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -188,11 +188,11 @@ def write_functions(grp, expandModel=None):
 (func infected_det_{grp} (+ infectious_det_{grp} H1_det3::{grp} H2_det3::{grp} H3_det3::{grp} C2_det3::{grp} C3_det3::{grp}))
 (func infected_cumul_{grp} (+ infected_{grp} recovered_{grp} deaths_{grp}))    
 
-(func prevalence_{grp} (/ infected_{grp} N_{grp}))    
-(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) N_{grp}))    
+(func prevalence_{grp} (/ infected_{grp} (- N_{grp} deaths_{grp} )))    
+(func seroprevalence_{grp} (/ (+ infected_{grp} recovered_{grp}) (- N_{grp} deaths_{grp} )))    
 
-(func prevalence_det_{grp} (/ infected_det_{grp} N_{grp}))    
-(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) N_{grp}))    
+(func prevalence_det_{grp} (/ infected_det_{grp} (- N_{grp} deaths_{grp} )))    
+(func seroprevalence_det_{grp} (/ (+ infected_det_{grp} recovered_det_{grp}) (- N_{grp} deaths_{grp} )))    
 
 """.format(grp=grp)
     

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -57,7 +57,7 @@ def trim_trajectories(simpath, scenario, colnames, ems):
 
 def plot_prevalences(exp_name, first_day, last_day, channels, fname='trajectoriesDat.csv'):
 
-    ems = ['All'] +  ['EMS-%d' % x for x in range(1, 12)]
+    ems = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
     get_det =0
     for ch in channels:
         if 'det' in ch: get_det = get_det + 1
@@ -74,7 +74,8 @@ def plot_prevalences(exp_name, first_day, last_day, channels, fname='trajectorie
                 column_list.append('infected_det_cumul_' + str(ems_num))
                 column_list.append('recovered_det_' + str(ems_num))
                 column_list.append('deaths_det_' + str(ems_num))
-        df = load_sim_data(exp_name, region_suffix=None, fname=fname, column_list=column_list, add_incidence=False, add_prevalence = True)
+        df = load_sim_data(exp_name, region_suffix=None, fname=fname, column_list=column_list, add_incidence=False)
+        df = calculate_prevalence(df,ems=ems)
         #df.to_csv(os.path.join(wdir, 'simulation_output', exp_name, "prevalenceDat.csv"), index=False, date_format='%Y-%m-%d')
 
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import matplotlib.pyplot as plt
 import sys
+
 sys.path.append('../')
 from load_paths import load_box_paths
 import matplotlib as mpl
@@ -10,9 +11,11 @@ import matplotlib.dates as mdates
 from datetime import date, timedelta, datetime
 import seaborn as sns
 from processing_helpers import *
-#from plotting.colors import load_color_palette
+
+# from plotting.colors import load_color_palette
 
 mpl.rcParams['pdf.fonttype'] = 42
+
 
 def parse_args():
     description = "Simulation run for modeling Covid-19"
@@ -39,52 +42,66 @@ def parse_args():
     )
     return parser.parse_args()
 
-def trim_trajectories(simpath, scenario, colnames, ems) :
+
+def trim_trajectories(simpath, scenario, colnames, ems):
     """also see plotter 'trim_trajectoriesDat.py' """
-    df = pd.read_csv(os.path.join(simpath, 'trajectoriesDat.csv' ))
-    df = df.rename(columns={ 'N_EMS_%d' % ems_num : 'N_EMS-%d' % ems_num for ems_num in range(1,12)})
+    df = pd.read_csv(os.path.join(simpath, 'trajectoriesDat.csv'))
+    df = df.rename(columns={'N_EMS_%d' % ems_num: 'N_EMS-%d' % ems_num for ems_num in range(1, 12)})
     df['N_All'] = df['susceptible_All'] + df['exposed_All'] + df['infected_All'] + df['recovered_All']
     keep_cols = ['%s_%s' % (x, y) for x in colnames for y in ems]
     df['startdate'] = pd.to_datetime(df['startdate'])
-    df['date'] = df.apply(lambda x : x['startdate'] + timedelta(days=x['time']), axis=1)
+    df['date'] = df.apply(lambda x: x['startdate'] + timedelta(days=x['time']), axis=1)
     df = df[['date'] + keep_cols]
     df.to_csv(os.path.join(simpath, 'trimmed_trajectoriesDat_%s.csv' % scenario), index=False)
 
 
-def plot_prevalences(exp_name,first_day,last_day, channels = ['prevalence'], fname='trajectoriesDat.csv',save_fname="prevalenceDat.csv"):
+def count_2weeks_before(df, curr_ch):
+    ch_list = list(df[curr_ch].values)
+    diff = [ch_list[x - 14] for x in range(1, len(df))]
+    return diff
 
+
+def plot_prevalences(exp_name, first_day, last_day, channels=['prevalence'], fname='trajectoriesDat.csv'):
     ems = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
-    column_list = ['time', 'startdate', 'scen_num','run_num','sample_num', 'infected_All', 'susceptible_All', 'exposed_All', 'recovered_All']
+    column_list = ['time', 'startdate', 'scen_num', 'run_num', 'sample_num']
     for ems_num in ems:
+        if not ems_num == "All":
+            column_list.append('N_' + str(ems_num.replace("EMS-", "EMS_"))) # Fixed pop
         column_list.append('infected_' + str(ems_num))
         column_list.append('exposed_' + str(ems_num))
         column_list.append('recovered_' + str(ems_num))
         column_list.append('susceptible_' + str(ems_num))
 
     df = load_sim_data(exp_name, region_suffix=None, fname=fname, column_list=column_list, add_incidence=False)
+    df[f'N_All'] = df['N_EMS_1'] + df['N_EMS_2'] + df['N_EMS_3'] + df['N_EMS_4'] + df['N_EMS_5'] + df['N_EMS_6'] + \
+                   df['N_EMS_7'] + df['N_EMS_8'] + df['N_EMS_9'] + df['N_EMS_10'] + df['N_EMS_11']
 
-    fig = plt.figure(figsize=(16,8))
-    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
-    palette = sns.color_palette('husl', 8)
+    for ems_num in ems:
+        df[f'recovered_shift14_{ems_num}'] = df.groupby(['scen_num', 'sample_num'])[f'recovered_{ems_num}'].transform(
+            'shift', 14)
 
-    for ems_num in ems :
-        df[f'N_{ems_num}'] = df[f'susceptible_{ems_num}'] + df[f'exposed_{ems_num}'] + \
-                             df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']
+        df[f'N_{ems_num}'] = df[f'N_{ems_num.replace("EMS-", "EMS_")}'] # Static N
+        df[f'N_t_{ems_num}'] = df[f'susceptible_{ems_num}'] + df[f'exposed_{ems_num}'] + \
+                               df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']  # Time varying N
+
+        # df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_t_{ems_num}']
+        # df[f'seroprevalence_{ems_num}'] = (df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']) / df[f'N_t_{ems_num}']
         df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_{ems_num}']
-        df[f'seroprevalence_{ems_num}'] = (df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']) / df[f'N_{ems_num}']
+        df[f'seroprevalence_{ems_num}'] = (df[f'recovered_shift14_{ems_num}']) / df[f'N_{ems_num}']
 
-    if save_fname != None:
-        simpath = os.path.join(wdir, 'simulation_output', exp_name)
-        if os.path.exists(os.path.join(simpath, "prevalenceDat.csv"))==False:
-            df.to_csv(os.path.join(simpath, "prevalenceDat.csv"), index=False, date_format='%Y-%m-%d')
+    df.to_csv(os.path.join(wdir, 'simulation_output', exp_name, "prevalenceDat.csv"), index=False,
+              date_format='%Y-%m-%d')
 
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
+    fig = plt.figure(figsize=(16, 8))
+    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
+    palette = sns.color_palette('husl', 8)
     for e, ems_num in enumerate(ems):
-        ax = fig.add_subplot(3,4,e+1)
+        ax = fig.add_subplot(3, 4, e + 1)
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
-        for k, channel in enumerate(channels) :
-            plot_label =''
-            if len(channels)>1 :
+        for k, channel in enumerate(channels):
+            plot_label = ''
+            if len(channels) > 1:
                 plot_label = channel.split('_')[0]
             channel_label = channel
             channel = f'{channel}_{ems_num}'
@@ -94,28 +111,28 @@ def plot_prevalences(exp_name,first_day,last_day, channels = ['prevalence'], fna
                             color=palette[k], linewidth=0, alpha=0.2)
             ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
                             color=palette[k], linewidth=0, alpha=0.4)
-        if ems_num == 'EMS-1' :
+        if ems_num == 'EMS-1':
             ax.legend()
         plotsubtitle = ems_num.replace('EMS-', 'COVID-19 Region ')
-        if ems_num == 'All' :
+        if ems_num == 'All':
             plotsubtitle = ems_num.replace('All', 'Illinois')
         ax.set_title(plotsubtitle)
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
         ax.set_xlim(first_day, last_day)
         ax.axvline(x=date.today(), color='#666666', linestyle='--')
 
-    if len(channels)==1:
+    if len(channels) == 1:
         fig.suptitle(x=0.5, y=0.999, t=channel_label)
 
     fig_name = channels[0]
-    if len(channels) == 2 :
+    if len(channels) == 2:
         fig_name = channels[0] + '-' + channels[1]
 
     plt.savefig(os.path.join(plot_path, f'{fig_name}_by_covidregion.png'))
-    plt.savefig(os.path.join(plot_path,'pdf', f'{fig_name}_by_covidregion.pdf'), format='PDF')
+    plt.savefig(os.path.join(plot_path, 'pdf', f'{fig_name}_by_covidregion.pdf'), format='PDF')
 
 
-if __name__ == '__main__' :
+if __name__ == '__main__':
 
     args = parse_args()
     stem = args.stem
@@ -131,6 +148,8 @@ if __name__ == '__main__' :
     for exp_name in exp_names:
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
 
-        plot_prevalences(exp_name, channels = ['prevalence'], fname=trajectoriesName, first_day=first_plot_day, last_day=last_plot_day)
-        plot_prevalences(exp_name, channels = ['seroprevalence'], fname=trajectoriesName, first_day=first_plot_day, last_day=last_plot_day)
-        #plot_prevalences(exp_name, channels = ['prevalence', 'seroprevalence'], fname=trajectoriesName, first_day=first_plot_day, last_day=last_plot_day)
+        plot_prevalences(exp_name, channels=['prevalence'], fname=trajectoriesName, first_day=first_plot_day,
+                         last_day=last_plot_day)
+        plot_prevalences(exp_name, channels=['seroprevalence'], fname=trajectoriesName, first_day=first_plot_day,
+                         last_day=last_plot_day)
+        # plot_prevalences(exp_name, channels = ['prevalence', 'seroprevalence'], fname=trajectoriesName, first_day=first_plot_day, last_day=last_plot_day)

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -59,28 +59,20 @@ def plot_prevalences(exp_name, first_day, last_day, channels=['prevalence'], fna
     ems = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
     column_list = ['time', 'startdate', 'scen_num', 'run_num', 'sample_num']
     for ems_num in ems:
-        if not ems_num == "All":
-            column_list.append('N_' + str(ems_num.replace("EMS-", "EMS_"))) # Fixed pop
         column_list.append('infected_' + str(ems_num))
         column_list.append('exposed_' + str(ems_num))
         column_list.append('recovered_' + str(ems_num))
         column_list.append('susceptible_' + str(ems_num))
 
     df = load_sim_data(exp_name, region_suffix=None, fname=fname, column_list=column_list, add_incidence=False)
-    df[f'N_All'] = df['N_EMS_1'] + df['N_EMS_2'] + df['N_EMS_3'] + df['N_EMS_4'] + df['N_EMS_5'] + df['N_EMS_6'] + \
-                   df['N_EMS_7'] + df['N_EMS_8'] + df['N_EMS_9'] + df['N_EMS_10'] + df['N_EMS_11']
 
     for ems_num in ems:
 
-        df[f'N_{ems_num}'] = df[f'N_{ems_num.replace("EMS-", "EMS_")}'] # Static N
-        df[f'N_t_{ems_num}'] = df[f'susceptible_{ems_num}'] + df[f'exposed_{ems_num}'] + \
-                               df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']  # Time varying N
+        df[f'N_{ems_num}'] = df[f'susceptible_{ems_num}'] + df[f'exposed_{ems_num}'] + \
+                             df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']
 
-        # df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_t_{ems_num}']
-        # df[f'seroprevalence_{ems_num}'] = (df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']) / df[f'N_t_{ems_num}']
         df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_{ems_num}']
-        df[f'seroprevalence_current_{ems_num}'] = (df[f'recovered_{ems_num}']) / df[f'N_{ems_num}']
-
+        df[f'seroprevalence_current_{ems_num}'] = df[f'recovered_{ems_num}'] / df[f'N_{ems_num}']
         df[f'seroprevalence_{ems_num}'] = df.groupby(['scen_num', 'sample_num'])[f'seroprevalence_current_{ems_num}'].transform('shift', 14)
 
     df.to_csv(os.path.join(wdir, 'simulation_output', exp_name, "prevalenceDat.csv"), index=False,

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -55,12 +55,6 @@ def trim_trajectories(simpath, scenario, colnames, ems):
     df.to_csv(os.path.join(simpath, 'trimmed_trajectoriesDat_%s.csv' % scenario), index=False)
 
 
-def count_2weeks_before(df, curr_ch):
-    ch_list = list(df[curr_ch].values)
-    diff = [ch_list[x - 14] for x in range(1, len(df))]
-    return diff
-
-
 def plot_prevalences(exp_name, first_day, last_day, channels=['prevalence'], fname='trajectoriesDat.csv'):
     ems = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
     column_list = ['time', 'startdate', 'scen_num', 'run_num', 'sample_num']

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -71,8 +71,6 @@ def plot_prevalences(exp_name, first_day, last_day, channels=['prevalence'], fna
                    df['N_EMS_7'] + df['N_EMS_8'] + df['N_EMS_9'] + df['N_EMS_10'] + df['N_EMS_11']
 
     for ems_num in ems:
-        df[f'recovered_shift14_{ems_num}'] = df.groupby(['scen_num', 'sample_num'])[f'recovered_{ems_num}'].transform(
-            'shift', 14)
 
         df[f'N_{ems_num}'] = df[f'N_{ems_num.replace("EMS-", "EMS_")}'] # Static N
         df[f'N_t_{ems_num}'] = df[f'susceptible_{ems_num}'] + df[f'exposed_{ems_num}'] + \
@@ -81,7 +79,9 @@ def plot_prevalences(exp_name, first_day, last_day, channels=['prevalence'], fna
         # df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_t_{ems_num}']
         # df[f'seroprevalence_{ems_num}'] = (df[f'infected_{ems_num}'] + df[f'recovered_{ems_num}']) / df[f'N_t_{ems_num}']
         df[f'prevalence_{ems_num}'] = df[f'infected_{ems_num}'] / df[f'N_{ems_num}']
-        df[f'seroprevalence_{ems_num}'] = (df[f'recovered_shift14_{ems_num}']) / df[f'N_{ems_num}']
+        df[f'seroprevalence_current_{ems_num}'] = (df[f'recovered_{ems_num}']) / df[f'N_{ems_num}']
+
+        df[f'seroprevalence_{ems_num}'] = df.groupby(['scen_num', 'sample_num'])[f'seroprevalence_current_{ems_num}'].transform('shift', 14)
 
     df.to_csv(os.path.join(wdir, 'simulation_output', exp_name, "prevalenceDat.csv"), index=False,
               date_format='%Y-%m-%d')

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -65,14 +65,16 @@ def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True, 
 
     ax.set_title(panel_heading, y=0.85)
     ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
-    ax.set_ylim(0, ymax)
+    if not ymax is None:
+        ax.set_ylim(0, ymax)
 
-def plot_main(nscen=None, showLegend =True) :
+def plot_main(nscen=None, showLegend =True, channels=None) :
     fig = plt.figure(figsize=(15, 8))
     fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
     palette = sns.color_palette('GnBu_d', len(exp_names))
 
-    channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+    if channels ==None:
+        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
     axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
 
     for d, exp_name in enumerate(exp_names) :
@@ -129,7 +131,7 @@ def plot_covidregions(subgroups =None,nscen=None, showLegend=True) :
         plt.savefig(os.path.join(plot_path, 'trajectories_%s.png' % region_label2))
         #plt.savefig(os.path.join(plot_path, 'pdf', 'trajectories_%s.pdf' % region_label2))
 
-def plot_covidregions_inone(subgroups=None,channel='hospitalized',nscen=None,showLegend = True, ymax=50) :
+def plot_covidregions_inone(subgroups=None,channel='hospitalized',nscen=None,showLegend = True, ymax=None) :
 
     if subgroups ==None:
         subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
@@ -169,7 +171,7 @@ if __name__ == '__main__' :
     trajectoriesName = args.trajectoriesName
     Location = args.Location
 
-    first_plot_day = date.today() - timedelta(60)
+    first_plot_day = date.today() - timedelta(300)
     last_plot_day = date.today() + timedelta(15)
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location="Local")
@@ -181,7 +183,14 @@ if __name__ == '__main__' :
         showLegend = True
 
     plot_path = os.path.join(wdir, 'simulation_output', exp_names[len(exp_names) - 1], '_plots')
-    plot_main(nscen=None, showLegend=showLegend)
+    plot_main(nscen=None, showLegend=showLegend, channels=['cfr_t','frac_crit_t','fraction_hospitalized_t',
+                                                           'fraction_dead_t','fraction_symptomatic','fraction_severe'])
+    #plot_main(nscen=None, showLegend=showLegend)
     #plot_covidregions(nscen=None, showLegend=showLegend)
     plot_covidregions_inone(channel='Ki_t', nscen=None, showLegend=showLegend, ymax=1.5)
     plot_covidregions_inone(channel='d_Sym_t', nscen=None, showLegend=showLegend, ymax=1)
+    #plot_covidregions_inone(channel='Ki_t', nscen=None, showLegend=showLegend, ymax=1.5)
+    #plot_covidregions_inone(channel='cfr_t', nscen=None, showLegend=showLegend)
+    #plot_covidregions_inone(channel='frac_crit_t', nscen=None, showLegend=showLegend)
+    #plot_covidregions_inone(channel='fraction_hospitalized_t', nscen=None, showLegend=showLegend1)
+    #plot_covidregions_inone(channel='fraction_dead_t', nscen=None, showLegend=showLegend)

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -8,7 +8,7 @@ datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
 
 
 def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname='trajectoriesDat.csv',
-                  input_sim_output_path =None, column_list=None, add_incidence=True, add_prevalence=False) :
+                  input_sim_output_path =None, column_list=None, add_incidence=True) :
     input_wdir = input_wdir or wdir
     sim_output_path_base = os.path.join(input_wdir, 'simulation_output', exp_name)
     sim_output_path = input_sim_output_path or sim_output_path_base
@@ -24,9 +24,6 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname='traje
 
     if region_suffix !=None :
         df.columns = df.columns.str.replace(region_suffix, '')
-
-    if add_prevalence:
-        df = calculate_prevalence(df)
 
     if add_incidence:
         if 'recovered' in df.columns:
@@ -215,7 +212,7 @@ def load_ref_df(ems_nr):
 
 def calculate_prevalence(df, ems=None):
     if ems is None:
-        ems = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
+        ems = ['EMS-%d' % x for x in range(1, 12)]
 
     for ems_num in ems:
             df[f'N_{ems_num}'] = df[f'N_{str(ems_num.replace("-","_"))}'] - df[f'deaths_{ems_num}']


### PR DESCRIPTION
- prevalence, seroprevalence, IFR now calculated in calculate_prevalence function after loading sim data
- IFR calculated based on resolved infections ` IFR = deaths/(recovered+deaths)`
- removed prevalence and seroprevalence functions from emodls
- edited observed channels in emodls needed for calculating the outcomes, for all and for det
- N total pop is now retrieved from the emodls to allow easier calculation when using N-deaths versus N-deaths_det
- Seroprevalence is calculated based on current recoveries and deaths and then shifted by 14 days, to have` seroprevalence = recoveries 2 weeks ago / (Population - deaths two weeks ago)`