### PR TITLE
added options for weighting time differently in trace selection

### DIFF
--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -58,7 +58,7 @@ def parse_args():
         "--cli_weight",
         type=float,
         help="Weight of CLI admissions in negative log likelihood calculation. Default is 1.0.",
-        default=0.0
+        default=0.5
     )
     parser.add_argument(
         "--plot",
@@ -77,9 +77,15 @@ def parse_args():
         help="Minimum number of traces to keep, might overwrite traces_to_keep_ratio for small simulations",
         default=100
     )
+    parser.add_argument(
+        "--wt",
+        action='store_true',
+        help="If true, weights simulations differently over time. The weighting needs to be specified within the sum_nll function "
+             "If true, it weights the deaths higher in the past than for more recent data, can be customized and also depends on --deaths_weight",
+    )
     return parser.parse_args()
 
-def sum_nll(df_values, ref_df_values):
+def sum_nll(df_values, ref_df_values, wt, wt_past=False):
     """remove NAs in data from both arrays"""
     na_pos = np.argwhere(np.isnan(ref_df_values))
     if len(na_pos) != 0 :
@@ -94,9 +100,18 @@ def sum_nll(df_values, ref_df_values):
     len_inf = len(list(i for i in list(x) if i == np.inf))
     if len_inf <= len(x)*0.9:
         x[np.abs(x) == np.inf] = 0
+
+    if wt:
+        if wt_past:
+            value_weight_array = [5] * 60 + [0.01] * (len(df_values) - 60)
+        else:
+            value_weight_array = [0.1] * (len(df_values) - 44) + [0.3] * 30 + [2] * 7 + [5] * 7
+        value_weight_array = [weight/np.sum(value_weight_array) for weight in value_weight_array]
+        x = x * value_weight_array
+
     return np.sum(x)
 
-def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0]):
+def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0],wt=False):
     #Creation of rank_df
     [deaths_weight, crit_weight, non_icu_weight, cli_weight] = weights_array
 
@@ -113,20 +128,23 @@ def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0]):
         total_nll = 0
         (run_num, sample_num, scen_num) = x
         df_trunc_slice = df_trunc[(df_trunc['run_num'] == run_num) & (df_trunc['sample_num'] == sample_num) & (df_trunc['scen_num'] == scen_num)]
-        total_nll += deaths_weight*sum_nll(df_trunc_slice['new_detected_deaths'].values, ref_df_trunc['deaths'].values)
-        total_nll += crit_weight*sum_nll(df_trunc_slice['crit_det'].values, ref_df_trunc['confirmed_covid_icu'].values)
-        total_nll += cli_weight*sum_nll(df_trunc_slice['new_detected_hospitalized'].values, ref_df_trunc['inpatient'].values)
-        total_nll += non_icu_weight*sum_nll(df_trunc_slice['hosp_det'].values, ref_df_trunc['covid_non_icu'].values)
+        total_nll += deaths_weight*sum_nll(df_trunc_slice['new_detected_deaths'].values[:-timelag_days], ref_df_trunc['deaths'].values[:-timelag_days], wt,wt_past=True)
+        total_nll += crit_weight*sum_nll(df_trunc_slice['crit_det'].values, ref_df_trunc['confirmed_covid_icu'].values, wt)
+        total_nll += cli_weight*sum_nll(df_trunc_slice['new_detected_hospitalized'].values, ref_df_trunc['inpatient'].values, wt)
+        total_nll += non_icu_weight*sum_nll(df_trunc_slice['hosp_det'].values, ref_df_trunc['covid_non_icu'].values, wt)
         rank_export_df = rank_export_df.append(pd.DataFrame({'run_num':[run_num], 'sample_num':[sample_num], 'scen_num':[scen_num], 'nll':[total_nll]}))
     rank_export_df = rank_export_df.dropna()
     rank_export_df['norm_rank'] = (rank_export_df['nll'].rank()-1)/(len(rank_export_df)-1)
     rank_export_df = rank_export_df.sort_values(by=['norm_rank']).reset_index(drop=True)
-    rank_export_df.to_csv(os.path.join(output_path,'traces_ranked_region_' + str(ems_nr) + '.csv'), index=False)
+    csv_name = 'traces_ranked_region_' + str(ems_nr) + '.csv'
+    #if wt:
+    #    csv_name = 'traces_ranked_region_' + str(ems_nr) + '_wt.csv'
+    rank_export_df.to_csv(os.path.join(output_path,csv_name), index=False)
 
     return rank_export_df
 
 
-def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,
+def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,wt,
                 traces_to_keep_ratio=2,traces_to_keep_min=1,plot_trajectories=False):
 
     if ems_nr == 0:
@@ -148,7 +166,7 @@ def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,
     df = load_sim_data(exp_name, region_suffix=region_suffix, column_list=column_list)
     df = df[df['date'].between(first_day, ref_df['date'].max())]
     df['critical_with_suspected'] = df['critical']
-    rank_export_df = rank_traces_nll(df, ems_nr, ref_df, weights_array=weights_array)
+    rank_export_df = rank_traces_nll(df, ems_nr, ref_df, weights_array=weights_array, wt=wt)
 
     #Creation of plots
     if plot_trajectories:
@@ -162,29 +180,31 @@ def compare_ems(exp_name, ems_nr,first_day,last_day,weights_array,
 
         df = pd.merge(rank_export_df[0:int(n_traces_to_keep)],df)
 
+        plot_name = f'_best_fit_{str(1/traces_to_keep_ratio)}_n{str(n_traces_to_keep)}'
+        if wt:
+          plot_name = f'_best_fit_{str(1/traces_to_keep_ratio)}_n{str(n_traces_to_keep)}_wt'
+
         plot_sim_and_ref(df, ems_nr, ref_df, channels=channels, data_channel_names=data_channel_names, titles=titles,
                          region_label=region_label, first_day=first_day, last_day=last_day, plot_path=plot_path,
-                         plot_name_suffix =f'_best_fit_{str(1/traces_to_keep_ratio)}_n{str(n_traces_to_keep)}')
+                         plot_name_suffix = plot_name)
 
 
 if __name__ == '__main__':
 
     args = parse_args()
+    weights_array = [args.deaths_weight, args.crit_weight, args.non_icu_weight, args.cli_weight]
     stem = args.stem
     Location = args.Location
-    weights_array = [args.deaths_weight, args.crit_weight, args.non_icu_weight, args.cli_weight]
 
     """ For plotting"""
     traces_to_keep_ratio = args.traces_to_keep_ratio
     traces_to_keep_min = args.traces_to_keep_min
 
-    """If fitting to deaths, include a lag of 14 days (applies to all indicators)"""
-    timelag_days = 0
-    if args.deaths_weight != 0:
-        timelag_days = 14
+    """Custom timelag applied to nll calculation for deaths only"""
+    timelag_days = 14
 
     first_plot_day = pd.Timestamp('2020-03-25')
-    last_plot_day =  pd.Timestamp.today() - pd.Timedelta(timelag_days,'days')
+    last_plot_day = pd.Timestamp.today()
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 
@@ -194,6 +214,12 @@ if __name__ == '__main__':
         output_path = os.path.join(wdir, 'simulation_output',exp_name)
         for ems_nr in range(0,12):
             print("Start processing region " + str(ems_nr))
-            compare_ems(exp_name, ems_nr=int(ems_nr),first_day=first_plot_day,last_day=last_plot_day,
-                        weights_array=weights_array, plot_trajectories=True,
-                        traces_to_keep_ratio=traces_to_keep_ratio,traces_to_keep_min=traces_to_keep_min)
+            compare_ems(exp_name,
+                        ems_nr=int(ems_nr),
+                        first_day=first_plot_day,
+                        last_day=last_plot_day,
+                        weights_array=weights_array,
+                        wt=args.wt,
+                        plot_trajectories=args.plot,
+                        traces_to_keep_ratio=traces_to_keep_ratio,
+                        traces_to_keep_min=traces_to_keep_min)

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -428,11 +428,10 @@ def get_datacomparison_channels():
     outcome_channels = ['hosp_det_cumul', 'hosp_cumul', 'hosp_det', 'hospitalized',
                     'crit_det_cumul', 'crit_cumul', 'crit_det', 'critical',
                     'deaths_det_cumul', 'deaths']
-    channels = ['new_detected_deaths', 'crit_det', 'hosp_det', 'new_deaths','new_detected_hospitalized',
+    channels = ['new_detected_deaths', 'crit_det', 'hosp_det', 'new_detected_hospitalized',
                 'new_detected_hospitalized']
-    data_channel_names = ['deaths',
-                          'confirmed_covid_icu', 'covid_non_icu', 'deaths','inpatient', 'admissions']
-    titles = ['New Detected\nDeaths (LL)', 'Critical Detected (EMR)', 'Inpatient non-ICU\nCensus (EMR)', 'New Detected\nDeaths (LL)',
+    data_channel_names = ['deaths','confirmed_covid_icu', 'covid_non_icu', 'inpatient', 'admissions']
+    titles = ['New Detected\nDeaths (LL)', 'Critical Detected (EMR)', 'Inpatient non-ICU\nCensus (EMR)',
               'Covid-like illness\nadmissions (IDPH)', 'New Detected\nHospitalizations (LL)']
     return outcome_channels, channels, data_channel_names, titles
     


### PR DESCRIPTION
-  to be able to fit the recent trend better, added weights to each nll value over time by adding the code chunk below to the sum_nll function
- wt_past applies for fitting the 1st wave and deaths
- wt_past is False per default for the other indicators
- the weighting is explorative and weight values as well as times need to be specified manually
- --wt argument defines whether to do time-weighting or not, default is False (as currently done)

```
    if wt:
        if wt_past:
            value_weight_array = [5] * 60 + [0.01] * (len(df_values) - 60)
        else:
            value_weight_array = [0.1] * (len(df_values) - 44) + [0.3] * 30 + [2] * 7 + [5] * 7
        value_weight_array = [weight/np.sum(value_weight_array) for weight in value_weight_array]
        x = x * value_weight_array
```