### PR TITLE
edited NA handling in trace_selection,  update date x axis on plots

### DIFF
--- a/plotters/data_comparison_spatial.py
+++ b/plotters/data_comparison_spatial.py
@@ -56,7 +56,7 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names, titles, r
 
         ax.set_title(titles[c], y=0.8, fontsize=12)
 
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         ax.set_xlim(first_day, last_day)
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
         if logscale :

--- a/plotters/data_comparison_spatial_2.py
+++ b/plotters/data_comparison_spatial_2.py
@@ -83,7 +83,7 @@ def plot_sim_and_ref(exp_names, ems_nr, first_day, last_day, ymax=10000, logscal
             ax.set_title(titles[c], y=0.8, fontsize=12)
 
         axes[-1].legend()
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         ax.set_xlim(first_day, last_day)
         if logscale:
             ax.set_ylim(0.1, ymax)

--- a/plotters/data_comparison_spatial_3.py
+++ b/plotters/data_comparison_spatial_3.py
@@ -59,7 +59,7 @@ def plot_sim_and_ref(df, ems_nr, ref_df, channels, data_channel_names,region_lab
         ax.set_title(titles[c], y=0.8, fontsize=12)
         #ax.legend()
 
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         ax.set_xlim(first_day, last_day)
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
         if logscale:

--- a/plotters/estimate_Rt_forCivisOutputs.py
+++ b/plotters/estimate_Rt_forCivisOutputs.py
@@ -86,7 +86,7 @@ def rt_plot(df, plotname,first_day=None, last_day=None):
         if reg == 'illinois':
             plotsubtitle = 'Illinois'
         ax.set_title(plotsubtitle)
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         if first_day != None:
             ax.set_xlim(first_day, last_day)
         ax.axvline(x=pd.Timestamp.today(), color='#737373', linestyle='--')

--- a/plotters/iteration_comparison.py
+++ b/plotters/iteration_comparison.py
@@ -65,7 +65,7 @@ def comparison_plot(reg_nr=0, channels=None, n_iter=3):
                         [capacity[channel], capacity[channel]], '--', linewidth=1, color='black')
 
             ax.set_title(channel_labels[c], y=0.978)
-            ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+            ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
     axes[-1].legend(loc='upper right')
     plotname = f'iteration_comparison_{region}'
 

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -110,7 +110,7 @@ def plot_prevalences(df, first_day, last_day, channels):
         if ems_num == 0:
             plotsubtitle = 'Illinois'
         ax.set_title(plotsubtitle)
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         ax.set_xlim(first_day, last_day)
         ax.axvline(x=pd.Timestamp.today(), color='#666666', linestyle='--')
 

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -79,7 +79,7 @@ def plot_sim(dat,suffix,channels) :
                       [capacity[channel], capacity[channel]], '--', linewidth=2, color=palette[c])
 
             ax.set_title(channel, y=0.85)
-            ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
+            ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
 
         plotname = f'{scenarioName}_{suffix}'
         plotname = plotname.replace('EMS-','covidregion_')

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -69,7 +69,7 @@ def parse_args():
         "--traces_to_keep_ratio",
         type=int,
         help="Ratio of traces to keep out of all trajectories",
-        default=2
+        default=4
     )
     parser.add_argument(
         "--traces_to_keep_min",

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -80,6 +80,11 @@ def parse_args():
     return parser.parse_args()
 
 def sum_nll(df_values, ref_df_values):
+    """remove NAs in data from both arrays"""
+    na_pos = np.argwhere(np.isnan(ref_df_values))
+    if len(na_pos) != 0 :
+        df_values = np.delete(df_values, na_pos)
+        ref_df_values = np.delete(ref_df_values, na_pos)
     try:
         x = -np.log10(scipy.stats.poisson(mu=df_values).pmf(k=ref_df_values))
     except ValueError:
@@ -139,7 +144,6 @@ def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,
 
     ref_df = load_ref_df(ems_nr)
     ref_df = ref_df[ref_df['date'].between(first_day, last_day)]
-    ref_df = ref_df.dropna()
 
     df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[df['date'].between(first_day, ref_df['date'].max())]


### PR DESCRIPTION
- in the `trace_selection.py` the `dropna() `seemed to behave differently on Quest than locally and dropped alll data after Dec 2020.
- therefore NAs are now dropped at the very end before calculating the NLL for each indicator and run separately 
- also date-x-axes became confusing with the day 1st and no year annotation, changed to show last 2 digits of the year after the months instead of the day.