### PR TITLE
added January time-event ('ki_multiplier_time_13': custom_function: D…

### DIFF
--- a/emodl/extendedmodel_EMS.emodl
+++ b/emodl/extendedmodel_EMS.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_changeTD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollback.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_criticaldet_triggeredrollbackdelay.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_dAsP.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsPSym_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_dAsP_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dSym.emodl
+++ b/emodl/extendedmodel_EMS_dSym.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_dSym_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_gradual_reopening.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
+++ b/emodl/extendedmodel_EMS_gradual_reopening_region_specific.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollback.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
+++ b/emodl/extendedmodel_EMS_hospdet_triggeredrollbackdelay.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
+++ b/emodl/extendedmodel_EMS_interventionSTOPadj.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_interventionStop.emodl
+++ b/emodl/extendedmodel_EMS_interventionStop.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_changeTD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_changeTD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dAsP.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsPSym_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dAsP_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dSym.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
+++ b/emodl/extendedmodel_EMS_reopen_dSym_TD.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_EMS_rollback.emodl
+++ b/emodl/extendedmodel_EMS_rollback.emodl
@@ -1680,6 +1680,7 @@
 (param Ki_red10_EMS_1 (* Ki_EMS_1 @ki_multiplier_10_EMS_1@))
 (param Ki_red11_EMS_1 (* Ki_EMS_1 @ki_multiplier_11_EMS_1@))
 (param Ki_red12_EMS_1 (* Ki_EMS_1 @ki_multiplier_12_EMS_1@))
+(param Ki_red13_EMS_1 (* Ki_EMS_1 @ki_multiplier_13_EMS_1@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_1 Ki_red3a_EMS_1)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_1 Ki_red3b_EMS_1)))
@@ -1693,6 +1694,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_1 Ki_red10_EMS_1)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_1 Ki_red11_EMS_1)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_1 Ki_red12_EMS_1)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_1 Ki_red12_EMS_1)))
             
 (param Ki_red3a_EMS_2 (* Ki_EMS_2 @ki_multiplier_3a_EMS_2@))
 (param Ki_red3b_EMS_2 (* Ki_EMS_2 @ki_multiplier_3b_EMS_2@))
@@ -1706,6 +1708,7 @@
 (param Ki_red10_EMS_2 (* Ki_EMS_2 @ki_multiplier_10_EMS_2@))
 (param Ki_red11_EMS_2 (* Ki_EMS_2 @ki_multiplier_11_EMS_2@))
 (param Ki_red12_EMS_2 (* Ki_EMS_2 @ki_multiplier_12_EMS_2@))
+(param Ki_red13_EMS_2 (* Ki_EMS_2 @ki_multiplier_13_EMS_2@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_2 Ki_red3a_EMS_2)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_2 Ki_red3b_EMS_2)))
@@ -1719,6 +1722,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_2 Ki_red10_EMS_2)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_2 Ki_red11_EMS_2)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_2 Ki_red12_EMS_2)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_2 Ki_red12_EMS_2)))
             
 (param Ki_red3a_EMS_3 (* Ki_EMS_3 @ki_multiplier_3a_EMS_3@))
 (param Ki_red3b_EMS_3 (* Ki_EMS_3 @ki_multiplier_3b_EMS_3@))
@@ -1732,6 +1736,7 @@
 (param Ki_red10_EMS_3 (* Ki_EMS_3 @ki_multiplier_10_EMS_3@))
 (param Ki_red11_EMS_3 (* Ki_EMS_3 @ki_multiplier_11_EMS_3@))
 (param Ki_red12_EMS_3 (* Ki_EMS_3 @ki_multiplier_12_EMS_3@))
+(param Ki_red13_EMS_3 (* Ki_EMS_3 @ki_multiplier_13_EMS_3@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_3 Ki_red3a_EMS_3)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_3 Ki_red3b_EMS_3)))
@@ -1745,6 +1750,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_3 Ki_red10_EMS_3)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_3 Ki_red11_EMS_3)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_3 Ki_red12_EMS_3)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_3 Ki_red12_EMS_3)))
             
 (param Ki_red3a_EMS_4 (* Ki_EMS_4 @ki_multiplier_3a_EMS_4@))
 (param Ki_red3b_EMS_4 (* Ki_EMS_4 @ki_multiplier_3b_EMS_4@))
