### PR TITLE
More flexible calculate_incidence function, updated plotters, aggregate trajectories by param

### DIFF
--- a/plotters/AgeSimulationPlots.py
+++ b/plotters/AgeSimulationPlots.py
@@ -23,9 +23,7 @@ def plot_on_fig(df, c, axes,channel, color,panel_heading, label=None, addgrid=Tr
     ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
                 color=color, linewidth=0, alpha=0.4)
     ax.set_title(panel_heading, y=0.85)
-    formatter = mdates.DateFormatter("%m-%d")
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.set_major_locator(mdates.MonthLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%b'))
 
    # ref_df  = compare_ems(ems=ems, channel=channel)
 
@@ -44,13 +42,13 @@ def plot_on_fig(df, c, axes,channel, color,panel_heading, label=None, addgrid=Tr
 
 def plot_covidregions(exp_names,channel,subgroups, psuffix) :
 
-    fig = plt.figure(figsize=(14, 10))
+    fig = plt.figure(figsize=(14, 8))
     fig.suptitle(f' {channel}', y=1, fontsize=14)
     plt.tight_layout(rect=[0, 0, 0, .95])
     fig.subplots_adjust(top=0.88)
-    fig.subplots_adjust(right=0.97, wspace=0.20, left=0.05, hspace=0.4, top=0.85, bottom=0.00)
+    fig.subplots_adjust(right=0.97, wspace=0.20, left=0.05, hspace=0.4, top=0.95, bottom=0.01)
     palette = sns.color_palette('Set1', len(exp_names))
-    axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
+    axes = [fig.add_subplot(3, 3, x + 1) for x in range(len(subgroups))]
 
     for c, age_suffix in enumerate(subgroups) :
 
@@ -58,7 +56,7 @@ def plot_covidregions(exp_names,channel,subgroups, psuffix) :
         region_label= region_label.replace('_All', 'all ')
 
         for d, exp_name in enumerate(exp_names) :
-            df = load_sim_data(exp_name, region_suffix=age_suffix, add_incidence=False)
+            df = load_sim_data(exp_name, region_suffix=age_suffix, add_incidence=True)
             df = df[df['date'].between(first_plot_day, last_plot_day)]
             
             version = exp_name.split("_")[-1]
@@ -86,13 +84,13 @@ if __name__ == '__main__' :
     plot_path = os.path.join(wdir, 'simulation_output', exp_names[len(exp_names) - 1], '_plots')
 
     ageGroup_list = ['_All',"_age0to9", "_age10to19", "_age20to29", "_age30to39", "_age40to49", "_age50to59", "_age60to69", "_age70to100"]
-    first_plot_day = pd.Timestamp.today()- pd.Timedelta(30,'days')
-    last_plot_day = pd.Timestamp.today()+ pd.Timedelta(15,'days')
+    first_plot_day = pd.Timestamp('2020-02-13')
+    last_plot_day = pd.Timestamp.today() + pd.Timedelta(30, 'days')
     
-    psuffix = '_MarchOct_log'
-    #plot_covidregions(exp_names,channel='crit_det', subgroups = ageGroup_list, psuffix ='_MarchOct')
-    #plot_covidregions(exp_names,channel='hosp_det', subgroups = ageGroup_list,  psuffix ='_MarchOct')
-    #plot_covidregions(exp_names,channel='hospitalized', subgroups = ageGroup_list,  psuffix ='_MarchOct')
-    #plot_covidregions(exp_names,channel='death_det_cumul', subgroups = ageGroup_list,  psuffix ='_MarchOct')
-    plot_covidregions(exp_names,channel='infected', subgroups = ageGroup_list,  psuffix ='_JulyOct')
-    #plot_covidregions(exp_names,channel='asymptomatic', subgroups = ageGroup_list,  psuffix ='_MarchOct')
+    psuffix = 'FebToToday'
+    #plot_covidregions(exp_names,channel='crit_det', subgroups = ageGroup_list, psuffix =psuffix)
+    #plot_covidregions(exp_names,channel='hosp_det', subgroups = ageGroup_list,  psuffix =psuffix)
+    #plot_covidregions(exp_names,channel='hospitalized', subgroups = ageGroup_list,  psuffix =psuffix)
+    #plot_covidregions(exp_names,channel='deaths_det_cumul', subgroups = ageGroup_list,  psuffix =psuffix)
+    plot_covidregions(exp_names,channel='infected', subgroups = ageGroup_list,  psuffix =psuffix)
+    #plot_covidregions(exp_names,channel='asymptomatic', subgroups = ageGroup_list,  psuffix =psuffix)

--- a/plotters/age_plot.py
+++ b/plotters/age_plot.py
@@ -1,0 +1,112 @@
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import sys
+sys.path.append('../')
+from load_paths import load_box_paths
+import matplotlib as mpl
+import matplotlib.dates as mdates
+import seaborn as sns
+from processing_helpers import *
+
+mpl.rcParams['pdf.fonttype'] = 42
+
+datapath, projectpath, wdir,exe_dir, git_dir = load_box_paths()
+
+first_plot_day = pd.Timestamp('2020-02-13')
+last_plot_day = pd.Timestamp.today()+ pd.Timedelta(30,'days')
+
+def load_sim_data(exp_name,channel, ageGroup_list,age_suffix ='_All', input_wdir=None,fname='trajectoriesDat.csv', input_sim_output_path =None) :
+    input_wdir = input_wdir or wdir
+    sim_output_path_base = os.path.join(input_wdir, 'simulation_output', exp_name)
+    sim_output_path = input_sim_output_path or sim_output_path_base
+
+    column_list = ['scen_num',  'time', 'startdate']
+    for grp in ageGroup_list:
+        column_list.append(channel + str(grp))
+        column_list.append('N' + str(grp))
+
+    df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=column_list)
+    df.columns = df.columns.str.replace(age_suffix, '')
+
+    return df
+
+def plot_covidregions(exp_name,channel,ageGroup_list,ageGroups, perPop=True) :
+
+    fig = plt.figure(figsize=(7, 3))
+    fig.tight_layout()
+    fig.subplots_adjust(top=0.88)
+    fig.subplots_adjust(right=0.97, wspace=0.5, left=0.1, hspace=0.9, top=0.90, bottom=0.07)
+    palette = sns.color_palette('Set1', 2)
+    axes = [fig.add_subplot(1, 2, x + 1) for x in range(len(exp_names))]
+
+    for p, exp_name in enumerate(exp_names) :
+        sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
+        df = load_sim_data(exp_name, channel=channel, ageGroup_list=ageGroup_list,age_suffix="")
+
+        exp_name_label = ''
+        if exp_name == "20201015_EMS_1_ms_age_cdc_v1":
+            exp_name_label = "Before age-adjustment 2nd Wave"
+        if exp_name == "20201021_EMS_1_testrun_ct_2ndWave_run2":
+            exp_name_label = "After age-adjustment 2nd Wave"
+
+        for i in range(len(ageGroups)) :
+            column_list = []
+            column_list2 = []
+            for grp in ageGroups[list(ageGroups.keys())[i]]:
+                column_list.append(channel + str(grp))
+                column_list2.append('N' + str(grp))
+            df[f'{channel}_grp{i+1}'] = df[column_list].sum(axis=1)
+            df[f'Npop_grp{i+1}'] = df[column_list2].sum(axis=1)
+            df[f'{channel}_perPop_grp{i + 1}'] = df[f'{channel}_grp{i+1}'] / df[f'Npop_grp{i+1}']
+
+        channels_new =  [x for x in df.columns.values if 'grp' in x]
+        ytitle = "Total infected"
+        if perPop == True :
+            channels_new =  [x for x in df.columns.values if 'perPop_grp' in x]
+            ytitle = "N infected / Population"
+
+        for c, grp_channel in enumerate(channels_new) :
+
+            grp_label =grp_channel #f'{channel} {list(ageGroups.keys())[c-1]}'
+
+            if grp_channel == f'{channel}_perPop_grp1':
+                grp_label = ' younger age group (<60)'
+            if grp_channel == f'{channel}_perPop_grp2':
+                grp_label = ' older age group (>60)'
+
+            ax = axes[p]
+            first_day = datetime.strptime(df['startdate'].unique()[0], '%Y-%m-%d')
+            df['date'] = df['time'].apply(lambda x: first_day + timedelta(days=int(x)))
+            df = df[(df['date'] >= first_plot_day) & (df['date'] <= last_plot_day)]
+            mdf = df.groupby('date')[grp_channel].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
+
+            ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
+            ax.plot(mdf['date'], mdf['CI_50']*100, color=palette[c], label=grp_label)
+            ax.fill_between(mdf['date'].values, mdf['CI_25']*100, mdf['CI_75']*100,
+                            color=palette[c], linewidth=0, alpha=0.4)
+            formatter = mdates.DateFormatter("%b")
+            ax.xaxis.set_major_formatter(formatter)
+            ax.xaxis.set_major_locator(mdates.MonthLocator())
+            ax.set_ylabel(ytitle)
+            ax.set_title(exp_name_label, y=0.98,size=10)
+
+            axes[-1].legend()
+            plt.tight_layout()
+
+    plt.savefig(os.path.join(sim_output_path, 'age_comparison_plot_%s.png' % channel))
+    plt.savefig(os.path.join(sim_output_path, 'age_comparison_plot_%s.pdf' % channel))
+
+
+if __name__ == '__main__' :
+
+    exp_names = ['20201015_EMS_1_ms_age_cdc_v1','20201021_EMS_1_testrun_ct_2ndWave_run2']
+
+    ageGroup_list = ["_age0to9", "_age10to19", "_age20to29", "_age30to39", "_age40to49", "_age50to59", "_age60to69", "_age70to100"]
+    ageGroups = {'young' : ['_age0to9', '_age10to19', '_age20to29', '_age30to39', '_age40to49', '_age50to59'],
+                  'elderly' : ['_age60to69', '_age70to100']}
+
+    #plot_covidregions(exp_names,channel='new_exposures', ageGroup_list=ageGroup_list,ageGroups = ageGroups)
+    #plot_covidregions(exp_names,channel='new_infected', ageGroup_list=ageGroup_list,ageGroups = ageGroups)
+    plot_covidregions(exp_names,channel='infected', ageGroup_list=ageGroup_list,ageGroups = ageGroups)
+

--- a/plotters/aggregate_by_param.py
+++ b/plotters/aggregate_by_param.py
@@ -1,0 +1,191 @@
+import argparse
+import numpy as np
+import pandas as pd
+import os
+import sys
+import matplotlib as mpl
+mpl.use('Agg')
+import matplotlib.pyplot as plt
+import seaborn as sns
+import matplotlib.dates as mdates
+sys.path.append('../')
+from processing_helpers import *
+from load_paths import load_box_paths
+
+def parse_args():
+    description = "Simulation run for modeling Covid-19"
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument(
+        "-exp",
+        "--exp_name",
+        type=str,
+        help="Name of simulation experiments"
+    )
+
+    parser.add_argument(
+        "-loc",
+        "--Location",
+        type=str,
+        help="Local or NUCLUSTER",
+        default="Local"
+    )
+    parser.add_argument(
+        "-p",
+        "--param",
+        type=str,
+        #nargs='+',
+        help="Name of parameter to keep when aggregating simulations. I.e. intervention coverage parameter",
+        default='recovery_time_crit'
+    )
+    parser.add_argument(
+        "-plot",
+        "--plot_only",
+        action='store_true',
+        help="If specified, only generates the plot, given that trajectoriesDat_aggr is available.",
+    )
+    return parser.parse_args()
+
+def plot_sim(exp_name,exp_path,grp_list, param, channel):
+
+    first_day = pd.Timestamp.today() - pd.Timedelta(60,'days')
+    last_day = pd.Timestamp.today() + pd.Timedelta(15,'days')
+
+    column_list =['date', 'grp']
+    for stat in ['_median','_50CI_upper','_50CI_lower','_95CI_upper','_95CI_lower']:
+        column_list.append(channel + stat)
+
+    if param is not None:
+        column_list = column_list + [param]
+
+    df = pd.read_csv(os.path.join(exp_path, 'trajectoriesDat_aggr.csv'), usecols=column_list)
+    df['date'] = pd.to_datetime(df['date'])
+    df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
+
+    fig = plt.figure(figsize=(16, 8))
+    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
+    palette = sns.color_palette('Set1', len(df[param].unique()))
+
+    for c, grp in enumerate(list(df['grp'].unique())):
+        mdf = df[df['grp']==grp]
+        ax = fig.add_subplot(3, 4, c + 1)
+
+        for k, p in enumerate(list(mdf[param].unique())):
+            pdf = mdf[mdf[param] == p]
+            ax.plot(pdf['date'], pdf['%s_median' % channel], color=palette[k], label=p)
+            ax.fill_between(pdf['date'].values, pdf['%s_95CI_lower' % channel], pdf['%s_95CI_upper' % channel],
+                            color=palette[k], linewidth=0, alpha=0.2)
+            ax.fill_between(pdf['date'].values, pdf['%s_50CI_lower' % channel], pdf['%s_50CI_upper' % channel],
+                            color=palette[k], linewidth=0, alpha=0.4)
+        ax.set_title(grp)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%Y'))
+    ax.legend(title=param)
+    plotname = f'{exp_name.split("_")[-1]}_{channel}'
+    plt.suptitle(channel, x=0.5, y=0.999, fontsize=14)
+    plt.tight_layout()
+
+    plt.savefig(os.path.join(plot_path, plotname + '.png'))
+    plt.savefig(os.path.join(plot_path, 'pdf', plotname + '.pdf'), format='PDF')
+
+
+def aggregate_trajectories(grp, param=None, channels=None):
+
+    if grp is not None:
+        region_suffix =  f'_{grp}'
+    else:
+        grp=''
+        region_suffix=''
+
+    column_list = ['startdate', 'time', 'scen_num', 'sample_num','run_num']
+    if channels is None:
+        channels = ['susceptible', 'infected', 'recovered', 'infected_cumul', 'asymp_cumul','asymp_det_cumul',
+                    'symp_mild_cumul', 'symp_severe_cumul', 'symp_mild_det_cumul','symp_severe_det_cumul',
+                    'hosp_det_cumul', 'hosp_cumul', 'detected_cumul', 'crit_cumul', 'crit_det_cumul',
+                    'deaths_det_cumul', 'deaths', 'crit_det',  'critical', 'hosp_det', 'hospitalized','Ki_t']
+
+    if grp =='All':
+        channels = [ch for ch in channels if ch != "Ki_t"]
+
+    if len(region_suffix)>0:
+        for channel in channels:
+            column_list.append(channel + region_suffix)
+
+    df = load_sim_data(exp_name,region_suffix = region_suffix,column_list=column_list,  add_incidence=True)
+    df['grp'] = grp
+    if param is not None:
+        sampled_df = pd.read_csv(os.path.join(exp_path, "sampled_parameters.csv"), usecols=['scen_num', param])
+        df = pd.merge(how='left', left=df, left_on='scen_num', right=sampled_df, right_on='scen_num')
+    else :
+        """Create dummy column"""
+        df['param'] = 1
+        param = 'param'
+
+    groupby_channels = ['date', 'startdate', 'time', 'grp',param]
+    groupby_channels = list(set(groupby_channels))
+    channels = [ch for ch in list(df.columns) if ch not in
+                list(set(groupby_channels + ['scen_num','sample_num','run_num','N',f'N_{grp}']))]
+
+    metrics = (np.min, CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75, np.max)
+    adf = pd.DataFrame()
+    for c, channel in enumerate(channels):
+        mdf = df.groupby(groupby_channels)[channel].agg(metrics).reset_index()
+
+        mdf = mdf.rename(columns={'amin': '%s_min' % channel,
+                                  'CI_50': '%s_median' % channel,
+                                  'CI_2pt5': '%s_95CI_lower' % channel,
+                                  'CI_97pt5': '%s_95CI_upper' % channel,
+                                  'CI_25': '%s_50CI_lower' % channel,
+                                  'CI_75': '%s_50CI_upper' % channel,
+                                  'amax': '%s_max' % channel})
+        if adf.empty:
+            adf = mdf
+        else:
+            adf = pd.merge(left=adf, right=mdf, on=groupby_channels)
+
+    return adf
+
+
+if __name__ == '__main__':
+
+    args = parse_args()
+    exp_name = "20210310_IL_locale_uniform_mean_mr_testB004_binfect"
+    Location = args.Location
+    param = args.param
+    plot_only = args.plot_only
+
+    datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
+
+    print(exp_name)
+    exp_path = os.path.join(wdir, 'simulation_output', exp_name)
+    plot_path = os.path.join(exp_path, '_plots')
+
+    """Get group names"""
+    grp_list, grp_suffix = get_group_names(exp_path=exp_path)
+
+    if not plot_only:
+        """Channels to keep (might change depending on simulation and focus"""
+        outcome_channels = ['recovered', 'infected_cumul','hosp_det_cumul','detected_cumul',
+                            'crit_det_cumul', 'deaths_det_cumul', 'deaths', 'crit_det', 'hosp_det','Ki_t']
+
+        if len(grp_list) >1:
+            dfAll = pd.DataFrame()
+            for grp in grp_list:
+                print(f'Start aggregating trajectories for {grp}')
+                df = aggregate_trajectories(grp, param=param, channels=outcome_channels)
+                df['scenario_name'] = exp_name.split("_")[-1]
+                df['simdate'] = exp_name.split("_")[0]
+                df['processdate'] = pd.Timestamp.today().date()
+                filename = f'trajectoriesDat_aggr_{grp}.csv'
+                df.to_csv(os.path.join(exp_path, filename), index=False)
+                dfAll = pd.concat([dfAll, df])
+                del df
+            dfAll.to_csv(os.path.join(exp_path, 'trajectoriesDat_aggr.csv'), index=False)
+        else:
+            df = aggregate_trajectories(grp=None, param=param,channels=outcome_channels)
+            df['scenario_name'] = exp_name.split("_")[-1]
+            df['simdate'] = exp_name.split("_")[0]
+            df['processdate'] = pd.Timestamp.today()
+            filename = f'trajectoriesDat_aggr.csv'
+            df.to_csv(os.path.join(exp_path, filename), index=False)
+
+    plot_sim(exp_name,exp_path,grp_list, param, channel='new_crit_det')

--- a/plotters/data_comparison.py
+++ b/plotters/data_comparison.py
@@ -45,7 +45,7 @@ def compare_NMH(exp_name) :
     df = load_sim_data(exp_name)
     first_day = datetime.strptime(df['startdate'].unique()[0], '%Y-%m-%d')
 
-    channels = ['new_detected_hospitalized', 'hosp_det_cumul', 'hospitalized', 'critical']
+    channels = ['new_hosp_det', 'hosp_det_cumul', 'hospitalized', 'critical']
     data_channel_names = ['covid pos admissions', 'cumulative admissions', 'inpatient census', 'ICU census']
 
     plot_path = os.path.join(wdir, 'simulation_output', exp_name, 'compare_to_data_NMH_v1')
@@ -146,7 +146,7 @@ def compare_county(exp_name, county_name, first_day, last_day) :
     df['critical_with_suspected'] = df['critical']
 
 
-    channels = ['new_detected', 'new_detected_hospitalized', 'detected_cumul', 'hosp_det_cumul']
+    channels = ['new_detected', 'new_hosp_det', 'detected_cumul', 'hosp_det_cumul']
     data_channel_names = ['new_case', 'new_hospitalizations', 'total_case', 'total_hospitalizations']
 
     plot_path = os.path.join(wdir, 'simulation_output', exp_name, 'compare_to_data')

--- a/plotters/hosp_icu_deaths_forecast_plotter.py
+++ b/plotters/hosp_icu_deaths_forecast_plotter.py
@@ -101,7 +101,7 @@ def compare_ems(exp_name, plot_name, ems_nr, first_day , last_day):
 
     outcome_channels = ['hosp_det_cumul', 'hosp_cumul', 'hosp_det', 'hospitalized',
                         'crit_det_cumul', 'crit_cumul', 'crit_det', 'critical',
-                        'death_det_cumul', 'deaths']
+                        'deaths_det_cumul', 'deaths']
 
 
     for channel in outcome_channels:

