### PR TITLE
Vaccine scenarios linear and linear doubled

### DIFF
--- a/Rfiles/vaccine_scenarios.R
+++ b/Rfiles/vaccine_scenarios.R
@@ -1,0 +1,212 @@
+#-------------------------------
+# Title     : COVID-19
+# Objective : Vaccine forward scenarios
+#-------------------------------
+
+require(data.table)
+require(tidyverse)
+require(cowplot)
+require(scales)
+
+setwd('Rfiles')
+source("load_paths.R")
+source('processing_helpers.R')
+
+dat <- fread(file.path(data_path, 'covid_IDPH','Corona virus reports','vaccinations_by_covidregion.csv'))
+dat$date <- as.Date(dat$date)
+
+## Set dates
+vaccine_past_start <- as.Date('2020-12-20')
+vaccine_past_end <- max(dat$date )
+vaccine_fut_start <- vaccine_past_end
+vaccine_fut_end <- as.Date('2021-06-01')
+target_increase <- c(2)
+
+### Linear model by COVID-19 region
+lmdat_list <- list()
+for(reg in c(1:11)){
+  dat_i <- dat %>%
+    filter(region==reg) %>%
+    select(date,persons_first_vaccinated)
+
+  model = lm(persons_first_vaccinated ~ date,  data=dat_i)
+  dates <- seq(from=vaccine_past_start,to=vaccine_fut_end, by='days')
+  xdat = as.data.frame(dates)
+  colnames(xdat)='date'
+
+  xdat$persons_first_vaccinated <- predict(model,xdat)
+  xdat$persons_first_vaccinated[xdat$persons_first_vaccinated <0] <-0
+  xdat$model='predicted'
+  xdat$region = reg
+  xdat$scenario = 'continued'
+  lmdat_list[[reg]] = xdat
+  rm(dat_i)
+}
+lmdat_continued <- lmdat_list %>% bind_rows()
+rm(lmdat_list)
+
+### Linear model, doubled
+lmdat_list <- list()
+for(reg in c(1:11)){
+
+  t = lmdat_continued %>%
+    filter(region==reg & date == vaccine_fut_end) %>%
+    mutate(t=persons_first_vaccinated * 2) %>%
+    select(t) %>% as.numeric()
+
+  dat_i <- dat %>%
+    filter(region==reg) %>%
+    select(date,persons_first_vaccinated)
+
+  dt_scen <- as.data.frame(cbind('date'=vaccine_fut_end, 'persons_first_vaccinated'=t))
+  dt_scen$date <- as.Date(dt_scen$date, origin = as.Date('1970-01-01'))
+
+  dat_i <- dat_i %>%
+    filter(date ==max(date)) %>%
+    select(date,persons_first_vaccinated)
+
+  dat_i <- rbind(dat_i,dt_scen)
+  model = lm(persons_first_vaccinated ~ date,  data=dat_i)
+  dates <- seq(from=vaccine_fut_start,to=vaccine_fut_end, by='days')
+  xdat = as.data.frame(dates)
+  colnames(xdat)='date'
+  xdat$persons_first_vaccinated <- predict(model,xdat)
+  xdat$persons_first_vaccinated[xdat$persons_first_vaccinated <0] <-0
+  xdat$model='predicted'
+  xdat$region = reg
+  xdat$scenario = 'doubled'
+  lmdat_list[[length(lmdat_list)+1]] = xdat
+  }
+lmdat_scenario <- lmdat_list %>% bind_rows()
+
+##--------------------------------------------
+### Combine and add population
+##--------------------------------------------
+popdat <- as.data.frame(cbind(c(1:11),c(660965,1243906, 556776, 656946, 403659, 739098, 800605, 1455324, 1004309, 2693959, 2456274)))
+colnames(popdat) <- c("region","pop")
+
+lmdat <- as.data.frame( rbind(lmdat_continued, lmdat_scenario)) %>% left_join( popdat, by="region")
+lmdat$persons_first_vaccinated_raw <- lmdat$persons_first_vaccinated
+lmdat <- lmdat %>% mutate(persons_first_vaccinated = ifelse(persons_first_vaccinated>pop,pop,persons_first_vaccinated))
+tapply(lmdat$persons_first_vaccinated,lmdat$scenario, summary)
+
+lmdat <- lmdat %>%
+  as.data.frame() %>%
+  arrange(region,pop,scenario, date) %>%
+  group_by(region,pop, scenario) %>%
+  mutate(remaining_susceptible = pop - persons_first_vaccinated,
+         daily_first_vacc = persons_first_vaccinated - lag(persons_first_vaccinated),
+         daily_first_vacc = ifelse(is.na(daily_first_vacc),0,daily_first_vacc),
+         daily_first_vacc_perc =  daily_first_vacc /remaining_susceptible,
+         daily_first_vacc_perc = ifelse(is.na(daily_first_vacc_perc),0,daily_first_vacc_perc),
+         daily_first_vacc_perc = ifelse(is.infinite(daily_first_vacc_perc),0,daily_first_vacc_perc))
+
+summary(lmdat$date)
+lmdat[duplicated(lmdat[,c("date","region","scenario")]),c("date","region","scenario")]
+
+ ggplot(data=subset(lmdat))+
+  geom_line(aes(x=date, y=persons_first_vaccinated, col=as.factor(scenario),group=scenario))+
+  theme_bw()+
+  facet_wrap(~region, scales="free")+
+  scale_y_continuous(labels=comma)+
+  labs(title="", color="scenario",x="")
+
+ ggplot(data=subset(lmdat))+
+  geom_line(aes(x=date, y=daily_first_vacc_perc, col=as.factor(scenario),group=scenario))+
+  theme_bw()+
+  facet_wrap(~region, scales="free")+
+  scale_y_continuous(labels=comma)+
+  labs(title="", color="scenario",x="")
+
+table(lmdat$scenario)
+lmdat$scenario <- factor(lmdat$scenario,
+                          levels=c('continued','doubled'),
+                          labels=c('continued_trend','doubled_trend'))
+
+lmdat %>% filter(date <= vaccine_past_end & scenario=='continued_trend') %>%
+  fwrite(file.path(git_dir,'experiment_configs','input_csv','vaccination_historical.csv'))
+
+lmdat %>% filter(scenario=='continued_trend') %>%
+  fwrite(file.path(git_dir,'experiment_configs','input_csv','vaccination_linear.csv'))
+
+lmdat %>%
+  filter((scenario=='continued_trend' & date < vaccine_past_end) |
+           (scenario=='doubled_trend' & date >= vaccine_past_end)) %>%
+  fwrite(file.path(git_dir,'experiment_configs','input_csv','vaccination_linear_doubled.csv'))
+
+lmdat %>%
+  group_by(region,scenario) %>%
+  filter(date ==max(date)) %>%
+  summarize(mean=mean(persons_first_vaccinated/pop)*100) %>%
+  pivot_wider(names_from=scenario , values_from=mean)
+
+
+### Plots
+f_custom_plot <- function(channel='persons_first_vaccinated'){
+  lmdat <- as.data.frame(lmdat)
+  lmdat[,'channel'] <- lmdat[,colnames(lmdat)==channel]
+  lmdat[,'channel'] <- as.numeric( lmdat[,'channel'])
+
+  pplot <- ggplot(data=lmdat)+
+  geom_hline(data=popdat,aes(yintercept=pop))+
+  geom_label(data=popdat,aes(y=pop, x=as.Date('2021-02-01'), label='total population'))+
+  geom_line(data=subset(lmdat, date < vaccine_fut_end),
+            aes(x=date, y=channel,col=scenario, group=scenario),size=1.3)+
+  geom_point(data=dat,aes(x=date, y=channel),col='black',size=0.8)+
+  theme_cowplot()+
+  customThemeNoFacet+
+  facet_wrap(~region, scales="free")+
+  scale_y_continuous(labels=comma)+
+  scale_x_date(date_labels = "%m")+
+  scale_color_manual(values=c('#add2c8','#00a08a'))+
+  labs(title="Total population that received 1st dose of a COVID-19 vaccine in Illinois by region",
+       subtitle='Assumed future scenarios\n',
+       color="scenario",
+       x="Month 2021",
+       y=channel)+
+  theme(legend.position = "top")
+
+ggsave(paste0(channel,".png"),
+       plot = pplot,
+       path = file.path(wdir, "parameters","vaccinations"), width = 14, height = 10, device = "png"
+)
+ggsave(paste0(channel,".pdf"),
+       plot = pplot,
+       path = file.path(wdir,  "parameters","vaccinations"), width = 14, height = 10, device = "pdf"
+)
+
+}
+
+f_custom_plot(channel='persons_first_vaccinated')
+f_custom_plot(channel='daily_first_vacc_perc')
+
+
+lmdatAggr <- lmdat %>% group_by(date,scenario) %>%
+  summarize(pop=sum(pop),
+            persons_first_vaccinated=sum(persons_first_vaccinated),
+            daily_first_vacc_perc=sum(daily_first_vacc_perc))
+
+pplot <- ggplot(data=lmdatAggr)+
+  geom_hline(aes(yintercept=pop))+
+  geom_label(aes(y=pop, x=as.Date('2021-02-01'), label='total population'))+
+  geom_line(data=subset(lmdatAggr,  date>vaccine_past_start & date<vaccine_fut_end),aes(x=date, y=persons_first_vaccinated,col=scenario, group=scenario),size=1.3)+
+  theme_cowplot()+
+  customThemeNoFacet+
+  scale_y_continuous(labels=comma)+
+  scale_x_date(date_labels = "%m")+
+  scale_color_manual(values=c('#add2c8','#00a08a'))+
+  labs(title="Percent of susceptible population that received 1st dose of a COVID-19 vaccine in Illinois by region",
+       subtitle='Assumed future scenarios\n',
+       color="scenario",
+       x="Month 2021",
+       y="Percent of susceptible population daily vaccinated")+
+  theme(legend.position = "top")
+
+ggsave("IL_vaccination_scale_up.png",
+       plot = pplot,
+       path = file.path(wdir, "parameters","vaccinations"), width = 14, height = 10, device = "png"
+)
+ggsave("IL_vaccination_scale_up.pdf",
+       plot = pplot,
+       path = file.path(wdir,  "parameters","vaccinations"), width = 14, height = 10, device = "pdf"
+)

