### PR TITLE
trajectoriesName defined in load_sim_data and removed as custom argument in plotters

### DIFF
--- a/plotters/data_comparison.py
+++ b/plotters/data_comparison.py
@@ -37,12 +37,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 def compare_NMH(exp_name) :
@@ -209,7 +203,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 

--- a/plotters/data_comparison_spatial.py
+++ b/plotters/data_comparison_spatial.py
@@ -36,12 +36,7 @@ def parse_args():
         help="Local or NUCLUSTER",
         default = "Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
+
     return parser.parse_args()
     
 def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, region_label,
@@ -79,10 +74,10 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, r
     plot_name = 'compare_to_data_covidregion_' + str(ems_nr)
     if logscale == False :
         plot_name = plot_name + "_nolog"
-    plt.savefig(os.path.join(plot_path, plot_name + '.png'))
-    plt.savefig(os.path.join(plot_path,'pdf', plot_name + '.pdf'), format='PDF')
+    plt.savefig(os.path.join(plot_path, plot_name + '_50perc.png'))
+    plt.savefig(os.path.join(plot_path,'pdf', plot_name + '_50perc.pdf'), format='PDF')
 
-def compare_ems(exp_name,fname, ems_nr,first_day,last_day):
+def compare_ems(exp_name, ems_nr,first_day,last_day):
 
     if ems_nr == 0:
         region_suffix = "_All"
@@ -98,6 +93,10 @@ def compare_ems(exp_name,fname, ems_nr,first_day,last_day):
 
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
+
+    fname = f'trajectoriesDat_region_{str(ems_nr)}.csv'
+    if os.path.exists(os.path.join(sim_output_path, fname)) == False:
+        fname = 'trajectoriesDat.csv'
 
     df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname,column_list=column_list)
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
@@ -121,8 +120,7 @@ def compare_ems(exp_name,fname, ems_nr,first_day,last_day):
 if __name__ == '__main__':
 
     args = parse_args()
-    stem = args.stem
-    trajectoriesName = args.trajectoriesName
+    stem = '20210115_IL_quest_As8_corPop'
     Location = args.Location
 
     first_plot_day = date(2020, 2, 13)
@@ -132,7 +130,8 @@ if __name__ == '__main__':
 
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
     for exp_name in exp_names:
-        plot_path = os.path.join(wdir, 'simulation_output',exp_name, '_plots')
-        for ems_nr in range(0,12):
+        sim_output_path  = os.path.join(wdir, 'simulation_output',exp_name)
+        plot_path = os.path.join(sim_output_path, '_plots')
+        for ems_nr in range(1,12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name,fname=trajectoriesName, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day)
+            compare_ems(exp_name, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day)

--- a/plotters/data_comparison_spatial.py
+++ b/plotters/data_comparison_spatial.py
@@ -94,11 +94,7 @@ def compare_ems(exp_name, ems_nr,first_day,last_day):
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
 
-    fname = f'trajectoriesDat_region_{str(ems_nr)}.csv'
-    if os.path.exists(os.path.join(sim_output_path, fname)) == False:
-        fname = 'trajectoriesDat.csv'
-
-    df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname,column_list=column_list)
+    df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
     df['critical_with_suspected'] = df['critical']
 

--- a/plotters/data_comparison_spatial.py
+++ b/plotters/data_comparison_spatial.py
@@ -74,8 +74,8 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, r
     plot_name = 'compare_to_data_covidregion_' + str(ems_nr)
     if logscale == False :
         plot_name = plot_name + "_nolog"
-    plt.savefig(os.path.join(plot_path, plot_name + '_50perc.png'))
-    plt.savefig(os.path.join(plot_path,'pdf', plot_name + '_50perc.pdf'), format='PDF')
+    plt.savefig(os.path.join(plot_path, plot_name + '.png'))
+    plt.savefig(os.path.join(plot_path,'pdf', plot_name + '.pdf'), format='PDF')
 
 def compare_ems(exp_name, ems_nr,first_day,last_day):
 
@@ -120,7 +120,7 @@ def compare_ems(exp_name, ems_nr,first_day,last_day):
 if __name__ == '__main__':
 
     args = parse_args()
-    stem = '20210115_IL_quest_As8_corPop'
+    stem = args.stem
     Location = args.Location
 
     first_plot_day = date(2020, 2, 13)

--- a/plotters/data_comparison_spatial_2.py
+++ b/plotters/data_comparison_spatial_2.py
@@ -134,6 +134,6 @@ if __name__ == '__main__':
     for ems_nr in range(1, 12):
         print("Start processing region " + str(ems_nr))
         plot_sim_and_ref(exp_names, ems_nr=ems_nr, first_day=first_plot_day,
-                         last_day=last_plot_day, fname=trajectoriesName, logscale=True)
+                         last_day=last_plot_day, logscale=True)
         plot_sim_and_ref(exp_names, ems_nr=ems_nr, first_day=first_plot_day,
-                         last_day=last_plot_day, fname=trajectoriesName, logscale=False)
+                         last_day=last_plot_day, logscale=False)