--- a/plotters/locale_age_postprocessing.py
+++ b/plotters/locale_age_postprocessing.py
@@ -82,7 +82,7 @@ if __name__ == '__main__' :
         sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
         plot_path = os.path.join(sim_output_path, '_plots')
 
-        df = load_sim_data(exp_name, region_suffix=None, add_incidence=False)
+        df = load_sim_data(exp_name, region_suffix=None, add_incidence=True)
         suffix_names = [x.split('_')[1] for x in df.columns.values if 'susceptible' in x]
         base_names = [x.split('_%s' % suffix_names[0])[0] for x in df.columns.values if suffix_names[0] in x]
 
@@ -105,9 +105,7 @@ if __name__ == '__main__' :
             df['infected_%s' % grp] = df['asymptomatic_%s' % grp] + df['presymptomatic_%s' % grp] + \
                                             df['symptomatic_mild_%s' % grp] + df['symptomatic_severe_%s' % grp] + \
                                             df['hospitalized_%s' % grp] + df['critical_%s' % grp]
-            df = calculate_incidence_by_age(df, grp,
-                                            output_filename=os.path.join(sim_output_path,
-                                                                         'trajectoriesDat_withIncidence_%s.csv' % grp))
+
             df['infections_cumul_%s' % grp] = df['asymp_cumul_%s' % grp] + \
                                                     df['symp_mild_cumul_%s' % grp] + \
                                                     df['symp_severe_cumul_%s' % grp]