@@ -1758,6 +1764,7 @@
 (param Ki_red10_EMS_4 (* Ki_EMS_4 @ki_multiplier_10_EMS_4@))
 (param Ki_red11_EMS_4 (* Ki_EMS_4 @ki_multiplier_11_EMS_4@))
 (param Ki_red12_EMS_4 (* Ki_EMS_4 @ki_multiplier_12_EMS_4@))
+(param Ki_red13_EMS_4 (* Ki_EMS_4 @ki_multiplier_13_EMS_4@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_4 Ki_red3a_EMS_4)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_4 Ki_red3b_EMS_4)))
@@ -1771,6 +1778,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_4 Ki_red10_EMS_4)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_4 Ki_red11_EMS_4)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_4 Ki_red12_EMS_4)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_4 Ki_red12_EMS_4)))
             
 (param Ki_red3a_EMS_5 (* Ki_EMS_5 @ki_multiplier_3a_EMS_5@))
 (param Ki_red3b_EMS_5 (* Ki_EMS_5 @ki_multiplier_3b_EMS_5@))
@@ -1784,6 +1792,7 @@
 (param Ki_red10_EMS_5 (* Ki_EMS_5 @ki_multiplier_10_EMS_5@))
 (param Ki_red11_EMS_5 (* Ki_EMS_5 @ki_multiplier_11_EMS_5@))
 (param Ki_red12_EMS_5 (* Ki_EMS_5 @ki_multiplier_12_EMS_5@))
+(param Ki_red13_EMS_5 (* Ki_EMS_5 @ki_multiplier_13_EMS_5@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_5 Ki_red3a_EMS_5)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_5 Ki_red3b_EMS_5)))
@@ -1797,6 +1806,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_5 Ki_red10_EMS_5)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_5 Ki_red11_EMS_5)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_5 Ki_red12_EMS_5)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_5 Ki_red12_EMS_5)))
             
 (param Ki_red3a_EMS_6 (* Ki_EMS_6 @ki_multiplier_3a_EMS_6@))
 (param Ki_red3b_EMS_6 (* Ki_EMS_6 @ki_multiplier_3b_EMS_6@))
@@ -1810,6 +1820,7 @@
 (param Ki_red10_EMS_6 (* Ki_EMS_6 @ki_multiplier_10_EMS_6@))
 (param Ki_red11_EMS_6 (* Ki_EMS_6 @ki_multiplier_11_EMS_6@))
 (param Ki_red12_EMS_6 (* Ki_EMS_6 @ki_multiplier_12_EMS_6@))
+(param Ki_red13_EMS_6 (* Ki_EMS_6 @ki_multiplier_13_EMS_6@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_6 Ki_red3a_EMS_6)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_6 Ki_red3b_EMS_6)))
@@ -1823,6 +1834,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_6 Ki_red10_EMS_6)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_6 Ki_red11_EMS_6)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_6 Ki_red12_EMS_6)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_6 Ki_red12_EMS_6)))
             
 (param Ki_red3a_EMS_7 (* Ki_EMS_7 @ki_multiplier_3a_EMS_7@))
 (param Ki_red3b_EMS_7 (* Ki_EMS_7 @ki_multiplier_3b_EMS_7@))
@@ -1836,6 +1848,7 @@
 (param Ki_red10_EMS_7 (* Ki_EMS_7 @ki_multiplier_10_EMS_7@))
 (param Ki_red11_EMS_7 (* Ki_EMS_7 @ki_multiplier_11_EMS_7@))
 (param Ki_red12_EMS_7 (* Ki_EMS_7 @ki_multiplier_12_EMS_7@))
+(param Ki_red13_EMS_7 (* Ki_EMS_7 @ki_multiplier_13_EMS_7@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_7 Ki_red3a_EMS_7)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_7 Ki_red3b_EMS_7)))
@@ -1849,6 +1862,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_7 Ki_red10_EMS_7)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_7 Ki_red11_EMS_7)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_7 Ki_red12_EMS_7)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_7 Ki_red12_EMS_7)))
             
 (param Ki_red3a_EMS_8 (* Ki_EMS_8 @ki_multiplier_3a_EMS_8@))
 (param Ki_red3b_EMS_8 (* Ki_EMS_8 @ki_multiplier_3b_EMS_8@))
