### PR TITLE
removed engine='python' specification in  pd.read_csv in load_sim_data

### DIFF
--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -13,7 +13,7 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname='traje
     sim_output_path_base = os.path.join(input_wdir, 'simulation_output', exp_name)
     sim_output_path = input_sim_output_path or sim_output_path_base
 
-    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=column_list, engine='python')
+    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=column_list)  ## engine='python'
     df = df.dropna()
     try:
         first_day = datetime.strptime(df['startdate'].unique()[0], '%Y-%m-%d')


### PR DESCRIPTION
the [engine specification](https://github.com/numalariamodeling/covid-chicago/blob/master/processing_helpers.py#L16)  in `pd.read_csv`,  added in a previous PR, caused pycharm to freeze or took more than half times longer to run postprocessing than when using the default `engine c`. 
([here ](https://stackoverflow.com/questions/52774459/engines-in-python-pandas-read-csv)some discussion on c versus python engine).  We could add a user-specific if statement to use `python `or `c` engine if needed. 