--- a/plotters/plot_prevalence.py
+++ b/plotters/plot_prevalence.py
@@ -36,10 +36,8 @@ def parse_args():
     )
     return parser.parse_args()
 
-def get_prev_df(df, channels, fname='trajectoriesDat.csv'):
+def get_prev_df(exp_name, channels):
 
-    sort_channels = ['scen_num', 'sample_num', 'run_num', 'time']
-    group_channels = ['scen_num', 'sample_num', 'run_num']
     region_list = ['All'] + ['EMS-%d' % x for x in range(1, 12)]
 
     df = pd.DataFrame()
@@ -63,14 +61,9 @@ def get_prev_df(df, channels, fname='trajectoriesDat.csv'):
             column_list.append('recovered_det_' + str(ems_region))
             column_list.append('deaths_det_' + str(ems_region))
 
-        df_i = load_sim_data(exp_name, region_suffix=f'_{ems_region}', column_list=column_list, add_incidence=False)
+        df_i = load_sim_data(exp_name, region_suffix=f'_{ems_region}', column_list=column_list, add_incidence=True)
         if ems_region !="All" :
             df_i['N'] = df_i['N_' + str(ems_region.replace("-", "_"))]
-        df_i[f'new_deaths'] = df_i.sort_values(sort_channels).groupby(group_channels)[f'deaths'].diff()
-        df_i[f'new_recovered'] = df_i.sort_values(sort_channels).groupby(group_channels)[f'recovered'].diff()
-        if get_det > 0:
-            df_i[f'new_deaths_det'] = df_i.sort_values(sort_channels).groupby(group_channels)[f'deaths_det'].diff()
-            df_i[f'new_recovered_det'] = df_i.sort_values(sort_channels).groupby(group_channels)[f'recovered_det'].diff()
 
         df_i = calculate_prevalence(df_i)
         df_i['region'] = ems_nr