@@ -1862,6 +1876,7 @@
 (param Ki_red10_EMS_8 (* Ki_EMS_8 @ki_multiplier_10_EMS_8@))
 (param Ki_red11_EMS_8 (* Ki_EMS_8 @ki_multiplier_11_EMS_8@))
 (param Ki_red12_EMS_8 (* Ki_EMS_8 @ki_multiplier_12_EMS_8@))
+(param Ki_red13_EMS_8 (* Ki_EMS_8 @ki_multiplier_13_EMS_8@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_8 Ki_red3a_EMS_8)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_8 Ki_red3b_EMS_8)))
@@ -1875,6 +1890,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_8 Ki_red10_EMS_8)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_8 Ki_red11_EMS_8)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_8 Ki_red12_EMS_8)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_8 Ki_red12_EMS_8)))
             
 (param Ki_red3a_EMS_9 (* Ki_EMS_9 @ki_multiplier_3a_EMS_9@))
 (param Ki_red3b_EMS_9 (* Ki_EMS_9 @ki_multiplier_3b_EMS_9@))
@@ -1888,6 +1904,7 @@
 (param Ki_red10_EMS_9 (* Ki_EMS_9 @ki_multiplier_10_EMS_9@))
 (param Ki_red11_EMS_9 (* Ki_EMS_9 @ki_multiplier_11_EMS_9@))
 (param Ki_red12_EMS_9 (* Ki_EMS_9 @ki_multiplier_12_EMS_9@))
+(param Ki_red13_EMS_9 (* Ki_EMS_9 @ki_multiplier_13_EMS_9@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_9 Ki_red3a_EMS_9)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_9 Ki_red3b_EMS_9)))
@@ -1901,6 +1918,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_9 Ki_red10_EMS_9)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_9 Ki_red11_EMS_9)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_9 Ki_red12_EMS_9)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_9 Ki_red12_EMS_9)))
             
 (param Ki_red3a_EMS_10 (* Ki_EMS_10 @ki_multiplier_3a_EMS_10@))
 (param Ki_red3b_EMS_10 (* Ki_EMS_10 @ki_multiplier_3b_EMS_10@))
@@ -1914,6 +1932,7 @@
 (param Ki_red10_EMS_10 (* Ki_EMS_10 @ki_multiplier_10_EMS_10@))
 (param Ki_red11_EMS_10 (* Ki_EMS_10 @ki_multiplier_11_EMS_10@))
 (param Ki_red12_EMS_10 (* Ki_EMS_10 @ki_multiplier_12_EMS_10@))
+(param Ki_red13_EMS_10 (* Ki_EMS_10 @ki_multiplier_13_EMS_10@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_10 Ki_red3a_EMS_10)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_10 Ki_red3b_EMS_10)))
@@ -1927,6 +1946,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_10 Ki_red10_EMS_10)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_10 Ki_red11_EMS_10)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_10 Ki_red12_EMS_10)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_10 Ki_red12_EMS_10)))
             
 (param Ki_red3a_EMS_11 (* Ki_EMS_11 @ki_multiplier_3a_EMS_11@))
 (param Ki_red3b_EMS_11 (* Ki_EMS_11 @ki_multiplier_3b_EMS_11@))
@@ -1940,6 +1960,7 @@
 (param Ki_red10_EMS_11 (* Ki_EMS_11 @ki_multiplier_10_EMS_11@))
 (param Ki_red11_EMS_11 (* Ki_EMS_11 @ki_multiplier_11_EMS_11@))
 (param Ki_red12_EMS_11 (* Ki_EMS_11 @ki_multiplier_12_EMS_11@))
+(param Ki_red13_EMS_11 (* Ki_EMS_11 @ki_multiplier_13_EMS_11@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_EMS_11 Ki_red3a_EMS_11)))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_EMS_11 Ki_red3b_EMS_11)))
@@ -1953,6 +1974,7 @@
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_EMS_11 Ki_red10_EMS_11)))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_EMS_11 Ki_red11_EMS_11)))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_EMS_11 Ki_red12_EMS_11)))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_EMS_11 Ki_red12_EMS_11)))
             
 (param d_Sym_EMS_1 @d_Sym_EMS_1@)
 (observe d_Sym_t_EMS-1 d_Sym_EMS_1)

