### PR TITLE
paths for both NU cluster allocations, rename scenario to baseline in civis deliverables

### DIFF
--- a/load_paths.py
+++ b/load_paths.py
@@ -2,7 +2,7 @@ import os
 
 def load_box_paths(user_path=None, Location='Local'):
     if Location == 'NUCLUSTER':
-        user_path = '/projects/p30781/'
+        user_path = os.getcwd()[:16]  #'/projects/p30781/'
         home_path = os.path.join(user_path, 'covidproject', 'projects')
         data_path = os.path.join(user_path, 'covidproject', 'data')
         git_dir = os.path.join(user_path, 'covidproject', 'covid-chicago')

--- a/plotters/NUcivis_filecopy.py
+++ b/plotters/NUcivis_filecopy.py
@@ -50,6 +50,12 @@ def copyFiles(output_dir):
     for file in filelist :
         shutil.copyfile(os.path.join(os.path.join(exp_dir, '_plots'), file), os.path.join(output_dir,'plots', file))
 
+    """Scenario needs to be 'baseline' for fname 1 and 2"""
+    for fname in [fname1,fname2]:
+        df = pd.read_csv(os.path.join(output_dir,'csv', fname))
+        df['scenario'] = 'baseline'
+        df.to_csv(os.path.join(output_dir,'csv', fname), index=False, date_format='%Y-%m-%d')
+
 def subset_df(fname, regions_to_keep, output_dir,save_dir=None):
     df = pd.read_csv(os.path.join(exp_dir, fname))
     df = df[df.geography_modeled.isin(regions_to_keep)]
@@ -76,7 +82,8 @@ def writeChangelog(output_dir,A1=None,A2=None, A3=None, A4=None, A5=None, A6=Non
     if A5 == None :  A5 = "- Reduction in transmission rate due to 'shelter in place policies': " \
                           "2020-03-12, 2020-03-17, 2020-03-21, 2020-04-21" \
                           "\n- Change in transmission rate during reopening period : " \
-                          "2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20 "\
+                          "2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20," \
+                          "2021-02-15 ,2021-03-15  "\
                           "\n- Increase in detection rates/ decrease in fraction dead: monthly between March to Oct/Dec 2020"
     if A6 == None : A6 = "- No additional scenarios"
 

--- a/plotters/NUcivis_filecopy.py
+++ b/plotters/NUcivis_filecopy.py
@@ -53,7 +53,7 @@ def copyFiles(output_dir):
     """Scenario needs to be 'baseline' for fname 1 and 2"""
     for fname in [fname1,fname2]:
         df = pd.read_csv(os.path.join(output_dir,'csv', fname))
-        df['scenario'] = 'baseline'
+        df['scenario_name'] = 'baseline_test'
         df.to_csv(os.path.join(output_dir,'csv', fname), index=False, date_format='%Y-%m-%d')
 
 def subset_df(fname, regions_to_keep, output_dir,save_dir=None):

--- a/simulation_helpers.py
+++ b/simulation_helpers.py
@@ -282,6 +282,12 @@ echo end""")
             file.write(f'cd { os.path.join(git_dir, "nucluster")} \n python {list(process_dict.values())[12]}  --stem "{exp_name}" --del_trajectories --zip_dir  >> "{sim_output_path}/log/{list(process_dict.keys())[12]}.txt" \n')
 
 def shell_header(A='p30781',p='short',t='02:00:00',N=1,ntasks_per_node=1, memG=18,job_name='myjob', arrayJob=None):
+
+    if 'b1139' in os.getcwd():
+      A = 'b1139'
+      p = 'b1139'
+      t = '00:45:00'
+
     header = f'#!/bin/bash\n' \
              f'#SBATCH -A {A}\n' \
              f'#SBATCH -p {p}\n' \
@@ -302,7 +308,7 @@ def shell_header(A='p30781',p='short',t='02:00:00',N=1,ntasks_per_node=1, memG=1
     return header
 
 def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajectories_dir, git_dir, temp_exp_dir,exe_dir,sim_output_path,model) :
-    # Generic shell submission script that should run for all having access to  projects/p30781
+    # Generic shell submission script that should run for all having access to NU cluster allocation
     # submit_runSimulations.sh
 
     process_dict = get_process_dict()
@@ -323,6 +329,8 @@ def generateSubmissionFile_quest(scen_num, exp_name, experiment_config, trajecto
 
     plotters_dir = os.path.join(git_dir, "plotters")
     pymodule = '\n\nmodule purge all\nmodule load python/anaconda3.6\nsource activate /projects/p30781/anaconda3/envs/team-test-py37\n'
+    if 'b1139' in os.getcwd():
+        pymodule = '\n\nmodule purge all\nmodule load python/anaconda3.6\nsource activate /projects/b1139/anaconda3/envs/team-test-py37\n'
 
     emodl_name = str([i for i in os.listdir(temp_exp_dir) if "emodl" in i][0]).replace('.emodl', '')
     emodl_from = os.path.join(sim_output_path, emodl_name + ".emodl")


### PR DESCRIPTION
- on the NU cluster the first 16 characters include the allocation, running either on '/projects/p30781/' or on '/projects/b1139/' 
- civis deliverables require a 'baseline' scenario, while the `scenario_name `is kept to indicate the simulated scenarios i.e. vaccine bvariant and others, hence the scenario_name is only changed in the NU civis deliverables folder when running  `plotters/NUcivis_filecopy.py `