### PR TITLE
Bugfix fraction_severe for B117 variant scenario

### DIFF
--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -740,7 +740,8 @@ class covidModel:
             reaction_str = reaction_str.replace('Ks E_V::', 'Ks E_V::')
             reaction_str = reaction_str.replace('Ksym P_V::', 'KsymV P_V::')
             reaction_str = reaction_str.replace('Ksys P_V::', 'KsysV P_V::')
-
+            reaction_str = reaction_str.replace('Ksym P_det_V::', 'KsymV P_det_V::')
+            reaction_str = reaction_str.replace('Ksys P_det_V::', 'KsysV P_det_V::')
 
         return reaction_str
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -1020,6 +1020,23 @@ class covidModel:
 
             frac_severe_str = '(param fraction_severeB (* @fraction_severe@ @bvariant_severity@))\n' + frac_severe_timevent
 
+            if 'vaccine' in self.add_interventions:
+                """fraction severe adjustment over time"""
+                frac_severeV_timevent = ''.join([f'(time-event fraction_severe_V_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} '
+                                                 f'('
+                                                 f'(fraction_severe_V (+ '
+                                                 f'(* @fraction_severe@ @reduced_fraction_Sys@ (- 1 bvariant_fracinfect)) '
+                                                 f'(* fraction_severeB @reduced_fraction_Sys@ bvariant_fracinfect )  '
+                                                 f')) '
+                                                 f'(KsysV ( * fraction_severe_V (/ 1 time_to_symptoms))) '
+                                                 f'(KsymV ( * (- 1 fraction_severe_V)(/ 1 time_to_symptoms)))'
+                                                 f')'
+                                                 f')\n' for i, date in enumerate(intervention_dates, 1)])
+
+                frac_severeV_str = '(observe fraction_severe_V_t fraction_severe_V)\n' + frac_severeV_timevent
+                frac_severe_str = frac_severe_str + frac_severeV_str
+
+
             emodl_str = emodl_str + bvariant_infectivity + fracinfect_str + frac_severe_str
 
             return emodl_str

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -275,7 +275,7 @@ sampled_parameters:
     function_kwargs: { 'low': 0, 'high': 0.05 }
   'reduced_infectious_V':
     np.random: uniform
-    function_kwargs: { 'low': 0.1, 'high': 0.2 }
+    function_kwargs: { 'low': 0.1, 'high': 0.1}
 intervention_parameters:
   ###------------------------------------------------
   ### ---- Parameter scalingfactor ------------------


### PR DESCRIPTION
- previously fraction_severe was changed, but not the transmission parameter, leading to no actual change in severity
-  fraction_severe was not related to prevalence of the new bvariant
- fraction_severe within the vaccine structure (fraction_severeB) was not changed in bvariant+vaccine scenario.

Corrections:
- generated parameter for bvariant prevalence over time (`bvariant_fracinfect`)
- created time-events for updating `fraction_severe`, `Ksys `and `Ksym  `(and  `fraction_severe_V`, `KsysV `and `KsymV `
- at each time-event recalculate fraction severe using  
`fraction_severe (+ (* @fraction_severe@ (- 1 bvariant_fracinfect)) (* fraction_severeB  bvariant_fracinfect )  )`
(for % of pop not infected with bvariant keep initial fraction severe + % of pop infected with bvariant use higher fraction_severe)


- for bvariant+ vaccine scenario, assume same % of vaccinated pop as in not vaccinated pop would be infected with the new bvariant.