--- a/emodl/extendedmodel_obsall_EMS.emodl
+++ b/emodl/extendedmodel_obsall_EMS.emodl
@@ -1023,6 +1023,10 @@
 (observe detected_All (+ detected_EMS_1 detected_EMS_2 detected_EMS_3 detected_EMS_4 detected_EMS_5 detected_EMS_6 detected_EMS_7 detected_EMS_8 detected_EMS_9 detected_EMS_10 detected_EMS_11))
 (observe symptomatic_mild_det_All (+ symptomatic_mild_det_EMS_1 symptomatic_mild_det_EMS_2 symptomatic_mild_det_EMS_3 symptomatic_mild_det_EMS_4 symptomatic_mild_det_EMS_5 symptomatic_mild_det_EMS_6 symptomatic_mild_det_EMS_7 symptomatic_mild_det_EMS_8 symptomatic_mild_det_EMS_9 symptomatic_mild_det_EMS_10 symptomatic_mild_det_EMS_11))
 (observe symptomatic_severe_det_All (+ symptomatic_severe_det_EMS_1 symptomatic_severe_det_EMS_2 symptomatic_severe_det_EMS_3 symptomatic_severe_det_EMS_4 symptomatic_severe_det_EMS_5 symptomatic_severe_det_EMS_6 symptomatic_severe_det_EMS_7 symptomatic_severe_det_EMS_8 symptomatic_severe_det_EMS_9 symptomatic_severe_det_EMS_10 symptomatic_severe_det_EMS_11))
+(observe infectious_det_All (+ infectious_det_EMS_1 infectious_det_EMS_2 infectious_det_EMS_3 infectious_det_EMS_4 infectious_det_EMS_5 infectious_det_EMS_6 infectious_det_EMS_7 infectious_det_EMS_8 infectious_det_EMS_9 infectious_det_EMS_10 infectious_det_EMS_11))
+(observe infectious_undet_All (+ infectious_undet_EMS_1 infectious_undet_EMS_2 infectious_undet_EMS_3 infectious_undet_EMS_4 infectious_undet_EMS_5 infectious_undet_EMS_6 infectious_undet_EMS_7 infectious_undet_EMS_8 infectious_undet_EMS_9 infectious_undet_EMS_10 infectious_undet_EMS_11))
+(observe infectious_det_symp_All (+ infectious_det_symp_EMS_1 infectious_det_symp_EMS_2 infectious_det_symp_EMS_3 infectious_det_symp_EMS_4 infectious_det_symp_EMS_5 infectious_det_symp_EMS_6 infectious_det_symp_EMS_7 infectious_det_symp_EMS_8 infectious_det_symp_EMS_9 infectious_det_symp_EMS_10 infectious_det_symp_EMS_11))
+(observe infectious_det_AsP_All (+ infectious_det_AsP_EMS_1 infectious_det_AsP_EMS_2 infectious_det_AsP_EMS_3 infectious_det_AsP_EMS_4 infectious_det_AsP_EMS_5 infectious_det_AsP_EMS_6 infectious_det_AsP_EMS_7 infectious_det_AsP_EMS_8 infectious_det_AsP_EMS_9 infectious_det_AsP_EMS_10 infectious_det_AsP_EMS_11))
 
 
 (observe susceptible_EMS-1 S::EMS_1)
@@ -1071,6 +1075,11 @@
 (observe symptomatic_severe_det_EMS-1 symptomatic_severe_det_EMS_1)
 (observe recovered_det_EMS-1 recovered_det_EMS_1)
 
+(observe infectious_undet_EMS-1 infectious_undet_EMS_1)
+(observe infectious_det_EMS-1 infectious_det_EMS_1)
+(observe infectious_det_symp_EMS-1 infectious_det_symp_EMS_1)
+(observe infectious_det_AsP_EMS-1 infectious_det_AsP_EMS_1)
+
 (observe susceptible_EMS-2 S::EMS_2)
 (observe infected_EMS-2 infected_EMS_2)
 (observe infected_det_EMS-2 infected_det_EMS_2)
@@ -1116,6 +1125,11 @@
 (observe symptomatic_mild_det_EMS-2 symptomatic_mild_det_EMS_2)
 (observe symptomatic_severe_det_EMS-2 symptomatic_severe_det_EMS_2)
 (observe recovered_det_EMS-2 recovered_det_EMS_2)