--- a/plotters/plot_single_trajectories.py
+++ b/plotters/plot_single_trajectories.py
@@ -30,7 +30,7 @@ if __name__ == '__main__' :
     adf = adf[adf['date'] >= pd.Timestamp('2020-10-01')]
     # print(adf.columns.values)
 
-    channels = ['infected', 'new_detected_hospitalized']
+    channels = ['infected', 'new_hosp_det']
 
     gdf = adf.groupby(['run_num', 'sample_num'])
     palette = sns.color_palette('rainbow', len(gdf))

--- a/plotters/plot_split_by_channel.py
+++ b/plotters/plot_split_by_channel.py
@@ -32,23 +32,31 @@ def parse_args():
     )
     return parser.parse_args()
 
-def plot_on_fig(df, channels, axes, color, label) :
+def plot_on_fig(df, channels, axes, color, label,logscale=False, ymax=10000) :
 
     for c, channel in enumerate(channels) :
+
         channeltitle = re.sub('_detected', '', str(channel), count=1)
         channeltitle = re.sub('_det','', str(channeltitle), count=1)
 
         ax = axes[c]
+        ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
+
         mdf = df.groupby('date')[channel].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
         ax.plot(mdf['date'], mdf['CI_50'], color=color, label=label)
-        # ax.fill_between(mdf['date'].values, mdf['CI_2pt5'], mdf['CI_97pt5'],
-        #                 color=color, linewidth=0, alpha=0.2)
+        ax.fill_between(mdf['date'].values, mdf['CI_2pt5'], mdf['CI_97pt5'],
+                        color=color, linewidth=0, alpha=0.2)
         ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
                         color=color, linewidth=0, alpha=0.4)
-        ax.set_title(' '.join(channeltitle.split('_')), y=0.85)
+        ax.set_title(' '.join(channeltitle.split('_')), y=0.985)
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
+        if logscale :
+            ax.set_ylim(0.1, ymax)
+            ax.set_yscale('log')
 
-def compare_channels(channelGrp,grp="All"):
+
+
+def get_channels(channelGrp):
     nchannels_symp = {'channels1': ['symp_severe_cumul', 'symp_mild_cumul', 'symptomatic_severe', 'symptomatic_mild'],
                       'channels2': ['symp_severe_det_cumul', 'symp_mild_det_cumul', 'symptomatic_severe_det',
                                     'symptomatic_mild_det']}