--- a/data_processing/vaccinations_by_covidregion.py
+++ b/data_processing/vaccinations_by_covidregion.py
@@ -15,12 +15,16 @@ from load_paths import load_box_paths
 def plot_vaccinations(adf, channels,channel_title):
 
     fig = plt.figure(figsize=(14, 8))
-    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.5, wspace=0.3, top=0.90, bottom=0.08)
+    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.5, wspace=0.3, top=0.91, bottom=0.08)
     palette = ('#913058', "#F6851F", "#00A08A", "#D61B5A", "#5393C3", "#F1A31F", "#98B548", "#8971B3", "#969696")
     # sns.color_palette('husl', len(channels))
     fig.suptitle(x=0.5, y=0.98, t=channel_title, size=14)
 
     for e, ems_num in enumerate(adf['region'].unique()):
+        plotsubtitle = f'COVID-19 Region {str(int(ems_num))}'
+        if ems_num == 0:
+            plotsubtitle = 'Illinois'
+
         ax = fig.add_subplot(3, 4, e + 1)
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
         mdf = adf[adf['region'] == ems_num]
@@ -30,11 +34,8 @@ def plot_vaccinations(adf, channels,channel_title):
             else :
                 ax.plot(mdf['date'], mdf[channel], color=palette[c], label=channel)
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%d'))
+        ax.set_title(plotsubtitle)
 
