### PR TITLE
use sample_num as main identifier in trace selection

### DIFF
--- a/processing_helpers.py
+++ b/processing_helpers.py
@@ -56,7 +56,7 @@ def load_sim_data(exp_name, region_suffix ='_All', input_wdir=None, fname=None,
                     n_traces_to_keep = len(rank_export_df)
 
                 rank_export_df_sub = rank_export_df[0:n_traces_to_keep]
-                df = df[df['scen_num'].isin(rank_export_df_sub.scen_num.unique())]
+                df = df[df['sample_num'].isin(rank_export_df_sub.sample_num.unique())]
     else :
         fname = 'trajectoriesDat.csv'
         if os.path.exists(os.path.join(sim_output_path, fname)) == False:

--- a/sample_parameters.py
+++ b/sample_parameters.py
@@ -138,7 +138,7 @@ def generateParameterSamples(samples, pop, start_dates, config, age_bins, Kivalu
         dfs.append(df_copy)
 
     result = pd.concat(dfs, ignore_index=True)
-    result["scen_num"] = range(1, len(result) + 1)
+    result["sample_num"] = range(1, len(result) + 1)
 
     return result
 
@@ -270,9 +270,9 @@ def gen_combos(csv_base, csv_add):
     csv_base.drop(list(csv_add.columns), axis=1, inplace=True, errors='ignore')
 
     ## Rename unique scenario identifier
-    csv_base = csv_base.rename(columns={"scen_num": "scen_num1"})
+    csv_base = csv_base.rename(columns={"sample_num": "sample_num1"})
     ## Add unique scenario identifier
-    csv_add['scen_num2'] = csv_add.reset_index().index
+    csv_add['sample_num2'] = csv_add.reset_index().index
 
     dfs_list = [''] * (2)
     dfs_list[0] = csv_base.copy()
@@ -300,8 +300,8 @@ def gen_combos(csv_base, csv_add):
         [c for c in master_df if c in index_columns] + [c for c in master_df if c not in index_columns]]
 
     ### Generate new unique scen_num
-    master_df['scen_num'] = make_identifier(master_df[['scen_num1', 'scen_num2']])
-
+    master_df['sample_num'] = make_identifier(master_df[['sample_num1', 'sample_num2']])
+    master_df['scen_num'] = master_df['sample_num']
     return master_df
 
 


### PR DESCRIPTION
- if no varying intervention_parameters are specified `scen_num `and `sample_num ` are the same 
- scen_num describes unique combination of sample and intervention parameters (and together with run_num) uniquely identify single trajectories
- in order to allow keeping variation in some parameters, the sample_num needs to be used (and keeping varying `scen_num `for each `sample_num`).
- Note: most default plotters do not group by parameter but aggregate all, however specific plotters exist to plot by parameter, which ones to use depends on whether accounting for parameter uncertainty or explicitly comparing parameter values (for the latter one it is more straight forward to run multiple separate simulations).
- Use case: include uncertainity in future transmission (latest ki multiplier or a future ki multiplier) (which need to be placed under `intervention_parameters` in the yaml file. (If region specific it is recommended to use a single scaling factor, as all parameters defined under   `intervention_parameters` will be full-factorial combinations)