+
+(observe infectious_undet_EMS-2 infectious_undet_EMS_2)
+(observe infectious_det_EMS-2 infectious_det_EMS_2)
+(observe infectious_det_symp_EMS-2 infectious_det_symp_EMS_2)
+(observe infectious_det_AsP_EMS-2 infectious_det_AsP_EMS_2)
 
 (observe susceptible_EMS-3 S::EMS_3)
 (observe infected_EMS-3 infected_EMS_3)
@@ -1163,6 +1177,11 @@
 (observe symptomatic_severe_det_EMS-3 symptomatic_severe_det_EMS_3)
 (observe recovered_det_EMS-3 recovered_det_EMS_3)
 
+(observe infectious_undet_EMS-3 infectious_undet_EMS_3)
+(observe infectious_det_EMS-3 infectious_det_EMS_3)
+(observe infectious_det_symp_EMS-3 infectious_det_symp_EMS_3)
+(observe infectious_det_AsP_EMS-3 infectious_det_AsP_EMS_3)
+
 (observe susceptible_EMS-4 S::EMS_4)
 (observe infected_EMS-4 infected_EMS_4)
 (observe infected_det_EMS-4 infected_det_EMS_4)
@@ -1208,6 +1227,11 @@
 (observe symptomatic_mild_det_EMS-4 symptomatic_mild_det_EMS_4)
 (observe symptomatic_severe_det_EMS-4 symptomatic_severe_det_EMS_4)
 (observe recovered_det_EMS-4 recovered_det_EMS_4)
+
+(observe infectious_undet_EMS-4 infectious_undet_EMS_4)
+(observe infectious_det_EMS-4 infectious_det_EMS_4)
+(observe infectious_det_symp_EMS-4 infectious_det_symp_EMS_4)
+(observe infectious_det_AsP_EMS-4 infectious_det_AsP_EMS_4)
 
 (observe susceptible_EMS-5 S::EMS_5)
 (observe infected_EMS-5 infected_EMS_5)
@@ -1255,6 +1279,11 @@
 (observe symptomatic_severe_det_EMS-5 symptomatic_severe_det_EMS_5)
 (observe recovered_det_EMS-5 recovered_det_EMS_5)
 
+(observe infectious_undet_EMS-5 infectious_undet_EMS_5)
+(observe infectious_det_EMS-5 infectious_det_EMS_5)
+(observe infectious_det_symp_EMS-5 infectious_det_symp_EMS_5)
+(observe infectious_det_AsP_EMS-5 infectious_det_AsP_EMS_5)
+
 (observe susceptible_EMS-6 S::EMS_6)
 (observe infected_EMS-6 infected_EMS_6)
 (observe infected_det_EMS-6 infected_det_EMS_6)
@@ -1300,6 +1329,11 @@
 (observe symptomatic_mild_det_EMS-6 symptomatic_mild_det_EMS_6)
 (observe symptomatic_severe_det_EMS-6 symptomatic_severe_det_EMS_6)
 (observe recovered_det_EMS-6 recovered_det_EMS_6)
+
+(observe infectious_undet_EMS-6 infectious_undet_EMS_6)
+(observe infectious_det_EMS-6 infectious_det_EMS_6)
+(observe infectious_det_symp_EMS-6 infectious_det_symp_EMS_6)
+(observe infectious_det_AsP_EMS-6 infectious_det_AsP_EMS_6)
 
 (observe susceptible_EMS-7 S::EMS_7)
 (observe infected_EMS-7 infected_EMS_7)
@@ -1347,6 +1381,11 @@
 (observe symptomatic_severe_det_EMS-7 symptomatic_severe_det_EMS_7)
 (observe recovered_det_EMS-7 recovered_det_EMS_7)
 
+(observe infectious_undet_EMS-7 infectious_undet_EMS_7)
+(observe infectious_det_EMS-7 infectious_det_EMS_7)
+(observe infectious_det_symp_EMS-7 infectious_det_symp_EMS_7)
+(observe infectious_det_AsP_EMS-7 infectious_det_AsP_EMS_7)
+
 (observe susceptible_EMS-8 S::EMS_8)
 (observe infected_EMS-8 infected_EMS_8)
 (observe infected_det_EMS-8 infected_det_EMS_8)
@@ -1392,6 +1431,11 @@
 (observe symptomatic_mild_det_EMS-8 symptomatic_mild_det_EMS_8)
 (observe symptomatic_severe_det_EMS-8 symptomatic_severe_det_EMS_8)
 (observe recovered_det_EMS-8 recovered_det_EMS_8)