@@ -59,52 +67,73 @@ def compare_channels(channelGrp,grp="All"):
 
     nchannels_hospCrit = {
         'channels1': ['hospitalized', 'new_hospitalized', 'hosp_cumul', 'critical', 'new_critical', 'crit_cumul'],
-        'channels2': ['hosp_det', 'new_detected_hospitalized', 'hosp_det_cumul', 'crit_det', 'new_detected_critical',
+        'channels2': ['hosp_det', 'new_hosp_det', 'hosp_det_cumul', 'crit_det', 'new_crit_det',
                       'crit_det_cumul']}
 
     nchannels_Vacc = {
         'channels1': ['vaccinated_cumul', 'asymp_det', 'hosp_det', 'crit_det', 'deaths_det', 'recovered_det'],
         'channels2': ['vaccinated_cumul', 'asymp_det_V', 'hosp_det_V', 'crit_det_V', 'deaths_det_V', 'recovered_det_V']}
 
+    nchannels_B = {
+        'channels1': ['new_infected', 'exposed', 'new_hosp',  'new_crit', 'new_deaths', 'new_recovered'],
+        'channels2': ['new_Binfect', 'exposed_B', 'new_hosp_B', 'new_crit_B', 'new_deaths_B', 'new_recovered_B']}
+
     if channelGrp == "symp":
         nchannels = nchannels_symp
+        label0 = "detected + undetected"
+        label1 = "detected"
     if channelGrp == "infect":
         nchannels = nchannels_infect
+        label0 = "detected + undetected"
+        label1 = "detected"
     if channelGrp == "hospCrit":
         nchannels = nchannels_hospCrit
+        label0 = "detected + undetected"
+        label1 = "detected"
     if channelGrp == "Vaccinated":
         nchannels = nchannels_Vacc
+        label0 = "vaccinated + not vaccinated"
+        label1 = "vaccinated"
+    if channelGrp == "bvariant":
+        nchannels = nchannels_B
+        label0 = "bvariant + not bvariant"
+        label1 = "bvariant"
+
+    return  nchannels, label0, label1
+
+
+def compare_channels(channelGrp,grp="All",logscale=False):
+
+    nchannels, label0, label1 = get_channels(channelGrp)
+
+    df = load_sim_data(exp_name, region_suffix=f'_{grp}', fname='trajectoriesDat.csv', add_incidence=True)
+    df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
 
     palette = sns.color_palette('Set1', len(nchannels))
-    fig = plt.figure(figsize=(16, 8))
-    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
-
+    fig = plt.figure(figsize=(14, 7))
+    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.3, wspace=0.2, top=0.92, bottom=0.08)
+    fig.suptitle(x=0.5, y=0.99, t=grp)
     axes = [fig.add_subplot(2, 3, x + 1) for x in range(len(nchannels['channels1']))]
 
     for d, key in enumerate(nchannels.keys()):
-
-        column_list = ['startdate', 'time']
-        for channel in nchannels[key]:
-            column_list.append(channel + f'_{grp}')
-
-        df = load_sim_data(exp_name, region_suffix=f'_{grp}',  fname = 'trajectoriesDat.csv')
-        df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
-
-
         channels = nchannels[key]
-        if d == 0:
-            label = "all"
-        if d == 1:
-            label = "detected"
-            if channelGrp == "Vaccinated":
-                label = "vaccinated"
+        if len([col for col in channels if not col in df.columns])>0:
+            raise ValueError("Not all columns in dataframe")
+        else:
+            if d == 0:
+                label = label0
+            if d == 1:
+                label = label1
 
-        plot_on_fig(df, channels, axes, color=palette[d], label=label)
+        plot_on_fig(df, channels, axes, color=palette[d], label=label,logscale=logscale)
     axes[-1].legend()
 
-    fname = 'channel_' + channelGrp + '_comparison'
-    plt.savefig(os.path.join(plot_path, fname + '.png'))
-    # plt.savefig(os.path.join(plot_path,'pdf', fname + '.pdf'), format='PDF')
+    plot_name = f'{channelGrp}_comparison_{grp}'
+    if logscale :
+        plot_name = plot_name + "_log"
+
+    plt.savefig(os.path.join(plot_path, plot_name + '.png'))
+    # plt.savefig(os.path.join(plot_path,'pdf', plot_name + '.pdf'), format='PDF')
     plt.show()
 
 if __name__ == '__main__' :
@@ -124,6 +153,6 @@ if __name__ == '__main__' :
         plot_path = os.path.join(sim_output_path, '_plots')
         #compare_channels(channelGrp= "symp")
         #compare_channels(channelGrp= "infect")
-        compare_channels(channelGrp= "hospCrit")
-        compare_channels(channelGrp= "Vaccinated")
+        #compare_channels(channelGrp= "hospCrit")
+        #compare_channels(channelGrp= "Vaccinated")
 

--- a/plotters/plot_split_by_channel.py
+++ b/plotters/plot_split_by_channel.py
@@ -2,10 +2,11 @@ import argparse
 import os
 import pandas as pd
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+mpl.use('Agg')
 import sys
 sys.path.append('../')
 from load_paths import load_box_paths
-import matplotlib as mpl
 import matplotlib.dates as mdates
 import seaborn as sns
 from processing_helpers import *
@@ -75,8 +76,8 @@ def get_channels(channelGrp):
         'channels2': ['vaccinated_cumul', 'asymp_det_V', 'hosp_det_V', 'crit_det_V', 'deaths_det_V', 'recovered_det_V']}
 
     nchannels_B = {
-        'channels1': ['new_infected', 'exposed', 'new_hosp',  'new_crit', 'new_deaths', 'new_recovered'],
-        'channels2': ['new_Binfect', 'exposed_B', 'new_hosp_B', 'new_crit_B', 'new_deaths_B', 'new_recovered_B']}
+        'channels1': ['B_prev','new_infected',  'new_hosp',  'new_crit', 'new_deaths', 'new_recovered'],
+        'channels2': ['B_prev','new_Binfect',  'new_hosp_B', 'new_crit_B', 'new_deaths_B', 'new_recovered_B']}
 
     if channelGrp == "symp":
         nchannels = nchannels_symp
@@ -108,6 +109,8 @@ def compare_channels(channelGrp,grp="All",logscale=False):
 
     df = load_sim_data(exp_name, region_suffix=f'_{grp}', fname='trajectoriesDat.csv', add_incidence=True)
     df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
+    if channelGrp =='bvariant':
+        df['B_prev'] = df['infected_B'] / df['infected']
 
     palette = sns.color_palette('Set1', len(nchannels))
     fig = plt.figure(figsize=(14, 7))
@@ -151,8 +154,14 @@ if __name__ == '__main__' :
     for exp_name in exp_names:
         sim_output_path = os.path.join(wdir, 'simulation_output', exp_name)
         plot_path = os.path.join(sim_output_path, '_plots')
+        grp_list, grp_suffix = get_group_names(exp_path = sim_output_path)
+
         #compare_channels(channelGrp= "symp")
         #compare_channels(channelGrp= "infect")
         #compare_channels(channelGrp= "hospCrit")
         #compare_channels(channelGrp= "Vaccinated")
 
+        for grp in grp_list:
+            print(f'Process started for {grp}')
+            compare_channels(channelGrp= "bvariant",grp=grp)
+            #compare_channels(channelGrp="bvariant", grp=grp,logscale=True)

--- a/plotters/plot_split_by_param.py
+++ b/plotters/plot_split_by_param.py
@@ -53,6 +53,7 @@ def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
 
 def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) :
     ax = axes[c]
+
     mdf = df.groupby('date')[channel].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
     if addgrid:
         ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
@@ -61,7 +62,11 @@ def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) 
                 color=color, linewidth=0, alpha=0.4)
     ax.set_title(panel_heading, y=0.85)
     ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
