### PR TITLE
edited data_comparison_spatial_3.py script to allow to compare region ki parameters 

### DIFF
--- a/plotters/data_comparison_spatial_3.py
+++ b/plotters/data_comparison_spatial_3.py
@@ -66,7 +66,7 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names,region_lab
         ax.fill_between(mdf_sub['date'], mdf_sub['CI_2pt5'], mdf_sub['CI_97pt5'], color=palette[i], linewidth=0, alpha=0.2)
 
         ax.set_title(titles[c], y=0.8, fontsize=12)
-        ax.legend()
+        #ax.legend()
 
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
         ax.set_xlim(first_day, last_day)
@@ -98,6 +98,7 @@ def compare_ems(exp_name,fname, param, ems_nr,first_day,last_day):
         region_label = 'Illinois'
     else:
         region_suffix = "_EMS-" + str(ems_nr)
+        region_suffix2 = "_EMS_" + str(ems_nr)
         region_label = region_suffix.replace('_EMS-', 'COVID-19 Region ')
 
     column_list = ['time', 'startdate', 'scen_num', 'sample_num', 'run_num']
@@ -110,6 +111,8 @@ def compare_ems(exp_name,fname, param, ems_nr,first_day,last_day):
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
 
+    if "ki" in param.lower() :
+        param = param + region_suffix2
     df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname, column_list=column_list)
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
     df['critical_with_suspected'] = df['critical']
@@ -143,7 +146,7 @@ if __name__ == '__main__':
 
     for exp_name in exp_names:
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
-        for ems_nr in range(0, 12):
+        for ems_nr in range(1, 12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name, fname=trajectoriesName, ems_nr=int(ems_nr), param="recovery_time_crit",
+            compare_ems(exp_name, fname=trajectoriesName, ems_nr=int(ems_nr), param="Ki",
                         first_day=first_plot_day, last_day=last_plot_day)


### PR DESCRIPTION
The data_comparison_spatial_3.py script produces separate lines for a specified parameter from the sample_parameters.csv, useful to compare either intervention parameters or one of the sample parameters within a simulation.
Added an if statement for ki parameters (incl. multipliers) to allow comparing these. 
(Note: region specific parameters have a underscore instead of a minus sign between EMS and its number to separate input from output parameters (EMS_1 vs EMS-1)
Commented out the legend as annoying if too many parameter values. 