+
+(observe infectious_undet_EMS-8 infectious_undet_EMS_8)
+(observe infectious_det_EMS-8 infectious_det_EMS_8)
+(observe infectious_det_symp_EMS-8 infectious_det_symp_EMS_8)
+(observe infectious_det_AsP_EMS-8 infectious_det_AsP_EMS_8)
 
 (observe susceptible_EMS-9 S::EMS_9)
 (observe infected_EMS-9 infected_EMS_9)
@@ -1439,6 +1483,11 @@
 (observe symptomatic_severe_det_EMS-9 symptomatic_severe_det_EMS_9)
 (observe recovered_det_EMS-9 recovered_det_EMS_9)
 
+(observe infectious_undet_EMS-9 infectious_undet_EMS_9)
+(observe infectious_det_EMS-9 infectious_det_EMS_9)
+(observe infectious_det_symp_EMS-9 infectious_det_symp_EMS_9)
+(observe infectious_det_AsP_EMS-9 infectious_det_AsP_EMS_9)
+
 (observe susceptible_EMS-10 S::EMS_10)
 (observe infected_EMS-10 infected_EMS_10)
 (observe infected_det_EMS-10 infected_det_EMS_10)
@@ -1485,6 +1534,11 @@
 (observe symptomatic_severe_det_EMS-10 symptomatic_severe_det_EMS_10)
 (observe recovered_det_EMS-10 recovered_det_EMS_10)
 
+(observe infectious_undet_EMS-10 infectious_undet_EMS_10)
+(observe infectious_det_EMS-10 infectious_det_EMS_10)
+(observe infectious_det_symp_EMS-10 infectious_det_symp_EMS_10)
+(observe infectious_det_AsP_EMS-10 infectious_det_AsP_EMS_10)
+
 (observe susceptible_EMS-11 S::EMS_11)
 (observe infected_EMS-11 infected_EMS_11)
 (observe infected_det_EMS-11 infected_det_EMS_11)
@@ -1530,6 +1584,11 @@
 (observe symptomatic_mild_det_EMS-11 symptomatic_mild_det_EMS_11)
 (observe symptomatic_severe_det_EMS-11 symptomatic_severe_det_EMS_11)
 (observe recovered_det_EMS-11 recovered_det_EMS_11)
+
+(observe infectious_undet_EMS-11 infectious_undet_EMS_11)
+(observe infectious_det_EMS-11 infectious_det_EMS_11)
+(observe infectious_det_symp_EMS-11 infectious_det_symp_EMS_11)
+(observe infectious_det_AsP_EMS-11 infectious_det_AsP_EMS_11)
 
 
 
@@ -2152,61 +2211,6 @@
 
 
             
