### PR TITLE
bugfix gradual change in Ki in reopen, rollback and bvariant scenarios

### DIFF
--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -1080,7 +1080,7 @@ class covidModel:
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event ki_bvariant_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                    temp_str = temp_str + ''.join([f' (Ki_{grp} ( + Ki_bvariant_initial_{grp}  (* (* Ki_bvariant_initial_{grp} 0.5)  (* @bvariant_fracinfect@ {(1 / (len(intervention_dates)) * i)} ))))' for grp in self.grpList])
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} ( + Ki_bvariant_initial_{grp}  (* (* Ki_bvariant_initial_{grp} @bvariant_infectivity@)  (* @bvariant_fracinfect@ {(1 / (len(intervention_dates)) * i)} ))))' for grp in self.grpList])
                     temp_str = temp_str + f'))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
 

--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -1002,7 +1002,6 @@ class covidModel:
             emodl_str = emodl_str + emodl_param_initial + emodl_timeevents
             return emodl_str
 
-
         def write_vaccine():
             emodl_str = ';COVID-19 vaccine scenario\n'
             read_from_csv = intervention_param['read_from_csv']
@@ -1052,35 +1051,40 @@ class covidModel:
                 df = pd.read_csv(os.path.join("./experiment_configs", 'input_csv', csvfile))
                 intervention_dates = list(df['Date'].values)
                 fracinfect = list(df['variant_freq'].values)
-                emodl_param = ''.join([f'(param Ki_bvariant_{i}_{grp} '
-                                       f'(* Ki_{grp} @bvariant_infectivity@ ' \
-                                       f'{fracinfect[i - 1]}' \
-                                       f'))\n' for i, date in enumerate(intervention_dates, 1) for grp in self.grpList])
 
                 fracinfect_timevent = ''.join([f'(time-event bvariant_fracinfect {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} '
                                                f'((bvariant_fracinfect {fracinfect[i - 1]})))\n'
                                                for i, date in enumerate(intervention_dates, 1)])
 
+                emodl_timeevents = ''
+                for i, date in enumerate(intervention_dates, 1):
+                    temp_str = f'(time-event ki_bvariant_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} ( + Ki_{grp}  (* (* Ki_{grp} 0.5)  (* @bvariant_fracinfect@ {fracinfect[i - 1]} ))))' for grp in self.grpList])
+                    temp_str = temp_str + f'))\n'
+                    emodl_timeevents = emodl_timeevents + temp_str
+
             else:
                 n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='bvariant')
-
-                emodl_param = ''.join([f'(param Ki_bvariant_{i}_{grp} '
-                                       f'(* Ki_{grp} @bvariant_infectivity@ ' \
-                                       f'(* @bvariant_fracinfect@ {(1 / (len(intervention_dates)) * i)}))' \
-                                       f')\n' for i, date in enumerate(intervention_dates, 1) for grp in self.grpList])
 
                 fracinfect_timevent = ''.join([f'(time-event bvariant_fracinfect {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)}'
                                                f' ((bvariant_fracinfect (* @bvariant_fracinfect@ '
                                                f'{(1 / (len(intervention_dates)) * i)})))'
                                                f')\n' for i, date in enumerate(intervention_dates, 1)])
 
