### PR TITLE
bugfix handling of Inf in trace_selection.py

### DIFF
--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -87,7 +87,9 @@ def sum_nll(df_values, ref_df_values):
         print('ERROR: The simulation and reference arrays may not be the same length.')
         print('Length simulation: ' + str(len(df_values)))
         print('Length reference: ' + str(len(ref_df_values)))
-    x[np.abs(x) == np.inf] = 0
+    len_inf = len(list(i for i in list(x) if i == float('inf')))
+    if len_inf <= len(x)*0.9:
+        x[np.abs(x) == np.inf] = 0
     return np.nansum(x)
 
 def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0]):
@@ -112,6 +114,7 @@ def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0]):
         total_nll += cli_weight*sum_nll(df_trunc_slice['new_detected_hospitalized'].values, ref_df_trunc['inpatient'].values)
         total_nll += non_icu_weight*sum_nll(df_trunc_slice['hosp_det'].values, ref_df_trunc['covid_non_icu'].values)
         rank_export_df = rank_export_df.append(pd.DataFrame({'run_num':[run_num], 'sample_num':[sample_num], 'scen_num':[scen_num], 'nll':[total_nll]}))
+    rank_export_df = rank_export_df.dropna()
     rank_export_df['norm_rank'] = (rank_export_df['nll'].rank()-1)/(len(rank_export_df)-1)
     rank_export_df = rank_export_df.sort_values(by=['norm_rank']).reset_index(drop=True)
     rank_export_df.to_csv(os.path.join(output_path,'traces_ranked_region_' + str(ems_nr) + '.csv'), index=False)
@@ -212,7 +215,7 @@ if __name__ == '__main__':
 
     """If fitting to deaths, include a lag of 14 days (applies to all indicators)"""
     timelag_days = 0
-    if args.deaths_weight is not 0:
+    if args.deaths_weight != 0:
         timelag_days = 14
 
     first_plot_day = pd.Timestamp('2020-03-25')

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -87,10 +87,10 @@ def sum_nll(df_values, ref_df_values):
         print('ERROR: The simulation and reference arrays may not be the same length.')
         print('Length simulation: ' + str(len(df_values)))
         print('Length reference: ' + str(len(ref_df_values)))
-    len_inf = len(list(i for i in list(x) if i == float('inf')))
+    len_inf = len(list(i for i in list(x) if i == np.inf))
     if len_inf <= len(x)*0.9:
         x[np.abs(x) == np.inf] = 0
-    return np.nansum(x)
+    return np.sum(x)
 
 def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0]):
     #Creation of rank_df


### PR DESCRIPTION
In a previous commit `np.sum` was changed to `np.nansum` as in one example vector one item was missing despite having ` x[np.abs(x) == np.inf] = 0`, returning NA/inf for the scenario.
However when all items are ` inf` (i.e. low transmission rate no epidemic), then `np.nansum`  returns 0 resulting in 'best fit'.
Therefore keep calculated nll value for scenarios with at least 90% non `inf `values (calculated per scenario over timesteps). 
Changed  `np.nansum`  back  to  `np.sum`, as there should not be any missing values left in `x`.
(issue of best fit for no epidemic occurred in '20210126_IL_mr_test2_newmodelparam')