-    ax.set_ylim(0, max(mdf['CI_75']))
+    if channel=='B_prev':
+        ax.set_ylim(0, 1)
+        ax.axhline(y=0.5, color='#737373', linestyle='--')
+    else:
+        ax.set_ylim(0, max(mdf['CI_75']))
 
 def plot_main(channels=None) :
 
@@ -135,8 +140,11 @@ def plot_covidregions_inone(channel='hospitalized') :
         region_label= region_suffix.replace('_EMS-', 'COVID-19 Region ')
 
         for d, exp_name in enumerate(exp_names) :
-            df = load_sim_data(exp_name, region_suffix=region_suffix)
+            df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat.csv')
             df = df[(df['date'] >= first_plot_day) & (df['date'] <= last_plot_day)]
+            if channel=='B_prev':
+                df['B_prev'] = df['infected_B'] / df['infected']
+                df = df.dropna(subset=["B_prev"])
             plot_on_fig2(df, c, axes, channel=channel, color=palette[d], panel_heading= region_label, label=exp_name)
 
         axes[-1].legend()
@@ -219,15 +227,13 @@ if __name__ == '__main__' :
     for exp_name in exp_names:
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
 
-        plot_main()
+        #plot_main()
         #plot_covidregions()
         plot_covidregions_inone(channel='Ki_t')
+        #plot_covidregions_inone(channel='B_prev')
         #plot_covidregions_inone(channel='hospitalized')
         #plot_restoreregions_inone(channel='hospitalized')
         #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
         #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
         #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild',
         #                                   'hosp_det','deaths_det','infectious_det'])
-        #plot_covidregions_inone2(channels=['infected_cumul','exposed',  'hospitalized', 'recovered', 'deaths',
-        #                                   'Binfect_cumul','exposed_B',  'hospitalized_B',  'recovered_B','deaths_B'])
-

--- a/plotters/plot_split_by_param.py
+++ b/plotters/plot_split_by_param.py
@@ -206,7 +206,7 @@ def plot_restoreregions_inone(channel='hospitalized') :
 if __name__ == '__main__' :
 
     args = parse_args()
-    stem = "20210310_IL_locale_uniform_mean_mr_testB010_binfect"
+    stem = args.stem
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths()

--- a/plotters/plot_split_by_param.py
+++ b/plotters/plot_split_by_param.py
@@ -47,9 +47,7 @@ def plot_on_fig(df, channels, axes, color, label, addgrid=True) :
         ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
                         color=color, linewidth=0, alpha=0.4)
         ax.set_title(' '.join(channel.split('_')), y=0.85)
-        formatter = mdates.DateFormatter("%m-%d")
-        ax.xaxis.set_major_formatter(formatter)
-        ax.xaxis.set_major_locator(mdates.MonthLocator())
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
         ax.set_ylim(0, max(mdf['CI_75']))
 
 
@@ -62,20 +60,21 @@ def plot_on_fig2(df, c, axes,channel, color,panel_heading, label, addgrid=True) 
     ax.fill_between(mdf['date'].values, mdf['CI_25'], mdf['CI_75'],
                 color=color, linewidth=0, alpha=0.4)
     ax.set_title(panel_heading, y=0.85)
-    formatter = mdates.DateFormatter("%m-%d")
-    ax.xaxis.set_major_formatter(formatter)
-    ax.xaxis.set_major_locator(mdates.MonthLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%b\n%y'))
     ax.set_ylim(0, max(mdf['CI_75']))
 
-def plot_main() :
-    fig = plt.figure(figsize=(8, 8))
-    fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+def plot_main(channels=None) :
+
+    if channels is None:
+        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+
+    fig = plt.figure(figsize=(14, 8))
+    fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
     palette = sns.color_palette('Set1', len(exp_names))
-    channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
     axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
 
     for d, exp_name in enumerate(exp_names) :
-        df = load_sim_data(exp_name)
+        df = load_sim_data(exp_name, fname='trajectoriesDat.csv')
         df = df[df['date'].between(first_plot_day, last_plot_day)]
         df['symptomatic_census'] = df['symp_mild'] + df['symp_severe']
         df['ventilators'] = get_vents(df['crit_det'].values)
@@ -87,10 +86,13 @@ def plot_main() :
     plt.savefig(os.path.join(plot_path,'pdf', 'iteration_comparison_IL.pdf'), format='PDF')
     #plt.show()
 
-def plot_covidregions() :
+def plot_covidregions(subgroups=None,channels=None) :
 
-    subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
-                 '_EMS-10', '_EMS-11']
+    if subgroups is None:
+        subgroups = ['_EMS-1', '_EMS-2', '_EMS-3', '_EMS-4', '_EMS-5', '_EMS-6', '_EMS-7', '_EMS-8', '_EMS-9',
+                     '_EMS-10', '_EMS-11']
+    if channels is None:
+        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
 
     for region_suffix in subgroups :
 
@@ -100,7 +102,7 @@ def plot_covidregions() :
         fig = plt.figure(figsize=(16, 8))
         fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
         palette = sns.color_palette('Set1', len(exp_names))
-        channels = ['infected', 'new_detected', 'new_deaths', 'hospitalized', 'critical', 'ventilators']
+
         axes = [fig.add_subplot(3, 2, x + 1) for x in range(len(channels))]
 
         for d, exp_name in enumerate(exp_names) :
@@ -126,11 +128,11 @@ def plot_covidregions_inone(channel='hospitalized') :
     fig = plt.figure(figsize=(16, 8))
     fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
     palette = sns.color_palette('Set1', len(exp_names))
-    axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
+    axes = [fig.add_subplot(3,4, x + 1) for x in range(len(subgroups))]
 
     for c, region_suffix in enumerate(subgroups) :
 
-        region_label= region_suffix.replace('_EMS-', 'covid region ')
+        region_label= region_suffix.replace('_EMS-', 'COVID-19 Region ')
 
         for d, exp_name in enumerate(exp_names) :
             df = load_sim_data(exp_name, region_suffix=region_suffix)
@@ -153,16 +155,16 @@ def plot_covidregions_inone2(channels=None):
 
     for channel in channels :
         fig = plt.figure(figsize=(12, 8))
-        fig.subplots_adjust(right=0.97, wspace=0.2, left=0.1, hspace=0.25, top=0.95, bottom=0.07)
+        fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
         palette = sns.color_palette('Set1', len(exp_names))
-        axes = [fig.add_subplot(4, 3, x + 1) for x in range(len(subgroups))]
+        axes = [fig.add_subplot(3, 4, x + 1) for x in range(len(subgroups))]
 
         for c, region_suffix in enumerate(subgroups) :
 
             region_label= region_suffix.replace('_EMS-', 'covid region ')
 
             for d, exp_name in enumerate(exp_names) :