-            emodl_timeevents = ''
-            for i, date in enumerate(intervention_dates, 1):
-                temp_str = f'(time-event ki_bvariant_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                temp_str = temp_str + ''.join([f' (Ki_{grp} Ki_bvariant_{i}_{grp})' for grp in self.grpList])
-                temp_str = temp_str + f'))\n'
-                emodl_timeevents = emodl_timeevents + temp_str
-            bvariant_infectivity = emodl_param + emodl_timeevents
+
+                emodl_param = ''.join([ f'(param Ki_bvariant_initial_{grp} 0)\n'
+                                        f'(time-event ki_bvariant_initial {covidModel.DateToTimestep(pd.Timestamp(intervention_dates[0])-pd.Timedelta(2,"days"), self.startdate)} ('
+                                        f'(Ki_bvariant_initial_{grp} Ki_{grp})'
+                                        f'))\n ' for grp in self.grpList])
+
+                emodl_timeevents = ''
+                for i, date in enumerate(intervention_dates, 1):
+                    temp_str = f'(time-event ki_bvariant_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} ( + Ki_bvariant_initial_{grp}  (* (* Ki_bvariant_initial_{grp} 0.5)  (* @bvariant_fracinfect@ {(1 / (len(intervention_dates)) * i)} ))))' for grp in self.grpList])
+                    temp_str = temp_str + f'))\n'
+                    emodl_timeevents = emodl_timeevents + temp_str
+
+            bvariant_infectivity =  emodl_param + emodl_timeevents
 
             """keep track of fracinfect, and use for update symptom development reactions"""
             fracinfect_str = '(param bvariant_fracinfect 0)\n' \
@@ -1136,11 +1140,16 @@ class covidModel:
                 n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='rollback')
                 perc_rollback = ['@rollback_multiplier@' for _ in range(len(intervention_dates))]
 
+            emodl_param = ''.join([ f'(param Ki_rollback_initial_{grp} 0)\n'
+                                    f'(time-event ki_rollback_initial_ {covidModel.DateToTimestep(pd.Timestamp(intervention_dates[0])-pd.Timedelta(2,"days"), self.startdate)} ('
+                                    f'(Ki_rollback_initial_{grp} Ki_{grp})'
+                                    f'))\n ' for grp in self.grpList])
+
             if rollback_relative_to_initial:
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event ki_rollback_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                    temp_str = temp_str + ''.join([f' (Ki_{grp} (- Ki_{grp} (* {perc_rollback[i - 1]} (- @Ki_{grp}@ Ki_{grp} ))))' for grp in self.grpList ])
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} (- Ki_rollback_initial_{grp} (* {perc_rollback[i - 1]} (- @Ki_{grp}@ Ki_rollback_initial_{grp} ))))' for grp in self.grpList ])
                     temp_str = temp_str + f'))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
 
@@ -1148,11 +1157,11 @@ class covidModel:
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event ki_rollback_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                    temp_str = temp_str + ''.join([f' (Ki_{grp} (- Ki_{grp} (* {perc_rollback[i - 1]}  Ki_{grp})))' for grp in self.grpList ])
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} (- Ki_rollback_initial_{grp} (* {perc_rollback[i - 1]}  Ki_rollback_initial_{grp})))' for grp in self.grpList ])
                     temp_str = temp_str + f'))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
 
-            emodl_str = emodl_str + emodl_timeevents
+            emodl_str = emodl_str + emodl_param + emodl_timeevents
 
             return emodl_str
 
@@ -1211,11 +1220,17 @@ class covidModel:
                 n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='reopen')
                 perc_reopen = ['@reopen_multiplier@' for _ in range(len(intervention_dates))]
 
+            emodl_param = ''.join([ f'(param Ki_reopen_initial_{grp} 0)\n'
+                                    f'(time-event ki_reopen_initial_ {covidModel.DateToTimestep(pd.Timestamp(intervention_dates[0])-pd.Timedelta(2,"days"), self.startdate)} ('
+                                    f'(Ki_reopen_initial_{grp} Ki_{grp})'
+                                    f'))\n ' for grp in self.grpList])
+
+
             if reopen_relative_to_initial:
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event ki_reopen_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                    temp_str = temp_str + ''.join([f' (Ki_{grp} (+ Ki_{grp} (* {perc_reopen[i - 1]} (- @Ki_{grp}@ Ki_{grp} ))))' for grp in self.grpList ])
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} (+ Ki_reopen_initial_{grp} (* {perc_reopen[i - 1]} (- @Ki_{grp}@ Ki_reopen_initial_{grp}))))' for grp in self.grpList ])
                     temp_str = temp_str + f'))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
 