-(param Ki_back_EMS_1 (+ Ki_red7_EMS_1 (* @backtonormal_multiplier@ (- Ki_EMS_1 Ki_red7_EMS_1))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_1 Ki_back_EMS_1)))
-        
-(param Ki_back_EMS_2 (+ Ki_red7_EMS_2 (* @backtonormal_multiplier@ (- Ki_EMS_2 Ki_red7_EMS_2))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_2 Ki_back_EMS_2)))
-        
-(param Ki_back_EMS_3 (+ Ki_red7_EMS_3 (* @backtonormal_multiplier@ (- Ki_EMS_3 Ki_red7_EMS_3))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_3 Ki_back_EMS_3)))
-        
-(param Ki_back_EMS_4 (+ Ki_red7_EMS_4 (* @backtonormal_multiplier@ (- Ki_EMS_4 Ki_red7_EMS_4))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_4 Ki_back_EMS_4)))
-        
-(param Ki_back_EMS_5 (+ Ki_red7_EMS_5 (* @backtonormal_multiplier@ (- Ki_EMS_5 Ki_red7_EMS_5))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_5 Ki_back_EMS_5)))
-        
-(param Ki_back_EMS_6 (+ Ki_red7_EMS_6 (* @backtonormal_multiplier@ (- Ki_EMS_6 Ki_red7_EMS_6))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_6 Ki_back_EMS_6)))
-        
-(param Ki_back_EMS_7 (+ Ki_red7_EMS_7 (* @backtonormal_multiplier@ (- Ki_EMS_7 Ki_red7_EMS_7))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_7 Ki_back_EMS_7)))
-        
-(param Ki_back_EMS_8 (+ Ki_red7_EMS_8 (* @backtonormal_multiplier@ (- Ki_EMS_8 Ki_red7_EMS_8))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_8 Ki_back_EMS_8)))
-        
-(param Ki_back_EMS_9 (+ Ki_red7_EMS_9 (* @backtonormal_multiplier@ (- Ki_EMS_9 Ki_red7_EMS_9))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_9 Ki_back_EMS_9)))
-        
-(param Ki_back_EMS_10 (+ Ki_red7_EMS_10 (* @backtonormal_multiplier@ (- Ki_EMS_10 Ki_red7_EMS_10))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_10 Ki_back_EMS_10)))
-        
-(param Ki_back_EMS_11 (+ Ki_red7_EMS_11 (* @backtonormal_multiplier@ (- Ki_EMS_11 Ki_red7_EMS_11))))
-(time-event stopInterventions @socialDistanceSTOP_time@ ((Ki_EMS_11 Ki_back_EMS_11)))
-        
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_1 Ki_red4_EMS_1)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_2 Ki_red4_EMS_2)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_3 Ki_red4_EMS_3)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_4 Ki_red4_EMS_4)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_5 Ki_red4_EMS_5)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_6 Ki_red4_EMS_6)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_7 Ki_red4_EMS_7)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_8 Ki_red4_EMS_8)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_9 Ki_red4_EMS_9)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_10 Ki_red4_EMS_10)))
-                
-(time-event ki_multiplier_change_rollback @socialDistance_rollback_time@ ((Ki_EMS_11 Ki_red4_EMS_11)))
-                
 ;[ADDITIONAL_TIMEEVENTS]
 
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -868,6 +868,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 (param Ki_red10_{grp} (* Ki_{grp} @ki_multiplier_10_{grp}@))
 (param Ki_red11_{grp} (* Ki_{grp} @ki_multiplier_11_{grp}@))
 (param Ki_red12_{grp} (* Ki_{grp} @ki_multiplier_12_{grp}@))
+(param Ki_red13_{grp} (* Ki_{grp} @ki_multiplier_13_{grp}@))
 
 (time-event ki_multiplier_change_3a @ki_multiplier_time_3a@ ((Ki_{grp} Ki_red3a_{grp})))
 (time-event ki_multiplier_change_3b @ki_multiplier_time_3b@ ((Ki_{grp} Ki_red3b_{grp})))
