### PR TITLE
plotters updates, minor bugfixes when running subregions

### DIFF
--- a/combine_and_trim.py
+++ b/combine_and_trim.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 sys.path.append('../')
 from load_paths import load_box_paths
+from processing_helpers import *
 
 def parse_args():
     description = "Simulation run for modeling Covid-19"
@@ -258,6 +259,8 @@ if __name__ == '__main__':
         else:
             dfc = pd.read_csv(os.path.join(exp_path, fname))
 
+        """Update group names"""
+        grp_list, grp_suffix,grp_numbers = get_group_names(exp_path=exp_path)
         trim_trajectories(df=dfc,
                           sample_param_to_keep = sample_param_to_keep,
                           time_start=time_start,

--- a/plotters/bar_timeline_plotter.py
+++ b/plotters/bar_timeline_plotter.py
@@ -107,6 +107,7 @@ def timeline_plot(exp_names,channel,labels, first_day,last_day,  region="All"):
     fig = plt.figure(figsize=(6, 4))
     fig.subplots_adjust(left=0.2)
     ax = fig.gca()
+    ax.grid(b=True, which='major', color='#999999', linestyle='-', alpha=0.3)
 
     for s, exp_name in enumerate(exp_names):
         simpath = os.path.join(projectpath, 'cms_sim', 'simulation_output', exp_name)

--- a/plotters/hosp_icu_deaths_forecast_plotter.py
+++ b/plotters/hosp_icu_deaths_forecast_plotter.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     Location = args.Location
 
     first_plot_day = pd.Timestamp.today()- pd.Timedelta(60,'days')
-    last_plot_day = pd.Timestamp.today()+ pd.Timedelta(15,'days')
+    last_plot_day = pd.Timestamp.today()+ pd.Timedelta(150,'days')
 
     datapath, projectpath, wdir, exe_dir, git_dir = load_box_paths(Location=Location)
 

--- a/plotters/plot_split_by_channel.py
+++ b/plotters/plot_split_by_channel.py
@@ -67,7 +67,7 @@ def plot_on_fig(df, channels, axes, color, label,logscale=False, ymax=10000) :
             ax.plot(adf['date'], adf['persons_first_vaccinated'], 'o', color='#303030', linewidth=0, ms=1.1)
 
         ax.set_title(' '.join(channeltitle.split('_')), y=0.985)
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%d\n%b'))
         if logscale :
             ax.set_ylim(0.1, ymax)
             ax.set_yscale('log')
@@ -89,8 +89,8 @@ def get_channels(channelGrp):
                       'crit_det_cumul']}
 
     nchannels_Vacc = {
-        'channels1': ['vaccinated_cumul', 'asymp_det', 'hosp_det', 'crit_det', 'deaths_det', 'recovered_det'],
-        'channels2': ['vaccinated_cumul', 'asymp_det_V', 'hosp_det_V', 'crit_det_V', 'deaths_det_V', 'recovered_det_V']}
+        'channels1': ['vaccinated_cumul', 'new_infected', 'new_asymp_det', 'crit_det', 'new_deaths', 'new_recovered'],
+        'channels2': ['vaccinated_cumul', 'new_infected_V', 'new_asymp_det_V', 'crit_det_V', 'new_deaths_V', 'new_recovered_V']}
 
     nchannels_B = {
         'channels1': ['B_prev','new_infected',  'new_hosp',  'new_crit', 'new_deaths', 'new_recovered'],
@@ -123,10 +123,14 @@ def get_channels(channelGrp):
 def compare_channels(channelGrp,grp="All",logscale=False):
 
     nchannels, label0, label1 = get_channels(channelGrp)
-    column_list = list(set([ch.replace('new_','') for ch in nchannels['channels1']+nchannels['channels2']]))
-    column_list = [f'{ch}_{grp}' for ch in column_list]
 
-    df = load_sim_data(exp_name, region_suffix=f'_{grp}', column_list=column_list,add_incidence=True)
+    trajectories_cols = pd.read_csv(os.path.join(sim_output_path, 'trajectoriesDat.csv'), index_col=0, nrows=0).columns.tolist()
+    cols = list(set([ch.replace('new_','').replace('_V','') for ch in nchannels['channels1']+nchannels['channels2']]))
+    column_list=[]
+    for col in cols:
+        column_list = column_list + [x for x in trajectories_cols if x.startswith(col)]
+
+    df = load_sim_data(exp_name, region_suffix=f'_{grp}',fname='trajectoriesDat.csv',column_list=column_list, add_incidence=True)
     df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
     if channelGrp =='bvariant':
         df['B_prev'] = df['infected_B'] / df['infected']

--- a/runScenarios.py
+++ b/runScenarios.py
@@ -639,10 +639,9 @@ if __name__ == '__main__':
         subregion_label = args.subregion[0]
     else:
         subregion = args.subregion
-        if len(subregion) == 11:
-            subregion_label = 'all'
-        if len(subregion) > 1 & len(subregion) < 11:
-            subregion_label = 'sub'
+        subregion_label = ''
+        if len(subregion) < 11:
+            subregion_label = '_sub'
 
     if emodl_template is None:
         log.debug(f"Running scenarios for {model} and {scenario}")
@@ -687,7 +686,7 @@ if __name__ == '__main__':
         exp_name = f"{today.strftime('%Y%m%d')}_{region}_{args.name_suffix}"
     else:
         if model =='locale':
-            exp_name = f"{today.strftime('%Y%m%d')}_{region}_{model}_{subregion_label}_{args.name_suffix}_{scenario}"
+            exp_name = f"{today.strftime('%Y%m%d')}_{region}_{model}{subregion_label}_{args.name_suffix}_{scenario}"
         else:
             exp_name = f"{today.strftime('%Y%m%d')}_{region}_{model}_{args.name_suffix}_{scenario}"
         if args.fit_params[0] != None:


### PR DESCRIPTION
- `trim_trajectories  `returned errors when not all regions were run, corrected by using get_group_names to update grp_list
- 'sub' was added to exp_name per default, not only when subregions were run
- edited plotters for deliverables, labels and timeframes
- [Rt script ](https://github.com/numalariamodeling/covid-chicago/blob/master/plotters/estimate_Rt_forCivisOutputs.py) now allows for separate Rt estimation versus plotting via `--plot_only` flag