### PR TITLE
bugfix, removed date constraints in civis process csv and rt plotter

### DIFF
--- a/plotters/estimate_Rt_forCivisOutputs.py
+++ b/plotters/estimate_Rt_forCivisOutputs.py
@@ -56,7 +56,7 @@ def get_distributions(show_plot=False):
     return si_distrb, delay_distrb
 
 
-def rt_plot(df, first_day=None, last_day=None):
+def rt_plot(df, plotname,first_day=None, last_day=None):
     fig = plt.figure(figsize=(16, 8))
     fig.suptitle(x=0.5, y=0.989, t='Estimated time-varying reproductive number (Rt)')
     fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.93, bottom=0.05)
@@ -93,9 +93,7 @@ def rt_plot(df, first_day=None, last_day=None):
         ax.axhline(y=1, color='black', linestyle='-')
         ax.set_ylim(rt_min, rt_max)
 
-    plotname = 'estimated_rt_by_covidregion_full'
-    if not first_day == None:
-        plotname = 'rt_by_covidregion_truncated'
+
     plt.savefig(os.path.join(plot_path, f'{plotname}.png'))
     plt.savefig(os.path.join(plot_path, 'pdf', f'{plotname}.pdf'), format='PDF')
 
@@ -141,8 +139,7 @@ def run_Rt_estimation(smoothing_window, r_window_size):
         df_rt_all = df_rt_all.append(df_rt)
 
     df_rt_all.to_csv(os.path.join(exp_dir, 'rtNU.csv'), index=False)
-    rt_plot(df=df_rt_all, first_day=None, last_day=None)
-    rt_plot(df=df_rt_all, first_day=first_plot_day, last_day=last_plot_day)
+    rt_plot(df=df_rt_all, first_day=last_plot_day - pd.Timedelta(60,'days'), last_day=last_plot_day, plotname='rt_by_covidregion_truncated')
 
     if not 'rt_median' in df.columns:
         df_with_rt = pd.merge(how='left', left=df, right=df_rt_all,
@@ -156,23 +153,24 @@ def run_Rt_estimation(smoothing_window, r_window_size):
                               left_on=['date', 'geography_modeled'],
                               right_on=['date', 'geography_modeled'])
         df_with_rt.to_csv(os.path.join(exp_dir, f'nu_{simdate}.csv'), index=False)
+    rt_plot(df=df_rt_all,plotname='estimated_rt_by_covidregion_full')
 
     return df_rt
 
 
 if __name__ == '__main__':
 
-    test_mode = False
+    test_mode = True
     if test_mode:
-        stem = '20210105_IL_mr_testrun'
+        stem = "20210203_IL_quest_baseline"
         Location = 'Local'
     else:
         args = parse_args()
         stem = args.stem
         Location = args.Location
 
-    first_plot_day = pd.Timestamp.today() - pd.Timedelta(30, 'days')
-    last_plot_day = pd.Timestamp.today() + pd.Timedelta(15, 'days')
+    first_plot_day = pd.Timestamp('2020-03-01')
+    last_plot_day = pd.Timestamp.today() + pd.Timedelta(60,'days')
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -52,13 +52,14 @@ def get_scenarioName(exp_suffix) :
     return(scenarioName)
 
 
-def plot_sim(dat,suffix,channels) :
+def plot_sim(dat,suffix,channels, first_plot_day, last_plot_day) :
 
         if suffix not in ["All","central","southern","northeast","northcentral"]:
             suffix_nr = str(suffix.split("-")[1])
         if suffix == "All":
             suffix_nr ="illinois"
         capacity = load_capacity(suffix_nr)
+        dat = dat[dat['date'].between(first_plot_day, last_plot_day)]
 
         fig = plt.figure(figsize=(18, 12))
         fig.subplots_adjust(right=0.97, wspace=0.2, left=0.07, hspace=0.15)
@@ -99,7 +100,7 @@ def load_and_plot_data(ems_region, savePlot=True) :
 
     df = load_sim_data(exp_name,region_suffix = region_suffix, column_list=column_list)
     df['ems'] = ems_region
-    df = df[df['date'].between(first_plot_day, last_plot_day)]
+
 
     df['ventilators'] = get_vents(df['crit_det'].values)
     df['new_symptomatic'] = df['new_symptomatic_severe'] + df['new_symptomatic_mild'] + df['new_detected_symptomatic_severe'] + df['new_detected_symptomatic_mild']
@@ -122,7 +123,7 @@ def load_and_plot_data(ems_region, savePlot=True) :
             adf = pd.merge(left=adf, right=mdf, on=['date', 'ems'])
 
     if savePlot :
-        plot_sim(adf, ems_region, channels=plotchannels)
+        plot_sim(adf, suffix=ems_region,first_plot_day=first_plot_day,last_plot_day=last_plot_day, channels=plotchannels)
 
     return adf
 
@@ -175,9 +176,9 @@ if __name__ == '__main__' :
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 
-    first_plot_day = pd.Timestamp.today()- pd.Timedelta(30,'days')
-    last_plot_day = pd.Timestamp.today()+ pd.Timedelta(60,'days')
-    
+    first_plot_day = pd.Timestamp('2020-03-01')
+    last_plot_day = pd.Timestamp.today() + pd.Timedelta(60,'days')
+
     regions = ['All', 'EMS-1', 'EMS-2', 'EMS-3', 'EMS-4', 'EMS-5', 'EMS-6', 'EMS-7', 'EMS-8', 'EMS-9', 'EMS-10','EMS-11']
     
     exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -52,14 +52,14 @@ def get_scenarioName(exp_suffix) :
     return(scenarioName)
 
 
-def plot_sim(dat,suffix,channels, first_plot_day, last_plot_day) :
+def plot_sim(dat,suffix,channels) :
 
         if suffix not in ["All","central","southern","northeast","northcentral"]:
             suffix_nr = str(suffix.split("-")[1])
         if suffix == "All":
             suffix_nr ="illinois"
         capacity = load_capacity(suffix_nr)
-        dat = dat[dat['date'].between(first_plot_day, last_plot_day)]
+
 
         fig = plt.figure(figsize=(18, 12))
         fig.subplots_adjust(right=0.97, wspace=0.2, left=0.07, hspace=0.15)
@@ -123,7 +123,7 @@ def load_and_plot_data(ems_region, savePlot=True) :
             adf = pd.merge(left=adf, right=mdf, on=['date', 'ems'])
 
     if savePlot :
-        plot_sim(adf, suffix=ems_region,first_plot_day=first_plot_day,last_plot_day=last_plot_day, channels=plotchannels)
+        plot_sim(adf, suffix=ems_region, channels=plotchannels)
 
     return adf
 
@@ -176,8 +176,6 @@ if __name__ == '__main__' :
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 
-    first_plot_day = pd.Timestamp('2020-03-01')
-    last_plot_day = pd.Timestamp.today() + pd.Timedelta(60,'days')
 
     regions = ['All', 'EMS-1', 'EMS-2', 'EMS-3', 'EMS-4', 'EMS-5', 'EMS-6', 'EMS-7', 'EMS-8', 'EMS-9', 'EMS-10','EMS-11']
     


### PR DESCRIPTION
-  civis csv was initially constrained to April 2021, then unintentionally removed 2020 history, and now no date constrains added
- also added a 'workaround' if hospital capacity thresholds include multiple capacity values , then select per default the higher value (prints message but does not stop the execution of the script)