-                df = load_sim_data(exp_name, region_suffix=region_suffix)
+                df = load_sim_data(exp_name, region_suffix=region_suffix, fname='trajectoriesDat.csv')
                 df = df[df['date'].between(first_plot_day, last_plot_day)]
                 plot_on_fig2(df, c, axes, channel=channel, color=palette[d],panel_heading = region_label,  label="")
 
@@ -204,12 +206,12 @@ def plot_restoreregions_inone(channel='hospitalized') :
 if __name__ == '__main__' :
 
     args = parse_args()
-    stem = args.stem
+    stem = "20210310_IL_locale_uniform_mean_mr_testB010_binfect"
     Location = args.Location
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths()
 
-    first_plot_day = pd.Timestamp.today()- pd.Timedelta(60,'days')
+    first_plot_day = pd.Timestamp('2020-01-01') #pd.Timestamp.today()- pd.Timedelta(60,'days')
     last_plot_day = pd.Timestamp.today()+ pd.Timedelta(15,'days')
 
 
@@ -219,10 +221,13 @@ if __name__ == '__main__' :
 
         plot_main()
         #plot_covidregions()
+        plot_covidregions_inone(channel='Ki_t')
         #plot_covidregions_inone(channel='hospitalized')
         #plot_restoreregions_inone(channel='hospitalized')
         #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
         #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
-        plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild',
-                                           'hosp_det','deaths_det','infectious_det'])
+        #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild',
+        #                                   'hosp_det','deaths_det','infectious_det'])
+        #plot_covidregions_inone2(channels=['infected_cumul','exposed',  'hospitalized', 'recovered', 'deaths',
+        #                                   'Binfect_cumul','exposed_B',  'hospitalized_B',  'recovered_B','deaths_B'])
 

--- a/plotters/plot_split_by_param.py
+++ b/plotters/plot_split_by_param.py
@@ -222,18 +222,15 @@ if __name__ == '__main__' :
     first_plot_day = pd.Timestamp('2020-01-01') #pd.Timestamp.today()- pd.Timedelta(60,'days')
     last_plot_day = pd.Timestamp.today()+ pd.Timedelta(15,'days')
 
+    plot_path = os.path.join(wdir, 'simulation_output', exp_names[-1], '_plots')
 
-    exp_names = [x for x in os.listdir(os.path.join(wdir, 'simulation_output')) if stem in x]
-    for exp_name in exp_names:
-        plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
-
-        #plot_main()
-        #plot_covidregions()
-        plot_covidregions_inone(channel='Ki_t')
-        #plot_covidregions_inone(channel='B_prev')
-        #plot_covidregions_inone(channel='hospitalized')
-        #plot_restoreregions_inone(channel='hospitalized')
-        #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
-        #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
-        #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild',
-        #                                   'hosp_det','deaths_det','infectious_det'])
+    #plot_main()
+    #plot_covidregions()
+    plot_covidregions_inone(channel='Ki_t')
+    #plot_covidregions_inone(channel='B_prev')
+    #plot_covidregions_inone(channel='hospitalized')
+    #plot_restoreregions_inone(channel='hospitalized')
+    #plot_covidregions_inone2(channels=['infected','new_detected','hospitalized', 'critical', 'deaths'])
+    #plot_covidregions_inone2(channels=['prevalence','recoverged','symptomatic_mild','symptomatic_severe'])
+    #plot_covidregions_inone2(channels=['symp_severe_det_cumul','symp_mild_det_cumul','symptomatic_mild',
+    #                                   'hosp_det','deaths_det','infectious_det'])

--- a/plotters/process_for_civis_EMSgrp.py
+++ b/plotters/process_for_civis_EMSgrp.py
@@ -103,10 +103,10 @@ def load_and_plot_data(ems_region, savePlot=True) :
 
 
     df['ventilators'] = get_vents(df['crit_det'].values)
-    df['new_symptomatic'] = df['new_symptomatic_severe'] + df['new_symptomatic_mild'] + df['new_detected_symptomatic_severe'] + df['new_detected_symptomatic_mild']
+    df['new_symptomatic'] = df['new_symp_severe'] + df['new_symp_mild'] + df['new_symp_severe_det'] + df['new_symp_mild_det']
 
-    channels = ['infected', 'new_infected', 'new_symptomatic', 'new_deaths', 'new_detected_deaths', 'hospitalized', 'critical', 'hosp_det', 'crit_det', 'ventilators', 'recovered']
-    plotchannels = ['infected', 'new_infected', 'new_symptomatic', 'new_deaths', 'new_detected_deaths', 'hosp_det', 'crit_det', 'ventilators', 'recovered']
+    channels = ['infected', 'new_infected', 'new_symptomatic', 'new_deaths', 'new_deaths_det', 'hospitalized', 'critical', 'hosp_det', 'crit_det', 'ventilators', 'recovered']
+    plotchannels = ['infected', 'new_infected', 'new_symptomatic', 'new_deaths', 'new_deaths_det', 'hosp_det', 'crit_det', 'ventilators', 'recovered']
 
     adf = pd.DataFrame()
     for c, channel in enumerate(channels):

--- a/plotters/readme.md
+++ b/plotters/readme.md
@@ -17,12 +17,18 @@ same as data_comparison_spatial.py, for plotting trends by a specified paramter
 Takes two experiment simulations and compares generates a plot comparing the trajectories of both
 - [plot_by_param_ICU_nonICU](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_by_param_ICU_nonICU.py)
 Plots the most recent trend in EMresource data for ICU and non-ICU and compares the next 2-3 weeks forward predictions, either with one or two exp_names
-- [plot_split_by_channel](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_channel.py)
-Comparison plotter for 2 channels in one panel (i.e. all vs detected for infected, symptomatic, hospitalized ...)
-- [plot_split_by_param_trajectories](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_param_trajectories.py)
-Simple plot per outcome channel for one experiment, instead of aggregating trajectories, show single trajectories
 - [plot_exp_by_varying_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_exp_by_varying_param.py)
 Plot to show trends by varying sample parameter (i.e. for intervention scenarios) within one simulation.
+
+### Compare parameter or channels within one simulation experiment
+- [aggregate_by_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/aggregate_by_param.py)
+Aggregate custom specified channels by defined parameter and generate plot for 1 channel across all groups compared by that parameter. Saved a csv with aggregated trajectores (large if too many channels selected!)
+- [plot_split_by_param_trajectories](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_param_trajectories.py)
+Simple plot per outcome channel for one experiment, instead of aggregating trajectories, show single trajectories
+- [plot_split_by_channel](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_channel.py)
+Comparison plotter for 2 channels in one panel (i.e. all vs detected for infected, symptomatic, hospitalized ...)
+- [plot_single_trajectories.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_single_trajectories.py)
+
 
 #### Stacked and grouped timeline plots
 - [EMS_combo_plotter.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/EMS_combo_plotter.py)