-    plotsubtitle = f'COVID-19 Region {str(int(ems_num))}'
-    if ems_num == 0:
-        plotsubtitle = 'Illinois'
-    ax.set_title(plotsubtitle)
     ax.legend()
 
     plt.savefig(os.path.join(plot_path, f'{channels[0]}_by_covidregion.png'))
@@ -105,11 +106,13 @@ if __name__ == '__main__':
                             'population': df['population'],
                             'persons_fully_vaccinated': df['persons_fully_vaccinated'],
                             'administered_count': df['administered_count'],
-                            'allocated_doses': df['allocated_doses'],
                             'daily_full_vaccinated': count_new(df, 'persons_fully_vaccinated'),
-                            'daily_new_administered_count': count_new(df, 'administered_count'),
-                            'daily_new_allocated_doses': count_new(df, 'allocated_doses')})
+                            'daily_new_administered_count': count_new(df, 'administered_count')})
         sdf['region'] = region
+
+        """Replace first entry (backlog)"""
+        sdf.loc[sdf['date'] == min(sdf['date']),'daily_full_vaccinated'] = sdf.loc[sdf['date'] == min(sdf['date']),'persons_fully_vaccinated']
+        sdf.loc[sdf['date'] == min(sdf['date']),'daily_new_administered_count'] = sdf.loc[sdf['date'] == min(sdf['date']),'administered_count']
         inc_df = pd.concat([inc_df, sdf])
 
     inc_df['persons_fully_vaccinated_perc'] = inc_df['persons_fully_vaccinated'] / inc_df['population']
@@ -125,17 +128,20 @@ if __name__ == '__main__':
 
     ## Daily vaccinations
 