--- a/plotters/data_comparison_spatial_2.py
+++ b/plotters/data_comparison_spatial_2.py
@@ -38,17 +38,11 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
 
     return parser.parse_args()
 
 
-def plot_sim_and_ref(exp_names, ems_nr, first_day, last_day, ymax=10000, logscale=True, fname="trajectoriesDat.csv"):
+def plot_sim_and_ref(exp_names, ems_nr, first_day, last_day, ymax=10000, logscale=True):
     if ems_nr == 0:
         region_suffix = "_All"
         region_label = 'Illinois'
@@ -83,7 +77,7 @@ def plot_sim_and_ref(exp_names, ems_nr, first_day, last_day, ymax=10000, logscal
             for chn in outcome_channels:
                 column_list.append(chn + "_EMS-" + str(ems_nr))
 
-            df = load_sim_data(exp_name, region_suffix, fname=fname, column_list=column_list)
+            df = load_sim_data(exp_name, region_suffix, column_list=column_list)
             df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
             df['critical_with_suspected'] = df['critical']
             exp_name_label = str(exp_name.split('_')[-1])
@@ -127,7 +121,6 @@ def plot_sim_and_ref(exp_names, ems_nr, first_day, last_day, ymax=10000, logscal
 if __name__ == '__main__':
 
     args = parse_args()
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     exp_names = args.exp_names
 

--- a/plotters/data_comparison_spatial_3.py
+++ b/plotters/data_comparison_spatial_3.py
@@ -39,12 +39,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 
@@ -113,7 +107,7 @@ def compare_ems(exp_name,fname, param, ems_nr,first_day,last_day):
 
     if "ki" in param.lower() :
         param = param + region_suffix2
-    df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname, column_list=column_list)
+    df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
     df['critical_with_suspected'] = df['critical']
 
@@ -134,7 +128,6 @@ def compare_ems(exp_name,fname, param, ems_nr,first_day,last_day):
 if __name__ == '__main__':
 
     args = parse_args()
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 
@@ -148,5 +141,5 @@ if __name__ == '__main__':
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
         for ems_nr in range(1, 12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name, fname=trajectoriesName, ems_nr=int(ems_nr), param="Ki",
+            compare_ems(exp_name,  ems_nr=int(ems_nr), param="Ki",
                         first_day=first_plot_day, last_day=last_plot_day)

--- a/plotters/data_comparison_spatial_3.py
+++ b/plotters/data_comparison_spatial_3.py
@@ -85,7 +85,7 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names,region_lab
     plt.savefig(os.path.join(plot_path, 'pdf', plot_name + '.pdf'), format='PDF')
 
 
-def compare_ems(exp_name,fname, param, ems_nr,first_day,last_day):
+def compare_ems(exp_name, param, ems_nr,first_day,last_day):
 
     if ems_nr == 0:
         region_suffix = "_All"

--- a/plotters/extract_sample_param.py
+++ b/plotters/extract_sample_param.py
@@ -104,8 +104,7 @@ def extract_samples(nsamples=100, seed_nr=751, save_dir=None, save_all_successfu
     fname = 'trajectoriesDat_trim.csv'
     if not os.path.exists(os.path.join(sim_output_path, fname)):
         fname = 'trajectoriesDat.csv'
-    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=['time', 'scen_num', 'sample_num', 'run_num'])
-    # sample_df = pd.read_csv(os.path.join(wdir, 'simulation_output', exp_name, 'sampled_parameters.csv'),usecols=['scen_num'] + sample_params)
+    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=['time','startdate' ,'scen_num', 'sample_num', 'run_num'])
     sample_df = pd.read_csv(os.path.join(wdir, 'simulation_output', exp_name, 'sampled_parameters.csv'))
 
     scen_success = list((df.scen_num.unique()))
@@ -149,7 +148,7 @@ def extract_mean_of_samples(save_dir=None, plot_dists=False, include_grp_param=T
                 IL_locale_param = IL_locale_param + [f'{param}_EMS_{reg_nr}']
         sample_params = sample_params + IL_locale_param
 
-    df = load_sim_data(exp_name, column_list=['time', 'scen_num', 'sample_num', 'run_num'], add_incidence=False)
+    df = load_sim_data(exp_name, column_list=['time','startdate', 'scen_num', 'sample_num', 'run_num'], add_incidence=False)
     sample_df = pd.read_csv(os.path.join(sim_output_path, 'sampled_parameters.csv'))
 
     scen_success = list((df.scen_num.unique()))
@@ -197,7 +196,7 @@ def extract_mean_of_samples(save_dir=None, plot_dists=False, include_grp_param=T
 
 if __name__ == '__main__':
     args = parse_args()
-    exp_name = "'20210119_IL_quest_varyParamForFit'"
+    exp_name = args.exp_name
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location="Local")

--- a/plotters/extract_sample_param.py
+++ b/plotters/extract_sample_param.py
@@ -43,12 +43,12 @@ def plot_param_by_channel(sample_df, param_list, param_class, plot_path, region_
         time_step = 262
     if fname is None:
         fname = 'trajectoriesDat_trim.csv'
-        if not os.path.exists(os.path.join(exp_dir, fname)):
+        if not os.path.exists(os.path.join(sim_output_path, fname)):
             fname = 'trajectoriesDat.csv'
     if channel is None:
         channel = 'crit_det'
     channel_name = f'{channel}_{region_suffix}'
-    df = pd.read_csv(os.path.join(exp_dir, fname), usecols=['time', 'startdate', 'scen_num', 'sample_num', 'run_num', channel_name])
+    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=['time', 'startdate', 'scen_num', 'sample_num', 'run_num', channel_name])
     df['time'] = df['time'].astype('int64')
     df = df[df['time'] == time_step]
     df = pd.merge(how='left', left=df, left_on=['scen_num', 'sample_num'], right=sample_df,
@@ -94,7 +94,7 @@ def plot_param_distributions(df, param_list, param_class, plot_path):
     plt.savefig(os.path.join(plot_path, 'pdf', plot_name + '.pdf'))
 
 
-def extract_samples(exp_dir, nsamples=100, seed_nr=751, save_dir=None, save_all_successfull=False, plot_dists=False,
+def extract_samples(nsamples=100, seed_nr=751, save_dir=None, save_all_successfull=False, plot_dists=False,
                     include_grp_param=True):
     sample_params, sample_params_core, IL_specific_param, IL_locale_param_stem = get_parameter_names(include_new=False)
 
@@ -106,9 +106,9 @@ def extract_samples(exp_dir, nsamples=100, seed_nr=751, save_dir=None, save_all_
         sample_params = sample_params + IL_locale_param
 
     fname = 'trajectoriesDat_trim.csv'
-    if not os.path.exists(os.path.join(exp_dir, fname)):
+    if not os.path.exists(os.path.join(sim_output_path, fname)):
         fname = 'trajectoriesDat.csv'
-    df = pd.read_csv(os.path.join(exp_dir, fname), usecols=['time', 'scen_num', 'sample_num', 'run_num'])
+    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=['time', 'scen_num', 'sample_num', 'run_num'])
     # sample_df = pd.read_csv(os.path.join(wdir, 'simulation_output', exp_name, 'sampled_parameters.csv'),usecols=['scen_num'] + sample_params)
     sample_df = pd.read_csv(os.path.join(wdir, 'simulation_output', exp_name, 'sampled_parameters.csv'))
 
@@ -126,7 +126,7 @@ def extract_samples(exp_dir, nsamples=100, seed_nr=751, save_dir=None, save_all_
     df_extract['scen_num'] = range(len(df_extract.index))
 
     if save_dir is None:
-        save_dir = exp_dir
+        save_dir = sim_output_path
     df_extract.to_csv(os.path.join(save_dir, f'sample_parameters_extract_n{str(nsamples)}.csv'), index=False)
     if save_all_successfull:
         df_all_success = sample_df[sample_df['scen_num'].isin(scen_success)]
@@ -143,7 +143,7 @@ def extract_samples(exp_dir, nsamples=100, seed_nr=751, save_dir=None, save_all_
                               plot_path=plot_path)
 
 
-def extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_grp_param=True, fname=None):
+def extract_mean_of_samples(save_dir=None, plot_dists=False, include_grp_param=True, fname=None):
     sample_params, sample_params_core, IL_specific_param, IL_locale_param_stem = get_parameter_names(include_new=False)
 
     if include_grp_param:
@@ -153,13 +153,8 @@ def extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_gr
                 IL_locale_param = IL_locale_param + [f'{param}_EMS_{reg_nr}']
         sample_params = sample_params + IL_locale_param
 
-    if fname is None:
-        fname = 'trajectoriesDat_trim.csv'
-        if not os.path.exists(os.path.join(exp_dir, fname)):
-            fname = 'trajectoriesDat.csv'
-    df = pd.read_csv(os.path.join(exp_dir, fname),
-                     usecols=['time', 'scen_num', 'sample_num', 'run_num'])
-    sample_df = pd.read_csv(os.path.join(exp_dir, 'sampled_parameters.csv'))
+    df = load_sim_data(exp_name, column_list=['time', 'scen_num', 'sample_num', 'run_num'], add_incidence=False)
+    sample_df = pd.read_csv(os.path.join(sim_output_path, 'sampled_parameters.csv'))
 
     scen_success = list((df.scen_num.unique()))
     del df
@@ -176,7 +171,7 @@ def extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_gr
             df_stats = pd.merge(how='left', left=df_stats, left_on='parameter', right=mdf, right_on='parameter')
 
     if save_dir is None:
-        save_dir = exp_dir
+        save_dir = sim_output_path
     df_stats.to_csv(os.path.join(save_dir, 'sample_parameters_summary_stats.csv'), index=False)
     df_mean = sample_df_success.groupby('dummy')[sample_df.columns].agg(np.mean).reset_index()
     df_mean['index'] = 1
@@ -184,6 +179,16 @@ def extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_gr
     df_mean['sample_num'] = 1
     df_mean['startdate'] = sample_df_success['startdate'].unique()
     df_mean.to_csv(os.path.join(save_dir, 'sample_parameters_mean.csv'), index=False)
+
+    if plot_dists:
+        plot_param_distributions(df=sample_df, param_list=sample_params_core, param_class="Core_model_parameters",
+                                 plot_path=plot_path)
+        plot_param_distributions(df=sample_df, param_list=IL_specific_param, param_class="IL_specific_model_parameters",
+                                 plot_path=plot_path)
+        plot_param_distributions(df=sample_df, param_list=IL_locale_param[1:20],
+                                 param_class="IL_specific_grp_parameters", plot_path=plot_path)
+
+
 
     if plot_dists:
         plot_param_distributions(df=sample_df, param_list=sample_params_core, param_class="Core_model_parameters",
@@ -196,12 +201,12 @@ def extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_gr
 
 if __name__ == '__main__':
     args = parse_args()
-    exp_name = args.exp_name
+    exp_name = "'20210119_IL_quest_varyParamForFit'"
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location="Local")
-    exp_dir = os.path.join(wdir, 'simulation_output', exp_name)
-    plot_path = os.path.join(exp_dir, '_plots')
+    sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+    plot_path = os.path.join(sim_output_path, '_plots')
 
-    extract_samples(exp_dir, save_dir=None, plot_dists=True, include_grp_param=True)
-    extract_mean_of_samples(exp_dir, save_dir=None, plot_dists=False, include_grp_param=True)
+    #extract_samples(save_dir=None, plot_dists=True, include_grp_param=True)
+    extract_mean_of_samples(save_dir=None, plot_dists=False, include_grp_param=True)

--- a/plotters/extract_sample_param.py
+++ b/plotters/extract_sample_param.py
@@ -37,18 +37,14 @@ def parse_args():
     return parser.parse_args()
 
 
-def plot_param_by_channel(sample_df, param_list, param_class, plot_path, region_suffix='All', fname=None, channel=None,
+def plot_param_by_channel(sample_df, param_list, param_class, plot_path, region_suffix='All', channel=None,
                           time_step=None):
     if time_step is None:
         time_step = 262
-    if fname is None:
-        fname = 'trajectoriesDat_trim.csv'
-        if not os.path.exists(os.path.join(sim_output_path, fname)):
-            fname = 'trajectoriesDat.csv'
     if channel is None:
         channel = 'crit_det'
     channel_name = f'{channel}_{region_suffix}'
-    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=['time', 'startdate', 'scen_num', 'sample_num', 'run_num', channel_name])
+    df = load_sim_data(exp_name, region_suffix=None, column_list=['time', 'startdate', 'scen_num', 'sample_num', 'run_num', channel_name])
     df['time'] = df['time'].astype('int64')
     df = df[df['time'] == time_step]
     df = pd.merge(how='left', left=df, left_on=['scen_num', 'sample_num'], right=sample_df,

--- a/plotters/hosp_icu_deaths_forecast_plotter.py
+++ b/plotters/hosp_icu_deaths_forecast_plotter.py
@@ -31,12 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 
@@ -114,7 +108,7 @@ def compare_ems(exp_name, fname, plot_name, ems_nr, first_day , last_day):
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
 
-    df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname, column_list=column_list)
+    df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[(df['date'] >= first_day) & (df['date'] <= last_day)]
 
     ref_df = load_ref_df(ems_nr)
@@ -135,7 +129,6 @@ if __name__ == '__main__':
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
 
     first_plot_day = date.today() - timedelta(60)
@@ -148,5 +141,5 @@ if __name__ == '__main__':
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
         for ems_nr in range(0, 12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name, fname=trajectoriesName, ems_nr=int(ems_nr), plot_name='forward_projection',
+            compare_ems(exp_name, ems_nr=int(ems_nr), plot_name='forward_projection',
                         first_day=first_plot_day, last_day=last_plot_day)

--- a/plotters/hosp_icu_deaths_forecast_plotter.py
+++ b/plotters/hosp_icu_deaths_forecast_plotter.py
@@ -89,7 +89,7 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, p
     plt.savefig(os.path.join(plot_path, plot_name_full + '.png'))
     plt.savefig(os.path.join(plot_path, 'pdf', plot_name_full + '.pdf'), format='PDF')
 
-def compare_ems(exp_name, fname, plot_name, ems_nr, first_day , last_day):
+def compare_ems(exp_name, plot_name, ems_nr, first_day , last_day):
 
     if ems_nr == 0:
         region_suffix = "_All"

--- a/plotters/locale_age_postprocessing.py
+++ b/plotters/locale_age_postprocessing.py
@@ -31,12 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 def calculate_mean_and_CI(adf, channel, output_filename=None) :
@@ -77,7 +71,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 
@@ -89,7 +82,7 @@ if __name__ == '__main__' :
         sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
         plot_path = os.path.join(sim_output_path, '_plots')
 
-        df = pd.read_csv(os.path.join(wdir, 'simulation_output', exp_name, 'trajectoriesDat.csv'))
+        df = load_sim_data(exp_name, region_suffix=None, add_incidence=False)
         suffix_names = [x.split('_')[1] for x in df.columns.values if 'susceptible' in x]
         base_names = [x.split('_%s' % suffix_names[0])[0] for x in df.columns.values if suffix_names[0] in x]
 

--- a/plotters/overflow_numbers.py
+++ b/plotters/overflow_numbers.py
@@ -99,7 +99,7 @@ def get_plot(selected_resource_type='hb_availforcovid', errorbars=True):
     fig.savefig(os.path.join(exp_dir, '_plots', 'pdf', f'{plotname}.pdf'))
 
 def get_numbers(exp_name, load_template=False):
-    trajectories = load_sim_data(exp_name)  # pd.read_csv('trajectoriesDat_200814_1.csv', usecols=column_list)
+    trajectories = load_sim_data(exp_name)
 
     if load_template:
         fname = get_latest_filedate()
@@ -147,9 +147,9 @@ def get_numbers(exp_name, load_template=False):
 if __name__ == '__main__':
     stem = sys.argv[1]
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
-    #exp_names = ['20201028_IL_rollback_toki8']
 
     for exp_name in exp_names:
+
         civis_template = get_numbers(exp_name)
         get_plot(selected_resource_type='icu_availforcovid')
         get_plot(selected_resource_type='hb_availforcovid')

--- a/plotters/overflow_probabilities.py
+++ b/plotters/overflow_probabilities.py
@@ -145,7 +145,7 @@ def plot_probs(exp_name, show_75=True) :
 
 
 if __name__ == '__main__':
-    stem = '20210119_IL_quest_varyParamForFit'
+    stem = sys.argv[1]
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
 
     for exp_name in exp_names:

--- a/plotters/overflow_probabilities.py
+++ b/plotters/overflow_probabilities.py
@@ -54,8 +54,8 @@ def get_latest_filedate(file_path=os.path.join(datapath, 'covid_IDPH', 'Corona v
 
 def get_probs(exp_name,select_traces=True):
 
-    fname = get_latest_filedate()
-    civis_template = pd.read_csv(os.path.join(datapath, 'covid_IDPH', 'Corona virus reports', 'hospital_capacity_thresholds', fname))
+    fname_capacity = get_latest_filedate()
+    civis_template = pd.read_csv(os.path.join(datapath, 'covid_IDPH', 'Corona virus reports', 'hospital_capacity_thresholds', fname_capacity))
     civis_template = civis_template.drop_duplicates()
     civis_template['date_window_upper_bound'] = pd.to_datetime(civis_template['date_window_upper_bound'])
     lower_limit = 170
@@ -145,7 +145,7 @@ def plot_probs(exp_name, show_75=True) :
 
 
 if __name__ == '__main__':
-    stem = sys.argv[1]
+    stem = '20210119_IL_quest_varyParamForFit'
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
 
     for exp_name in exp_names:

--- a/plotters/plot_by_param_ICU_nonICU.py
+++ b/plotters/plot_by_param_ICU_nonICU.py
@@ -31,13 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
-
     return parser.parse_args()
 
 def plot_on_fig(df, c, axes,channel, color,panel_heading, ems, label=None, addgrid=True) :
@@ -149,7 +142,6 @@ def plot_covidregions(channel,subgroups, plot_path,first_day, last_day) :
 if __name__ == '__main__' :
 
     args = parse_args()
-    trajectoriesName = args.trajectoriesName
     exp_names = args.exp_names
     Location = args.Location
 

--- a/plotters/plot_exp_by_varying_param.py
+++ b/plotters/plot_exp_by_varying_param.py
@@ -32,12 +32,6 @@ def parse_args():
         default = "Local"
     )
     parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
-    parser.add_argument(
         "-p", "--param",
         type=str,
         help="Name of parameter with varying levels to plot",
@@ -115,7 +109,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     param = args.param
     channel = args.channel

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -34,25 +34,19 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 def get_prev_df(df, channels, fname='trajectoriesDat.csv'):
 
     sort_channels = ['scen_num', 'sample_num', 'run_num', 'time']
     group_channels = ['scen_num', 'sample_num', 'run_num']
-    region_list = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
+    region_list = ['EMS-%d' % x for x in range(1, 12)]
 
     df = pd.DataFrame()
     for ems_region in region_list:
         print(ems_region)
         ems_nr = ems_region.replace("EMS-","")
-        if ems_region=="All": ems_nr  = 0
+        if ems_region== "All": ems_nr = 0
         get_det =0
         for ch in channels:
             if 'det' in ch: get_det = get_det + 1
@@ -69,7 +63,7 @@ def get_prev_df(df, channels, fname='trajectoriesDat.csv'):
             column_list.append('recovered_det_' + str(ems_region))
             column_list.append('deaths_det_' + str(ems_region))
 
-        df_i = load_sim_data(exp_name, region_suffix=f'_{ems_region}', fname=fname, column_list=column_list, add_incidence=False)
+        df_i = load_sim_data(exp_name, region_suffix=f'_{ems_region}', column_list=column_list, add_incidence=False)
         if ems_region !="All" :
             df_i['N'] = df_i['N_' + str(ems_region.replace("-", "_"))]
         df_i[f'new_deaths'] = df_i.sort_values(sort_channels).groupby(group_channels)[f'deaths'].diff()
@@ -135,7 +129,6 @@ if __name__ == '__main__':
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
 
     first_plot_day = date.today() - timedelta(300)
@@ -151,7 +144,7 @@ if __name__ == '__main__':
 
         channels = ['prevalence','seroprevalence','IFR','IFR_t']
         #channels = ['prevalence','prevalence_det' ,'seroprevalence','seroprevalence_det' ,'IFR','IFR_t','IFR_det']
-        df = get_prev_df(exp_name, channels=channels, fname=trajectoriesName)
+        df = get_prev_df(exp_name, channels=channels)
         plot_prevalences(df, channels=['prevalence'], first_day=first_plot_day, last_day=last_plot_day)
         plot_prevalences(df, channels=['seroprevalence'], first_day=first_plot_day,last_day=last_plot_day)
         plot_prevalences(df, channels=['IFR'],first_day=first_plot_day,last_day=last_plot_day)

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -40,7 +40,7 @@ def get_prev_df(df, channels, fname='trajectoriesDat.csv'):
 
     sort_channels = ['scen_num', 'sample_num', 'run_num', 'time']
     group_channels = ['scen_num', 'sample_num', 'run_num']
-    region_list = ['EMS-%d' % x for x in range(1, 12)]
+    region_list = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
 
     df = pd.DataFrame()
     for ems_region in region_list:

--- a/plotters/plot_split_by_channel.py
+++ b/plotters/plot_split_by_channel.py
@@ -31,12 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 def plot_on_fig(df, channels, axes, color, label) :
@@ -84,7 +78,7 @@ def compare_channels(channelGrp):
     axes = [fig.add_subplot(2, 3, x + 1) for x in range(len(nchannels['channels1']))]
 
     for d, key in enumerate(nchannels.keys()):
-        sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+
         df = load_sim_data(exp_name)
         df = df[(df['date'] >= first_plot_day) & (df['date'] <= last_plot_day)]
 
@@ -106,7 +100,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths()
@@ -116,7 +109,8 @@ if __name__ == '__main__' :
 
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
     for exp_name in exp_names:
-        plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
+        sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+        plot_path = os.path.join(sim_output_path, '_plots')
         #compare_channels(channelGrp= "symp")
         #compare_channels(channelGrp= "infect")
         compare_channels(channelGrp= "hospCrit")

--- a/plotters/plot_split_by_param.py
+++ b/plotters/plot_split_by_param.py
@@ -31,12 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default="Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 
@@ -211,7 +205,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths()

--- a/plotters/plot_split_by_param_trajectories.py
+++ b/plotters/plot_split_by_param_trajectories.py
@@ -31,12 +31,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default = "Local"
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
     return parser.parse_args()
 
 def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
@@ -168,7 +162,6 @@ if __name__ == '__main__' :
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
 
     first_plot_day = date.today() - timedelta(300)

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -37,13 +37,6 @@ def parse_args():
         help="Local or NUCLUSTER",
         default='Local',
     )
-    parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, could be trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv',
-    )
-
     return parser.parse_args()
     
 def get_scenarioName(exp_suffix) :
@@ -94,7 +87,7 @@ def plot_sim(dat,suffix,channels) :
         plt.savefig(os.path.join(plot_path, 'pdf', plotname + '.pdf'), format='PDF')
         # plt.show()
 
-def load_and_plot_data(ems_region, fname , savePlot=True) :
+def load_and_plot_data(ems_region, savePlot=True) :
     region_suffix = f'_{str(ems_region)}'
     column_list = ['startdate', 'time', 'scen_num', 'sample_num', 'run_num']
     outcome_channels = ['susceptible', 'infected', 'recovered', 'infected_cumul', 'asymp_cumul', 'asymp_det_cumul', 'symp_mild_cumul', 'symp_severe_cumul', 'symp_mild_det_cumul',
@@ -104,7 +97,7 @@ def load_and_plot_data(ems_region, fname , savePlot=True) :
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
 
-    df = load_sim_data(exp_name,region_suffix = region_suffix,fname=fname, column_list=column_list)
+    df = load_sim_data(exp_name,region_suffix = region_suffix, column_list=column_list)
     df['ems'] = ems_region
     df = df[(df['date'] >= plot_first_day) & (df['date'] <= plot_last_day)]
 
@@ -179,7 +172,6 @@ if __name__ == '__main__' :
     exp_name = args.exp_name # "20200910_IL_RR_baseline_combined"
     simdate = exp_name.split("_")[0]
     processStep = args.processStep # 'generate_outputs'
-    trajectoriesName = args.trajectoriesName
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=args.Location)
 
@@ -197,7 +189,7 @@ if __name__ == '__main__' :
         dfAll = pd.DataFrame()
         for reg in regions :
             print( f'Start processing {reg}')
-            tdf = load_and_plot_data(reg,fname=trajectoriesName , savePlot=True)
+            tdf = load_and_plot_data(reg, savePlot=True)
             adf = process_and_save(tdf, reg, SAVE=True)
             dfAll = pd.concat([dfAll, adf])
             del tdf

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -203,4 +203,4 @@ if __name__ == '__main__':
         output_path = os.path.join(wdir, 'simulation_output',exp_name)
         for ems_nr in range(0,12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day,weights_array=weights_array, plot_trajectories=True)
+            compare_ems(exp_name, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day,weights_array=weights_array, plot_trajectories=args.plot)

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -36,12 +36,6 @@ def parse_args():
         default = "Local"
     )
     parser.add_argument(
-        "-t", "--trajectoriesName",
-        type=str,
-        help="Name of trajectoriesDat file, trajectoriesDat.csv or trajectoriesDat_trim.csv",
-        default='trajectoriesDat.csv'
-    )
-    parser.add_argument(
         "--deaths_weight",
         type=float,
         help="Weight of deaths in negative log likelihood calculation. Default is 1.0.",
@@ -159,7 +153,7 @@ def compare_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles
         plt.savefig(os.path.join(plot_path,'pdf', plot_name + '.pdf'), format='PDF')
 
 
-def compare_ems(exp_name,fname, ems_nr,first_day,last_day,weights_array,plot_trajectories=False):
+def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,plot_trajectories=False):
 
     if ems_nr == 0:
         region_suffix = "_All"
@@ -176,7 +170,7 @@ def compare_ems(exp_name,fname, ems_nr,first_day,last_day,weights_array,plot_tra
     for channel in outcome_channels:
         column_list.append(channel + region_suffix)
 
-    df = load_sim_data(exp_name, region_suffix=region_suffix, fname=fname,column_list=column_list)
+    df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[(df['date'] >= date(2020, 2, 13)) & (df['date'] <= date.today() + timedelta(15))]
     df['critical_with_suspected'] = df['critical']
 
@@ -196,7 +190,6 @@ if __name__ == '__main__':
 
     args = parse_args()
     stem = args.stem
-    trajectoriesName = args.trajectoriesName
     Location = args.Location
     weights_array = [args.deaths_weight, args.crit_weight, args.non_icu_weight, args.cli_weight]
 
@@ -210,4 +203,4 @@ if __name__ == '__main__':
         output_path = os.path.join(wdir, 'simulation_output',exp_name)
         for ems_nr in range(0,12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name,fname=trajectoriesName, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day,weights_array=weights_array, plot_trajectories=args.plot)
+            compare_ems(exp_name, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day,weights_array=weights_array, plot_trajectories=True)

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -9,7 +9,7 @@ datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
 
 def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname=None,
                   input_sim_output_path =None, column_list=None, add_incidence=True,
-                  select_traces=True, traces_to_keep_ratio=2, min_traces_to_keep=10) :
+                  select_traces=True, traces_to_keep_ratio=4, min_traces_to_keep=100) :
     input_wdir = input_wdir or wdir
     sim_output_path_base = os.path.join(input_wdir, 'simulation_output', exp_name)
     sim_output_path = input_sim_output_path or sim_output_path_base
@@ -34,7 +34,7 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname=None,
                 n_traces_to_keep = int(len(rank_export_df) / traces_to_keep_ratio)
                 if n_traces_to_keep < min_traces_to_keep and len(rank_export_df) >= min_traces_to_keep :
                     n_traces_to_keep = min_traces_to_keep
-                elif n_traces_to_keep < min_traces_to_keep and len(rank_export_df) < min_traces_to_keep :
+                if len(rank_export_df) < min_traces_to_keep :
                     n_traces_to_keep = len(rank_export_df)
 
                 rank_export_df_sub = rank_export_df[0:n_traces_to_keep]

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -272,14 +272,14 @@ def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajecto
     pymodule = '\n\nml python/anaconda3.6\n'
     rmodule = '\n\nml module load R/4.0.0\n'
 
-    pycommand = f'\npython /projects/p30781/covidproject/covid-chicago/nucluster/combine.py  "{exp_name}" "120" "10"'
-    file = open(os.path.join(temp_exp_dir, 'combineSimulations.sh'), 'w')
+    pycommand = f'\npython /projects/p30781/covidproject/covid-chicago/nucluster/combine_and_trim.py  --stem "{exp_name}" '
+    file = open(os.path.join(temp_exp_dir, '0_runCombineAndTrimTrajectories.sh'), 'w')
     file.write(header + jobname + err + out + pymodule + pycommand)
     file.close()
 
     pycommand = f'cd {plotters_dir} \npython /projects/p30781/covidproject/covid-chicago/nucluster/cleanup.py --stem "{exp_name}"' \
                 ' --delete_simsfiles "True"'
-    file = open(os.path.join(temp_exp_dir, 'cleanupSimulations.sh'), 'w')
+    file = open(os.path.join(temp_exp_dir, '0_cleanupSimulations.sh'), 'w')
     file.write(header + jobname + err + out + pymodule + pycommand)
     file.close()
 
@@ -288,7 +288,7 @@ def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajecto
     if "spatial_EMS" not in experiment_config:
         fname = "data_comparison.py"
     pycommand = f'cd {plotters_dir} \npython {plotters_dir}/{fname} --stem "{exp_name}" --Location "NUCLUSTER"'
-    file = open(os.path.join(temp_exp_dir, '0_compareToData.sh'), 'w')
+    file = open(os.path.join(temp_exp_dir, '0_runDataComparison.sh'), 'w')
     file.write(header + jobname + err + out + pymodule + pycommand)
     file.close()
 

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -253,6 +253,13 @@ def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajecto
              '#SBATCH -N 1\n' \
              '#SBATCH --ntasks-per-node=1\n' \
              '#SBATCH --mem=18G'
+    header_post = '#!/bin/bash\n'\
+                  '#SBATCH -A p30781\n' \
+                  '#SBATCH -p short\n' \
+                  '#SBATCH -t 02:00:00\n' \
+                  '#SBATCH -N 1\n' \
+                  '#SBATCH --ntasks-per-node=1\n' \
+                  '#SBATCH --mem=32G'
     jobname = f'\n#SBATCH	--job-name="{exp_name_short}"'
     array = f'\n#SBATCH --array=1-{str(scen_num)}'
     err = '\n#SBATCH --error=log/arrayJob_%A_%a.err'
@@ -272,9 +279,9 @@ def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajecto
     pymodule = '\n\nml python/anaconda3.6\n'
     rmodule = '\n\nml module load R/4.0.0\n'
 
-    pycommand = f'\npython /projects/p30781/covidproject/covid-chicago/nucluster/combine_and_trim.py  --stem "{exp_name}" '
+    pycommand = f'\ncd /projects/p30781/covidproject/covid-chicago/nucluster/\npython combine_and_trim.py  --stem "{exp_name}" '
     file = open(os.path.join(temp_exp_dir, '0_runCombineAndTrimTrajectories.sh'), 'w')
-    file.write(header + jobname + err + out + pymodule + pycommand)
+    file.write(header_post + jobname + err + out + pymodule + pycommand)
     file.close()
 
     pycommand = f'cd {plotters_dir} \npython /projects/p30781/covidproject/covid-chicago/nucluster/cleanup.py --stem "{exp_name}"' \


### PR DESCRIPTION
- currently `fname`  was an custom argument in each plotters file, per default set to '`trajectoriesDat.csv`'
- large simulations have separate trajectories per region, which was not supported in postprocessing files
- instead of revising  `fname` in each plotters file, the `load_sim_data `function was revised to per default take the region specific trajectoriesDat (`trajectoriesDat_region_1.csv`)) if available and otherwise take the  '`trajectoriesDat.csv`'
- therefore the name of the trajectoriesDat.csv does not need to be specified anymore in each plotters script (still optional argument when calling `load_sim_data `
- edited `combine_and_trim.csv` used on the NU cluster and will be aligned with local in separate PR (managing sample parameters and n scenarios to keep differently to avoid when running into file size and memory issues, as simulations on quest are bigger)

- Note: based on discussions changed default for trace selection in `load_sim_data `to 25% of trajectories **OR** at least 100 trajectories, if less than 100 trajectories were run, the maximum is taken (i.e. in testing sims).