@@ -51,10 +57,8 @@ Building on [trace_selection.py](https://github.com/numalariamodeling/covid-chic
 The script also uses functions from [sample_parameters.py](https://github.com/numalariamodeling/covid-chicago/blob/master/sample_parameters.py).
 
 #### Further scripts 
-- [extract_sample_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/extract_sample_param.py) Extract and visualize sample parameters that successfully ran in a simulation. Can be used to generate csv files that can be used as inpput in another simulation.
-- [plot_exp_by_varying_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_exp_by_varying_param.py)
+- [extract_sample_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/extract_sample_param.py) 
+Extract and visualize sample parameters that successfully ran in a simulation. Can be used to generate csv files that can be used as inpput in another simulation.
 - [emresource_cli_per_covidregion.py](https://github.com/numalariamodeling/covid-chicago/blob/master/data_plotters/emresource_cli_per_covidregion.py) (data_plotters folder)
-- [plot_split_by_channel.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_channel.py)
-- [plot_split_by_param_trajectories.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_split_by_param_trajectories.py)
-- [plot_single_trajectories.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_single_trajectories.py)
+
 

--- a/plotters/readme.md
+++ b/plotters/readme.md
@@ -19,6 +19,8 @@ Takes two experiment simulations and compares generates a plot comparing the tra
 Plots the most recent trend in EMresource data for ICU and non-ICU and compares the next 2-3 weeks forward predictions, either with one or two exp_names
 - [plot_exp_by_varying_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/plot_exp_by_varying_param.py)
 Plot to show trends by varying sample parameter (i.e. for intervention scenarios) within one simulation.
+- [bar_timeline_plotter.py](https://github.com/numalariamodeling/covid-chicago/blob/master/data_plotters/bar_timeline_plotter.py)
+Often used for civis slides, generates timeline comparing outcome channelf across multiple simulation experiments and cumulative barplot
 
 ### Compare parameter or channels within one simulation experiment
 - [aggregate_by_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/aggregate_by_param.py)
@@ -60,5 +62,10 @@ The script also uses functions from [sample_parameters.py](https://github.com/nu
 - [extract_sample_param.py](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/extract_sample_param.py) 
 Extract and visualize sample parameters that successfully ran in a simulation. Can be used to generate csv files that can be used as inpput in another simulation.
 - [emresource_cli_per_covidregion.py](https://github.com/numalariamodeling/covid-chicago/blob/master/data_plotters/emresource_cli_per_covidregion.py) (data_plotters folder)
+- [bar_plotter.py](https://github.com/numalariamodeling/covid-chicago/blob/master/data_plotters/bar_plotter.py)
+Note extended version in [bar_timeline_plotter.py](https://github.com/numalariamodeling/covid-chicago/blob/master/data_plotters/bar_timeline_plotter.py)
+
+
+
 
 

--- a/plotters/trace_selection.py
+++ b/plotters/trace_selection.py
@@ -128,9 +128,9 @@ def rank_traces_nll(df, ems_nr, ref_df, weights_array=[1.0,1.0,1.0,1.0],wt=False
         total_nll = 0
         (run_num, sample_num, scen_num) = x
         df_trunc_slice = df_trunc[(df_trunc['run_num'] == run_num) & (df_trunc['sample_num'] == sample_num) & (df_trunc['scen_num'] == scen_num)]
-        total_nll += deaths_weight*sum_nll(df_trunc_slice['new_detected_deaths'].values[:-timelag_days], ref_df_trunc['deaths'].values[:-timelag_days], wt,wt_past=True)
+        total_nll += deaths_weight*sum_nll(df_trunc_slice['new_deaths_det'].values[:-timelag_days], ref_df_trunc['deaths'].values[:-timelag_days], wt,wt_past=True)
         total_nll += crit_weight*sum_nll(df_trunc_slice['crit_det'].values, ref_df_trunc['confirmed_covid_icu'].values, wt)
-        total_nll += cli_weight*sum_nll(df_trunc_slice['new_detected_hospitalized'].values, ref_df_trunc['inpatient'].values, wt)
+        total_nll += cli_weight*sum_nll(df_trunc_slice['new_hosp_det'].values, ref_df_trunc['inpatient'].values, wt)
         total_nll += non_icu_weight*sum_nll(df_trunc_slice['hosp_det'].values, ref_df_trunc['covid_non_icu'].values, wt)
         rank_export_df = rank_export_df.append(pd.DataFrame({'run_num':[run_num], 'sample_num':[sample_num], 'scen_num':[scen_num], 'nll':[total_nll]}))
     rank_export_df = rank_export_df.dropna()

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -47,7 +47,8 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname=None,
                 fname = 'trajectoriesDat.csv'
 
         print(f'Using {fname}')
-        column_list = list(set(['run_num', 'sample_num', 'scen_num','startdate', 'time'] + column_list))
+        if column_list is not None:
+            column_list = list(set(['run_num', 'sample_num', 'scen_num','startdate', 'time'] + column_list))
         df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=column_list)
         reg_cols = [col for col in df.columns if region_suffix in col]
         reg_cols = list(set(reg_cols + [col for col in df.columns if region_suffix.replace('-','_') in col]))

--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -47,7 +47,14 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname=None,
                 fname = 'trajectoriesDat.csv'
 
         print(f'Using {fname}')
+        column_list = list(set(['run_num', 'sample_num', 'scen_num','startdate', 'time'] + column_list))
         df = pd.read_csv(os.path.join(sim_output_path, fname), usecols=column_list)
+        reg_cols = [col for col in df.columns if region_suffix in col]
+        reg_cols = list(set(reg_cols + [col for col in df.columns if region_suffix.replace('-','_') in col]))
+        if region_suffix =='_EMS-1':
+            reg_cols = [col for col in reg_cols if not 'EMS-10' in col]
+            reg_cols = [col for col in reg_cols if not 'EMS-11' in col]
+        df = df[['run_num', 'sample_num', 'scen_num','startdate', 'time']+reg_cols]
         df.columns = df.columns.str.replace(region_suffix, '')
 
         if select_traces:


### PR DESCRIPTION
Note, since the hardcoded column names were replaced  using the chunk below, the new incidence columns have the same pattern as the cumulative channels i.e. `new_detected_hospitalized ` is not present anymore, instead  `new_hosp_det`, in alignment observed emodl channels.  

```
    channel_cumul = [col for col in adf.columns if 'cumul' in col]
    channel_cumul = channel_cumul + [col for col in adf.columns if 'deaths' in col]
    channel_cumul = channel_cumul + [col for col in adf.columns if 'recovered' in col]
    channel_cumul_new = ['new_'+ col.replace('_cumul','') for col in channel_cumul]

```

The` aggregate_by_param.py` script is similar to  `process_for_civis_EMSgrp.py`, however aimed for more  general analysis independent from the format for the civis deliverables, also the plot produced compares 1 outcome channel over all groups by varying parameter, rather than showing multiple outcomes for one group (not restricted to locale model)