+
+
+    ## Daily vaccinations
     """Plots per COVID-19 region"""
     plot_vaccinations(adf=inc_df,
                       channels = ['daily_first_vacc_perc','daily_fully_vacc_perc'],
                       channel_title="Daily vaccinated population 1st or 2nd (fully) dose (proportion)")
 
     plot_vaccinations(adf=inc_df,
-                      channels = ['persons_first_vaccinated','persons_fully_vaccinated'],
-                      channel_title="Daily vaccinated population")
+                      channels = ['daily_first_vacc','daily_full_vaccinated'],
+                      channel_title="Daily vaccinated population 1st or 2nd (fully) dose (population)")
 
     plot_vaccinations(adf=inc_df,
-                      channels = ['persons_fully_vaccinated_perc','persons_first_vaccinated_perc'],
+                      channels = ['persons_first_vaccinated_perc','persons_fully_vaccinated_perc'],
                       channel_title="Total vaccinated population (proportion)")
 
     plot_vaccinations(adf=inc_df,

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -953,7 +953,7 @@ class covidModel:
                     temp_str = f'(time-event vaccination_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ((Kv_1 {intervention_effectsizes[i-1]})))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
             else:
-                n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='bvariant')
+                n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='vaccine')
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event vaccination_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ((Kv_1 (*  @vacc_daily_cov@ {(1 / (len(intervention_dates)) * i)}) )))\n'

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -744,9 +744,8 @@ class covidModel:
             reaction_str = reaction_str.replace('Ksys P_V::', 'KsysV P_V::')
             reaction_str = reaction_str.replace('Ksym P_det_V::', 'KsymV P_det_V::')
             reaction_str = reaction_str.replace('Ksys P_det_V::', 'KsysV P_det_V::')
-        reaction_str = reaction_str + reaction_str_exposure
 
-        reaction_str = reaction_str_I + reaction_str
+        reaction_str = reaction_str_exposure + reaction_str
         return reaction_str
 
     def write_time_varying_parameter(self, total_string):

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -616,8 +616,6 @@ class covidModel:
                           f'))\n'
 
         if 'vaccine' in self.add_interventions:
-            """Keep option to specify actual numbers for past vaccinations and fraction vaccinated for future scenarios, if not used, set to 0"""
-            #reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (+ n_daily_vaccinated_{grp} (* Kv_{grp} S::{grp}) ))\n'
             reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (* Kv_{grp} S::{grp}))\n'
             reaction_str_I = reaction_str_I + reaction_str_Ia + reaction_str_Ib
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -575,50 +575,49 @@ class covidModel:
     def write_reactions(self, grp):
         grp = str(grp)
 
-        reaction_str_I = f'\n(reaction exposure_{grp}   ' \
-                         f'(S::{grp}) (E::{grp}) ' \
-                         f'(* Ki_{grp} S::{grp} ' \
-                         f'(/  ' \
-                         f'(+ infectious_undet_symp_{grp} ' \
-                         f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                         f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                         f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                         f') N_{grp} )' \
-                         f'))\n'
+        reaction_str_exposure = f'\n(reaction exposure_{grp}   ' \
+                                f'(S::{grp}) (E::{grp}) ' \
+                                f'(* Ki_{grp} S::{grp} ' \
+                                f'(/  ' \
+                                f'(+ infectious_undet_symp_{grp} ' \
+                                f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                                f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                                f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                                f') N_{grp} )' \
+                                f'))\n'
 
-        reaction_str_V_Ia = f'\n(reaction exposure_{grp}   ' \
-                            f'(S::{grp}) (E::{grp}) ' \
-                            f'(* Ki_{grp} S::{grp} ' \
-                            f'(/  ' \
-                            f'(+ infectious_undet_symp_{grp}' \
-                            f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
-                            f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                            f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                            f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                            f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
-                            f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
-                            f') N_{grp} )' \
-                            f'))\n'
+        reaction_str_exposure_Va = f'\n(reaction exposure_{grp}   ' \
+                                   f'(S::{grp}) (E::{grp}) ' \
+                                   f'(* Ki_{grp} S::{grp} ' \
+                                   f'(/  ' \
+                                   f'(+ infectious_undet_symp_{grp}' \
+                                   f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
+                                   f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                                   f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                                   f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                                   f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
+                                   f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
+                                   f') N_{grp} )' \
+                                   f'))\n'
 
-        reaction_str_V_Ib = f'\n(reaction exposure_{grp}   ' \
-                            f'(S_V::{grp}) (E_V::{grp}) ' \
-                            f'(* Ki_{grp} S_V::{grp} ' \
-                            f'(/  ' \
-                            f'(+ infectious_undet_symp_{grp}' \
-                            f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
-                            f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                            f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                            f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                            f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
-                            f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
-                            f') N_{grp} )' \
-                            f'))\n'
+        reaction_str_exposure_Vb = f'\n(reaction exposure_{grp}   ' \
+                                   f'(S_V::{grp}) (E_V::{grp}) ' \
+                                   f'(* Ki_{grp} S_V::{grp} ' \
+                                   f'(/  ' \
+                                   f'(+ infectious_undet_symp_{grp}' \
+                                   f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
+                                   f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                                   f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                                   f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                                   f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
+                                   f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
+                                   f') N_{grp} )' \
+                                   f'))\n'
 
         if 'vaccine' in self.add_interventions:
-            #reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (* Kv S::{grp}))\n'
-            reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) n_past_daily_vaccinated_{grp})\n'
-            #reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (+ n_past_daily_vaccinated_{grp} (* Kv S::{grp}) ))\n'
-            reaction_str_I = reaction_str_I + reaction_str_V_Ia + reaction_str_V_Ib
+            """Keep option to specify actual numbers for past vaccinations and fraction vaccinated for future scenarios, if not used, set to 0"""
+            reaction_str_exposure = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (+ n_past_daily_vaccinated_{grp} (* Kv S::{grp}) ))\n'
+            reaction_str_exposure = reaction_str_exposure + reaction_str_exposure_Va + reaction_str_exposure_Vb
 
         reaction_str_III = f'(reaction recovery_H1_{grp} (H1::{grp}) (RH1::{grp}) (* Kr_h{grp} H1::{grp}))\n' \
                            f'(reaction recovery_C2_{grp} (C2::{grp}) (H2post::{grp}) (* Kr_c{grp} C2::{grp}))\n' \
@@ -722,11 +721,11 @@ class covidModel:
                                         f'(reaction recovery_Sym_det2b_{grp} (Sym_det2b::{grp}) (RSym_det2::{grp}) (* Kr_m Sym_det2b::{grp}))\n'
 
         if self.expandModel == None:
-            reaction_str = reaction_str_I + expand_base_str + reaction_str_III
+            reaction_str = expand_base_str + reaction_str_III
         if self.expandModel == "SymSys" or self.expandModel == "uniform":
-            reaction_str = reaction_str_I + expand_testDelay_SymSys_str + reaction_str_III
+            reaction_str = expand_testDelay_SymSys_str + reaction_str_III
         if self.expandModel == 'AsSymSys':
-            reaction_str = reaction_str_I + expand_testDelay_AsSymSys_str + reaction_str_III
+            reaction_str = expand_testDelay_AsSymSys_str + reaction_str_III
 
         if 'vaccine' in self.add_interventions:
             reaction_str_V = reaction_str.replace(f'_{grp}',f'_V_{grp}')
@@ -744,6 +743,7 @@ class covidModel:
             reaction_str = reaction_str.replace('Ksys P_V::', 'KsysV P_V::')
             reaction_str = reaction_str.replace('Ksym P_det_V::', 'KsymV P_det_V::')
             reaction_str = reaction_str.replace('Ksys P_det_V::', 'KsysV P_det_V::')
+        reaction_str = reaction_str + reaction_str_exposure
 
         return reaction_str
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -765,7 +765,7 @@ class covidModel:
 
         def write_frac_crit_change(nchanges):
             n_frac_crit_change = range(1, nchanges+1)
