### PR TITLE
updated rollback scenarios, read trigger from capacity csv

### DIFF
--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -956,12 +956,13 @@ class covidModel:
 
         intervention_start = pd.to_datetime(config_dic_dates[f'{scen}_start']['function_kwargs']['dates'])
         intervention_scaleupend = pd.to_datetime(config_dic_dates[f'{scen}_scaleupend']['function_kwargs']['dates'])
-        intervention_end = pd.to_datetime(config_dic_dates[f'{scen}_end']['function_kwargs']['dates'])
+        #intervention_end = pd.to_datetime(config_dic_dates[f'{scen}_end']['function_kwargs']['dates'])
 
-        if n_gradual_steps > 1:
+        if n_gradual_steps > 1 and intervention_scaleupend < pd.Timestamp('2090-01-01') :
             date_freq = (intervention_scaleupend - intervention_start) /(n_gradual_steps-1)
             intervention_dates = pd.date_range(start=intervention_start,end=intervention_scaleupend, freq=date_freq).tolist()
         else:
+            n_gradual_steps = 1
             intervention_dates = [intervention_start]
 
         return n_gradual_steps, intervention_dates
@@ -1164,7 +1165,7 @@ class covidModel:
                                             f'(func time_since_trigger_{grp} (- time time_of_trigger_{grp}))\n'
                                             f'(state-event apply_rollback_{grp} '
                                             f'(> (- time_since_trigger_{grp} @trigger_delay_days@) 0) ('
-                                            f'(- Ki_{grp}  (* @rollback_multiplier@ (- @Ki_{grp}@  Ki_{grp})))'
+                                            f'(Ki_{grp} (- Ki_{grp} (* @rollback_multiplier@ (- @Ki_{grp}@  Ki_{grp})))) '
                                             f'))\n'
                                             f'(observe triggertime_{covidModel.sub(grp)} time_of_trigger_{grp})\n' for
                                             grp in self.grpList])
@@ -1228,7 +1229,7 @@ class covidModel:
         intervention_str = ""
         if "bvariant" in self.add_interventions:
             intervention_str = intervention_str + write_bvariant()
-        if "rollback" in self.add_interventions:
+        if "rollback" in self.add_interventions and not "triggeredrollback" in self.add_interventions:
             intervention_str = intervention_str + write_rollback()
         if "triggeredrollback" in self.add_interventions:
             intervention_str = intervention_str + write_triggeredrollback()

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -553,7 +553,7 @@ time_parameters:
     function_kwargs: {'dates': 2021-04-10}
   'rollback_scaleupend':
     custom_function: DateToTimestep
-    function_kwargs: {'dates': 2021-04-10} #if gradual change
+    function_kwargs: {'dates': 2099-01-01} #if gradual change
   'rollback_end':
     custom_function: DateToTimestep
     function_kwargs: {'dates': 2099-01-01} #no end

--- a/experiment_configs/intervention_emodl_config.yaml
+++ b/experiment_configs/intervention_emodl_config.yaml
@@ -16,5 +16,3 @@ interventions:
   'bvariant_csv': ""
   'vaccination_csv': "vaccination_linear.csv" #"vaccination_linear_doubled.csv" 
   #'reopen_csv': "ki_increase_scenario.csv"
-  #'n_gradual_intervals': 4
-  #'start_today': True

--- a/experiment_configs/spatial_EMS_experiment.yaml
+++ b/experiment_configs/spatial_EMS_experiment.yaml
@@ -428,42 +428,7 @@ sampled_parameters:
         - {'low': 12.0, 'high':  12.0}
         - {'low': 12.0, 'high': 12.0}
         - {'low': 5.0, 'high':  5.0}
-        - {'low': 9.0, 'high':  9.0}  
-  ##Set threshold value for triggering a state event
-  ## Default set to ICU census from 30 July 2020
-  ## to switch between thresholds, remove or add the '_notused'
-  trigger:   # icu_total 
-    IL:
-      expand_by_age: True
-      np.random: uniform
-      function_kwargs:
-        - {'low':64, 'high':64}
-        - {'low':101, 'high':101}
-        - {'low':53, 'high':53}
-        - {'low':46, 'high':46}
-        - {'low':29, 'high':29}
-        - {'low':88, 'high':88}
-        - {'low':67, 'high':67}
-        - {'low':141 , 'high':141}
-        - {'low':92, 'high':92}
-        - {'low':287 , 'high':287}
-        - {'low':377 , 'high':377}
-  trigger_notused:   # medsurg_total 
-    IL:
-      expand_by_age: True
-      np.random: uniform
-      function_kwargs:
-        - {'low':671, 'high':671}
-        - {'low':1320,  'high':1320}
-        - {'low':796, 'high':796}
-        - {'low':528, 'high':528}
-        - {'low':551, 'high':551}
-        - {'low':911, 'high':911}
-        - {'low':660, 'high':660}
-        - {'low':1203,  'high':1203}
-        - {'low':709, 'high':709}
-        - {'low':2223, 'high':2223}
-        - {'low':2575, 'high':2575}
+        - {'low': 9.0, 'high':  9.0}
 ### If using setting specific increase in symptomatic infections in future scenarios (i.e. contact tracing)
 #d_Sym_ct1:
 #    IL:


### PR DESCRIPTION
region specific thresholds to trigger a 'rollback' event , previously specified  and manually updated in [the spatial yaml file](https://github.com/numalariamodeling/covid-chicago/blob/master/experiment_configs/spatial_EMS_experiment.yaml#L432) are read from the latest capacity csv file, aligned to the function in processing_helpers ([load_capacity](https://github.com/numalariamodeling/covid-chicago/blob/master/processing_helpers.py#L295)).
Outcome channel to use for threshold needs to be specified in the [intervention_emodl_config.yaml](https://github.com/numalariamodeling/covid-chicago/blob/master/experiment_configs/intervention_emodl_config.yaml#L14), (default crit_det)