@@ -1223,11 +1238,11 @@ class covidModel:
                 emodl_timeevents = ''
                 for i, date in enumerate(intervention_dates, 1):
                     temp_str = f'(time-event ki_reopen_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} ('
-                    temp_str = temp_str + ''.join([f' (Ki_{grp} (+ Ki_{grp} (* {perc_reopen[i - 1]}  Ki_{grp})))' for grp in self.grpList ])
+                    temp_str = temp_str + ''.join([f' (Ki_{grp} (+ Ki_reopen_initial_{grp} (* {perc_reopen[i - 1]}  Ki_reopen_initial_{grp})))' for grp in self.grpList ])
                     temp_str = temp_str + f'))\n'
                     emodl_timeevents = emodl_timeevents + temp_str
 
-            emodl_str = emodl_str + emodl_timeevents
+            emodl_str = emodl_str + emodl_param + emodl_timeevents
 
             return emodl_str
 

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -300,9 +300,10 @@ intervention_parameters:
   ###------------------------------------------------  
   ### ---- B.1.1.7 Variant  ----------------------
   ### Relative increase in transmission and severity due to COVID-19 B variant
+  ### here i.e. 50% increase = 0.5, not 1.5
   'bvariant_infectivity':
     np: linspace
-    function_kwargs: {'start':1.5, 'stop':1.5}
+    function_kwargs: {'start':0.5, 'stop':0.5}
   ### Fraction of the population infected with COVID-19 B variant  
   'bvariant_fracinfect':
     np: linspace
@@ -310,7 +311,8 @@ intervention_parameters:
     #function_kwargs: {'start':0.5, 'stop':0.5}
     #function_kwargs: {'start':0.75, 'stop':0.75}
     #function_kwargs: {'start':0.25, 'stop':0.75, 'num' : 3}
-  ### Relative increase in fraction severe due to COVID-19 B variant  
+  ### Relative increase in fraction severe due to COVID-19 B variant
+  ### Here 50% increase = 1.5
   'bvariant_severity':
     np: linspace
     function_kwargs: {'start':1.5, 'stop':1.5}

--- a/experiment_configs/intervention_emodl_config.yaml
+++ b/experiment_configs/intervention_emodl_config.yaml
@@ -8,7 +8,8 @@ time_varying_parameter:
   'n_recovery_time_hosp_change': 1
 interventions:
   'n_gradual_steps': 8
-  'rollback_relative_to_initial': True
+  'rollback_relative_to_initial': False
+  'rollback_regionspecific': False
   'reopen_relative_to_initial': False
   'reopen_regionspecific': False
   'trigger_channel': 'crit_det'


### PR DESCRIPTION
**- Bugfix in emodl for gradual change in future Ki scenarios** 

```
(param Ki_red8 (* Ki @ki_multiplier_8@))
(time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki Ki_red8)))
```
behaves differently from
`(time-event ki_multiplier_change_8 @ki_multiplier_time_8@ ((Ki (* Ki @ki_multiplier_8@))))`

therefore either use parameter change directly in time event or if not applicable, use another time event to write out value of the parameter before changing

```
(param Ki_bvariant_initial_EMS_1 0)
(time-event ki_bvariant_initial 399 ((Ki_bvariant_initial_EMS_1 Ki_EMS_1)))
```

**- corrected bvariant transmission increase equation**
using` current_ki+((current_ki*bvariant_infectivity)*bvariant_fracinfect)`
with `bvariant_infectivity`= 0.5, `bvariant_fracinfect `varying over time from 0 to target prevalence
(same as `current_ki-(current_ki-(current_ki*bvariant_infectivity))*bvariant_fracinfect` when using `bvariant_fracinfect`=1.5


example plot on [Box](https://northwestern.box.com/s/9v0g5p8wopssqz6uvz4n3t8norwf03op)