-            frac_crit_change_observe = '(observe frac_crit_t fraction_critical)'
+            frac_crit_change_observe = '(observe frac_crit_t fraction_critical)\n'
             frac_crit_change_timeevent = ''.join([f'(time-event frac_crit_adjust{i} @crit_time_{i}@ '
                                                   f'('
                                                   f'(fraction_critical @fraction_critical_change{i}@) '
@@ -783,7 +783,7 @@ class covidModel:
         def write_fraction_dead_change(nchanges):
             n_fraction_dead_change = range(1, nchanges+1)
             fraction_dead_change_observe = '(observe fraction_dead_t fraction_dead)\n' \
-                                           '(observe fraction_hospitalized_t fraction_hospitalized)'
+                                           '(observe fraction_hospitalized_t fraction_hospitalized)\n'
 
             fraction_dead_change_timeevent = ''.join([f'(time-event fraction_dead_adjust2 @fraction_dead_time_{i}@ '
                                                       f'('
@@ -801,7 +801,7 @@ class covidModel:
 
         def write_dSys_change(nchanges):
             n_dSys_change = range(1, nchanges+1)
-            dSys_change_observe = '(observe d_Sys_t d_Sys)'
+            dSys_change_observe = '(observe d_Sys_t d_Sys)\n'
             dSys_change_timeevent = ''.join([f'(time-event dSys_change{i} @d_Sys_change_time_{i}@ '
                                              f'((d_Sys @d_Sys_incr{i}@))'
                                              f')'

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -576,49 +576,50 @@ class covidModel:
     def write_reactions(self, grp):
         grp = str(grp)
 
-        reaction_str_exposure = f'\n(reaction exposure_{grp}   ' \
-                                f'(S::{grp}) (E::{grp}) ' \
-                                f'(* Ki_{grp} S::{grp} ' \
-                                f'(/  ' \
-                                f'(+ infectious_undet_symp_{grp} ' \
-                                f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                                f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                                f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                                f') N_{grp} )' \
-                                f'))\n'
+        reaction_str_I = f'\n(reaction exposure_{grp}   ' \
+                         f'(S::{grp}) (E::{grp}) ' \
+                         f'(* Ki_{grp} S::{grp} ' \
+                         f'(/  ' \
+                         f'(+ infectious_undet_symp_{grp} ' \
+                         f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                         f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                         f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                         f') N_{grp} )' \
+                         f'))\n'
 
-        reaction_str_exposure_Va = f'\n(reaction exposure_{grp}   ' \
-                                   f'(S::{grp}) (E::{grp}) ' \
-                                   f'(* Ki_{grp} S::{grp} ' \
-                                   f'(/  ' \
-                                   f'(+ infectious_undet_symp_{grp}' \
-                                   f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
-                                   f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                                   f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                                   f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                                   f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
-                                   f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
-                                   f') N_{grp} )' \
-                                   f'))\n'
+        reaction_str_Ia = f'\n(reaction exposure_{grp}   ' \
+                          f'(S::{grp}) (E::{grp}) ' \
+                          f'(* Ki_{grp} S::{grp} ' \
+                          f'(/  ' \
+                          f'(+ infectious_undet_symp_{grp}' \
+                          f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
+                          f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                          f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                          f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                          f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
+                          f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
+                          f') N_{grp} )' \
+                          f'))\n'
 
-        reaction_str_exposure_Vb = f'\n(reaction exposure_{grp}   ' \
-                                   f'(S_V::{grp}) (E_V::{grp}) ' \
-                                   f'(* Ki_{grp} S_V::{grp} ' \
-                                   f'(/  ' \
-                                   f'(+ infectious_undet_symp_{grp}' \
-                                   f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
-                                   f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
-                                   f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
-                                   f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
-                                   f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
-                                   f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
-                                   f') N_{grp} )' \
-                                   f'))\n'
+        reaction_str_Ib = f'\n(reaction exposure_{grp}   ' \
+                          f'(S_V::{grp}) (E_V::{grp}) ' \
+                          f'(* Ki_{grp} S_V::{grp} ' \
+                          f'(/  ' \
+                          f'(+ infectious_undet_symp_{grp}' \
+                          f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V ) ' \
+                          f'(* infectious_undet_As_{grp} reduced_infectious_As ) ' \
+                          f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases) ' \
+                          f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases)' \
+                          f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases) ' \
+                          f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases)' \
+                          f') N_{grp} )' \
+                          f'))\n'
 
         if 'vaccine' in self.add_interventions:
             """Keep option to specify actual numbers for past vaccinations and fraction vaccinated for future scenarios, if not used, set to 0"""
-            reaction_str_exposure = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (+ n_past_daily_vaccinated_{grp} (* Kv_{grp} S::{grp}) ))\n'
-            reaction_str_exposure = reaction_str_exposure + reaction_str_exposure_Va + reaction_str_exposure_Vb
+            #reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (+ n_daily_vaccinated_{grp} (* Kv_{grp} S::{grp}) ))\n'
+            reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (* Kv_{grp} S::{grp}))\n'
+            reaction_str_I = reaction_str_I + reaction_str_Ia + reaction_str_Ib
 
         reaction_str_III = f'(reaction recovery_H1_{grp} (H1::{grp}) (RH1::{grp}) (* Kr_h{grp} H1::{grp}))\n' \
                            f'(reaction recovery_C2_{grp} (C2::{grp}) (H2post::{grp}) (* Kr_c{grp} C2::{grp}))\n' \
@@ -745,7 +746,7 @@ class covidModel:
             reaction_str = reaction_str.replace('Ksym P_det_V::', 'KsymV P_det_V::')
             reaction_str = reaction_str.replace('Ksys P_det_V::', 'KsysV P_det_V::')
 
-        reaction_str = reaction_str_exposure + reaction_str
+        reaction_str = reaction_str_I + reaction_str
         return reaction_str
 
     def write_time_varying_parameter(self, total_string):
@@ -968,46 +969,27 @@ class covidModel:
 
         def write_vaccine():
             emodl_str = ';COVID-19 vaccine scenario\n'