@@ -881,6 +882,7 @@ def write_interventions(grpList, total_string, scenarioName, change_testDelay=No
 (time-event ki_multiplier_change_10 @ki_multiplier_time_10@ ((Ki_{grp} Ki_red10_{grp})))
 (time-event ki_multiplier_change_11 @ki_multiplier_time_11@ ((Ki_{grp} Ki_red11_{grp})))
 (time-event ki_multiplier_change_12 @ki_multiplier_time_12@ ((Ki_{grp} Ki_red12_{grp})))
+(time-event ki_multiplier_change_13 @ki_multiplier_time_13@ ((Ki_{grp} Ki_red12_{grp})))
             """.format(grp=grp)
         ki_multiplier_change_str = ki_multiplier_change_str + temp_str
 

--- a/experiment_configs/EMSspecific_sample_parameters.yaml
+++ b/experiment_configs/EMSspecific_sample_parameters.yaml
@@ -408,6 +408,40 @@ sampled_parameters:
     EMS_11:
       np.random: uniform
       function_kwargs: {'low': 0.095, 'high': 0.095} 
+  'ki_multiplier_13':
+    EMS_1:
+      np.random: uniform
+      function_kwargs: {'low': 0.180, 'high': 0.180}
+    EMS_2:
+      np.random: uniform
+      function_kwargs: {'low': 0.131, 'high': 0.131}
+    EMS_3:
+      np.random: uniform
+      function_kwargs: {'low': 0.315, 'high': 0.315}
+    EMS_4:
+      np.random: uniform
+      function_kwargs: {'low': 0.205, 'high': 0.205}
+    EMS_5:
+      np.random: uniform
+      function_kwargs: {'low': 0.180, 'high': 0.180}
+    EMS_6:
+      np.random: uniform
+      function_kwargs: {'low': 0.220, 'high': 0.220}
+    EMS_7:
+      np.random: uniform
+      function_kwargs: {'low': 0.140, 'high': 0.140}
+    EMS_8:
+      np.random: uniform
+      function_kwargs: {'low': 0.120, 'high': 0.120}
+    EMS_9:
+      np.random: uniform
+      function_kwargs: {'low': 0.140, 'high': 0.140}
+    EMS_10:
+      np.random: uniform
+      function_kwargs: {'low': 0.150, 'high': 0.150}
+    EMS_11:
+      np.random: uniform
+      function_kwargs: {'low': 0.095, 'high': 0.095}
   'd_Sym':
     EMS_1:
       np.random: uniform

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -293,10 +293,12 @@ time_parameters:
   'ki_multiplier_time_11':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-11-11}
-   ### ki_multiplier_time_12 'inactivated' for later use
   'ki_multiplier_time_12':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-12-20}
+  'ki_multiplier_time_13':
+    custom_function: DateToTimestep
+    function_kwargs: {'dates': 2021-1-20}
   ### ---- Increased detections ---- 
   ### Change in d_Sys
   'detection_time_1':

--- a/experiment_configs/extendedcobey_200428_means.yaml
+++ b/experiment_configs/extendedcobey_200428_means.yaml
@@ -290,10 +290,12 @@ time_parameters:
   'ki_multiplier_time_11':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-11-11}
-   ### ki_multiplier_time_12 'inactivated' for later use
   'ki_multiplier_time_12':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-12-20}
+  'ki_multiplier_time_13':
+    custom_function: DateToTimestep
+    function_kwargs: {'dates': 2021-1-20}
   ### ---- Increased detections ---- 
   ### Change in d_Sys
   'detection_time_1':

--- a/experiment_configs/spatial_EMS_experiment.yaml
+++ b/experiment_configs/spatial_EMS_experiment.yaml
@@ -219,6 +219,22 @@ sampled_parameters:
         - {'low': 0.140, 'high': 0.140}
         - {'low': 0.150, 'high': 0.150}
         - {'low': 0.095, 'high': 0.095}
+  ki_multiplier_13:
+    IL:
+      expand_by_age: True
+      np.random: uniform
+      function_kwargs:
+        - {'low': 0.180, 'high': 0.180}
+        - {'low': 0.131, 'high': 0.131}
+        - {'low': 0.315, 'high': 0.315}
+        - {'low': 0.205, 'high': 0.205}
+        - {'low': 0.180, 'high': 0.180}
+        - {'low': 0.220, 'high': 0.220}
+        - {'low': 0.140, 'high': 0.140}
+        - {'low': 0.120, 'high': 0.120}
+        - {'low': 0.140, 'high': 0.140}
+        - {'low': 0.150, 'high': 0.150}
+        - {'low': 0.095, 'high': 0.095}
   ###------------------------------------------------
   ### REGION-SPECIFIC PARAMETER UPDATE
   ###------------------------------------------------

--- a/experiment_configs/spatial_EMS_experiment_means.yaml
+++ b/experiment_configs/spatial_EMS_experiment_means.yaml
@@ -219,6 +219,22 @@ sampled_parameters:
         - {'low': 0.140, 'high': 0.140}
         - {'low': 0.150, 'high': 0.150}
         - {'low': 0.095, 'high': 0.095}
+  ki_multiplier_13:
+    IL:
+      expand_by_age: True
+      np.random: uniform
+      function_kwargs:
+        - {'low': 0.180, 'high': 0.180}
+        - {'low': 0.131, 'high': 0.131}
+        - {'low': 0.315, 'high': 0.315}
+        - {'low': 0.205, 'high': 0.205}
+        - {'low': 0.180, 'high': 0.180}
+        - {'low': 0.220, 'high': 0.220}
+        - {'low': 0.140, 'high': 0.140}
+        - {'low': 0.120, 'high': 0.120}
+        - {'low': 0.140, 'high': 0.140}
+        - {'low': 0.150, 'high': 0.150}
+        - {'low': 0.095, 'high': 0.095}
   ###------------------------------------------------
   ### REGION-SPECIFIC PARAMETER UPDATE
   ###------------------------------------------------


### PR DESCRIPTION
…ateToTimestep function_kwargs: {'dates': 2021-1-20}) to: master yaml, master means yaml, spatial yaml, spatial means yamls. removed ki_multiplier_time_12 description text about activation status no longer needed ("### ki_multiplier_time_12 'inactivated' for later use").