### PR TITLE
bugfix high number of simulation failures on Quest

### DIFF
--- a/runScenarios.py
+++ b/runScenarios.py
@@ -347,6 +347,14 @@ def generateScenarios(simulation_population, Kivalues, duration, monitoring_samp
                                        generateNew=generateNew,
                                        use_means=use_means)
 
+    if Location == 'NUCLUSTER' and cfg_file =="model_B.cfg":
+        fin = open(os.path.join(temp_exp_dir, cfg_file), "rt")
+        cfg_txt = fin.read()
+        cfg_txt = cfg_txt.replace('"Tau"  : 0.001', '"Tau"  : 0.0001')
+        fin.close()
+        fin = open(os.path.join(temp_exp_dir, cfg_file), "wt")
+        fin.write(cfg_txt)
+
     for row_i, row in dfparam.iterrows():
         Ki = row['Ki']
         scen_num = row['scen_num']

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -281,7 +281,7 @@ echo end""")
             file = open(os.path.join(temp_exp_dir,'bat', f'{list(process_dict.keys())[12]}.bat'), 'w')
             file.write(f'cd { os.path.join(git_dir, "nucluster")} \n python {list(process_dict.values())[12]}  --stem "{exp_name}" --del_trajectories --zip_dir  >> "{sim_output_path}/log/{list(process_dict.keys())[12]}.txt" \n')
 
-def shell_header(A='p30781',p='short',t='00:30:00',N=1,ntasks_per_node=1, memG=18,job_name='myjob', arrayJob=None):
+def shell_header(A='p30781',p='short',t='02:00:00',N=1,ntasks_per_node=1, memG=18,job_name='myjob', arrayJob=None):
     header = f'#!/bin/bash\n' \
              f'#SBATCH -A {A}\n' \
              f'#SBATCH -p {p}\n' \


### PR DESCRIPTION
 it was observed that the number of simulation failures was too high, possibly contributed to increasing model complexity among other factors. Increasing the step size in addition to longer run-time limit resulted in much less failures.
However a step size of 0.0001 would take too long locally whereas the failure rate is less an issue locally, therefore the step size is only changed when running on the NUCLUSTER. 
(Removing the post-ICU compartment had not improved simulation success)