-            df = pd.read_csv(os.path.join("./experiment_configs", 'input_csv', 'vaccination_history_by_covidregion.csv'))
-            df['Date'] = pd.to_datetime(df['Date'])
+            read_from_csv = intervention_param['read_from_csv']
+            csvfile = intervention_param['vaccination_csv']
+            df = pd.read_csv(os.path.join("./experiment_configs", 'input_csv', csvfile))
+            df['Date'] = pd.to_datetime(df['date'])
             emodl_str_grp = ""
             for grp in self.grpList:
                 grp_num = grp.replace('EMS_','')
                 df_grp = df[df['region']==int(grp_num)]
-                emodl_param_initial = f'(param n_past_daily_vaccinated_{grp} 0)\n' \
-                                      f'(param Kv_{grp} 0)\n' \
-                                      f'(observe n_daily_vaccinated_{grp}  (+ n_past_daily_vaccinated_{grp} Kv_{grp}))\n'
-
-                intervention_dates = list(df_grp['Date'].values)
-                intervention_effectsizes = list(df_grp['daily_first_vacc'].values)
+                emodl_param_initial = f'(param Kv_{grp} 0)\n' \
+                                      f'(observe n_daily_vaccinated_{grp}  (* Kv_{grp}  S::{grp} ))\n'
+                intervention_dates = list(df_grp['Date'].values) + [max(df_grp['Date']) + pd.Timedelta(1,'days')]
+                intervention_effectsizes = list(df_grp['daily_first_vacc_perc'].values) + [0]
+                #intervention_effectsizes = list(df_grp['daily_first_vacc'].values) + [0]
 
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
-                    temp_str = f'(time-event past_daily_vaccinations_{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ((n_past_daily_vaccinated_{grp} {intervention_effectsizes[i-1]})))\n'
+                    temp_str = f'(time-event daily_vaccinations_{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ((Kv_{grp} {intervention_effectsizes[i-1]})))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
                 emodl_str_grp = emodl_str_grp + emodl_param_initial + emodl_timeevents
                 del df_grp
-            emodl_str_past = emodl_str + emodl_str_grp
-
-            """Future scenario - vaccination continuation"""
-            emodl_str_grp = ""
-            for grp in self.grpList:
-                grp_num = grp.replace('EMS_', '')
-                df_grp = df[df['region'] == int(grp_num)]
-
-                """ Per default assume that vaccinations would continue on average rate of last 14 days if future vaccine scenario not specified"""
-                intervention_dates = [max(df_grp['Date']) + pd.Timedelta(1, 'days')]
-                intervention_effectsizes = [np.mean(df_grp['daily_first_vacc_perc'][-14:])]
-
-                emodl_timeevents = ''
-                for i, date in enumerate(intervention_dates, 1):
-                    temp_str = f'(time-event future_daily_vaccinations_{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ((Kv_{grp} {intervention_effectsizes[i - 1]})))\n'
-                    emodl_timeevents = emodl_timeevents + temp_str
-                emodl_str_grp = emodl_str_grp + emodl_timeevents
-                del df_grp
-            emodl_str_future = emodl_str + emodl_str_grp
-            emodl_str = emodl_str_past + emodl_str_future
-
+            emodl_str = emodl_str + emodl_str_grp
             return emodl_str
 
         def write_bvariant():

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -523,11 +523,11 @@ time_parameters:
   ### ---- Bvariant ---
   'bvariant_start':
     custom_function: DateToTimestep
-    function_kwargs: {'dates': 2021-02-10}
+    function_kwargs: {'dates': 2021-02-20}
     #function_kwargs: {'dates': [2021-01-01, 2021-01-14, 2021-02-01]}
   'bvariant_scaleupend':
     custom_function: DateToTimestep
-    function_kwargs: {'dates': 2021-03-10} #if gradual change
+    function_kwargs: {'dates': 2021-06-01} #if gradual change
   'bvariant_end':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2099-01-01} #no end

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -317,10 +317,10 @@ intervention_parameters:
     np: linspace
     function_kwargs: {'start':0.20, 'stop':0.20, 'num' : 1}
   ### ---- VACCINE ----------------------
+  ### Used if no intervention csv is specified in intervention_emodl_config.yaml
   'vacc_daily_cov':
     np: linspace
     function_kwargs: {'start':0.00523, 'stop':0.00523, 'num' : 1}
-    #function_kwargs: {'start':0.00523, 'stop':0.00523, 'num' : 1}
   ### ---- IMPROVED TESTING/ISOLATION TURNAROUND -----------
   'change_testDelay_As_1':
     np: linspace

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -499,10 +499,6 @@ time_parameters:
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-07-01}                     
     custom_function: DateToTimestep
-    function_kwargs: {'dates': 2020-06-01}   
-  'cfr_time_2':
-    custom_function: DateToTimestep
-    function_kwargs: {'dates': 2020-07-01}   
   'fraction_dead_time_4':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2020-08-01}   

