### PR TITLE
extended simulation duration, added ntrajectories to plot filename

### DIFF
--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -1,8 +1,8 @@
 experiment_setup_parameters:
   'number_of_samples': 600
   'number_of_runs': 1
-  'duration': 530
-  'monitoring_samples': 530 # needs to be less than or equal to duration
+  'duration': 560 # until 5th Sep 2021 for startdate 2020-02-13 
+  'monitoring_samples': 560 # needs to be less than or equal to duration
   'random_seed': 751
   'initialAs': 10
 fixed_parameters_region_specific:

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -164,7 +164,7 @@ def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,
 
         plot_sim_and_ref(df, ems_nr, ref_df, channels=channels, data_channel_names=data_channel_names, titles=titles,
                          region_label=region_label, first_day=first_day, last_day=last_day, plot_path=plot_path,
-                         plot_name_suffix =f'_best_fit_{str(1/traces_to_keep_ratio)}')
+                         plot_name_suffix =f'_best_fit_{str(1/traces_to_keep_ratio)}_n{str(n_traces_to_keep)}')
 
 
 if __name__ == '__main__':

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -75,7 +75,7 @@ def parse_args():
         "--traces_to_keep_min",
         type=int,
         help="Minimum number of traces to keep, might overwrite traces_to_keep_ratio for small simulations",
-        default=5
+        default=100
     )
     return parser.parse_args()
 


### PR DESCRIPTION
- set default minimum traces to keep when plotting data comparison to 100, to have same default in trace_selection.py example plot as in the processing_helpers.py that applies to all other postprocessing scripts
- simulation duration  until 5th Sep 2021 for startdate 2020-02-13