--- a/experiment_configs/intervention_emodl_config.yaml
+++ b/experiment_configs/intervention_emodl_config.yaml
@@ -7,14 +7,14 @@ time_varying_parameter:
   'n_recovery_time_crit_change': 1
   'n_recovery_time_hosp_change': 1
 interventions:
-  'n_gradual_steps': 1
+  'n_gradual_steps': 8
   'rollback_relative_to_initial': True
   'reopen_relative_to_initial': False
   'reopen_regionspecific': False
   'trigger_channel': 'crit_det'
   'read_from_csv': False
-  'bvariant_csv': "bvariant_frequency_scenario.csv"
-  'vaccination_csv': "vaccination_medium.csv" #"vaccination_low.csv" # "vaccination_medium.csv" #  "vaccination_high.csv"
+  'bvariant_csv': ""
+  'vaccination_csv': "vaccination_linear.csv" #"vaccination_linear_doubled.csv" 
   #'reopen_csv': "ki_increase_scenario.csv"
   #'n_gradual_intervals': 4
   #'start_today': True

--- a/plotters/bar_timeline_plotter.py
+++ b/plotters/bar_timeline_plotter.py
@@ -57,9 +57,6 @@ def cumulative_barplot(exp_names,channel,labels, first_day,last_day,  region="Al
     fig = plt.figure(figsize=(6, 4))
     fig.subplots_adjust(left=0.2)
     ax = fig.gca()
-    #p = load_color_palette('wes')
-    #palette = [p[x] for x in [8, 4, 2, 1, 3]]
-    palette = ('#913058', "#F6851F", "#00A08A", "#D61B5A", "#5393C3", "#F1A31F", "#98B548", "#8971B3", "#969696")
     first_md = first_day.strftime('%b %d')
     last_md = last_day.strftime('%b %d')
 
@@ -85,9 +82,6 @@ def timeline_plot(exp_names,channel,labels, first_day,last_day,  region="All"):
     fig = plt.figure(figsize=(6, 4))
     fig.subplots_adjust(left=0.2)
     ax = fig.gca()
-    #p = load_color_palette('wes')
-    #palette = [p[x] for x in [8, 4, 2, 1, 3]]
-    palette = ('#913058', "#F6851F", "#00A08A", "#D61B5A", "#5393C3", "#F1A31F", "#98B548", "#8971B3", "#969696")
 
     for s, exp_name in enumerate(exp_names):
         simpath = os.path.join(projectpath, 'cms_sim', 'simulation_output', exp_name)
@@ -99,7 +93,7 @@ def timeline_plot(exp_names,channel,labels, first_day,last_day,  region="All"):
         df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
         ax.plot(df['date'], df['%s_median' % channel], color=palette[s], label=labels[s])
         ax.fill_between(df['date'], df['%s_lower' % channel], df['%s_upper' % channel], color=palette[s], linewidth=0, alpha=0.4)
-
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
     ax.legend()
     ax.set_ylabel(f'{channel}')
     plt.savefig(os.path.join(plot_path, f'{channel}_timelineplot.png'))
@@ -107,6 +101,11 @@ def timeline_plot(exp_names,channel,labels, first_day,last_day,  region="All"):
     #plt.show()
 
 if __name__ == '__main__':
+
+    #p = load_color_palette('wes')
+    #palette = [p[x] for x in [8, 4, 2, 1, 3]]
+    #palette = ('#65213d', "#9c4468", "#b26e8a", "#D61B5A", "#5393C3", "#F1A31F", "#98B548", "#8971B3", "#969696")
+    palette = ('#65213d', "#9c4468", "#b26e8a",  "#007060", "#00a08a", "#66c6b8")
 
     args = parse_args()
     exp_names = args.exp_names
@@ -120,7 +119,7 @@ if __name__ == '__main__':
 
     plot_path = os.path.join(wdir, 'simulation_output', exp_names[len(exp_names) - 1], '_plots')
 
-    first_day = pd.Timestamp('2020-02-01')
+    first_day = pd.Timestamp('2021-03-01')
     last_day = pd.Timestamp('2021-06-01')
 
     cumulative_barplot(exp_names,channel,labels, first_day,last_day, region="All")


### PR DESCRIPTION
- updated bvariant parameters in yaml (note bvariant startdate needs to be AFTER last Ki multiplier)
- write out barplot values in [bar_timeline_plotter.py ]( https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/bar_timeline_plotter.py)
- region specific vaccine scenario, per default read from csv if scenario includes 'vaccine'
Note: vaccine scenarios informed by data but keep using daily fractions of population vaccinated to avoid negative counts when one would use total numbers