### PR TITLE
dotenv , yamlorderredditloader  workaround

### DIFF
--- a/load_paths.py
+++ b/load_paths.py
@@ -11,33 +11,8 @@ def load_box_paths(user_path=None, Location='Local'):
         exe_dir = os.path.join(user_path,'covidproject', 'binaries', 'compartments')
 
     else:
-        from dotenv import load_dotenv
-        load_dotenv()
-        home_path = os.getenv("HOME_PATH")
-        data_path = os.getenv("DATA_PATH")
-        project_path = os.getenv("PROJECT_PATH")
-        wdir = os.getenv("WDIR")
-        exe_dir = os.getenv("EXE_DIR")
-        git_dir = os.getenv("GIT_DIR")
-
         if not user_path:
             user_path = os.path.expanduser('~')
-
-        if 'garrett' in user_path:
-            # user_path= 'C:/Users/geickelb1'
-            ## idk where to put datapath since i don't have access to NU-malaria-team
-            data_path = os.path.join(user_path, 'Box', 'data')
-            project_path = os.path.join(user_path, 'Box', 'covid_chicago')  # was origionally project_path
-            wdir = os.path.join(user_path, 'Box', 'covid_chicago', 'cms_sim')
-            exe_dir = os.path.join(user_path, 'Box', 'compartments')
-            git_dir = os.path.join(user_path, 'Documents', 'GitHub', 'covid-chicago')
-
-        if 'patri' in user_path:
-            data_path = os.path.join(user_path, 'Box Sync')
-            project_path = os.path.join(user_path, 'Box Sync', 'covid_chicago')  # was origionally project_path
-            wdir = os.path.join(user_path, 'Box Sync', 'covid_chicago', 'cms_sim')
-            exe_dir = os.path.join(user_path, 'Box Sync', 'compartments')
-            git_dir = os.path.join(user_path, 'Documents', 'GitHub', 'covid-chicago')
 
         if 'tmh6260' in user_path:
             data_path = os.path.join(user_path, 'Box Sync')
@@ -47,45 +22,60 @@ def load_box_paths(user_path=None, Location='Local'):
             exe_dir = os.path.join(user_path, 'Box Sync', 'compartments')
             git_dir = os.path.join(user_path, 'Documents', 'GitHub', 'covid-chicago')
 
-
-        else:
-
-            if 'jlg1657' in user_path:
-                git_dir = os.path.join('C:/Users/jlg1657', 'Documents/covid-chicago/')
-                # user_path = 'E:/'
-                home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
-                data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
-            if 'mrung' in user_path or 'mrm9534' in user_path and Location != "NUCLUSTER":
-                user_path = user_path
-                home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
-                data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
-                git_dir = os.path.join(user_path, 'gitrepos', 'covid-chicago/')
-            if 'geickelb1' in user_path:
-                # user_path = 'C:/Users/geickelb1'
-                home_path = os.path.join(user_path, 'Box')
-                # data_path = os.path.join(user_path, 'Box',  'data')
-                git_dir = os.path.join(user_path, 'Documents', 'Github', 'covid-chicago')
-            if 'Ibis' in user_path:
-                # user_path = r'\~/'
-                git_dir = os.path.join(user_path, 'Documents', 'GitHub', 'covid-chicago')
-                home_path = os.path.join(user_path, 'Box')
-                data_path = os.path.join(user_path, 'Box')
-                # project_path = os.path.join(home_path, 'Box', 'covid_chicago')
-            if 'HP1' in user_path:
-                # user_path = r'\~/'
-                git_dir = os.path.join(user_path, 'Documents', 'covid-chicago')
-                home_path = os.path.join(user_path, 'Box')
-                data_path = os.path.join(user_path, 'Box')
-                # project_path = os.path.join(home_path, 'Box', 'covid_chicago')
-            if 'aec7248' in user_path:
-                user_path = user_path
-                home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
-                data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
-                git_dir = os.path.join(user_path, 'Documents', 'covid-chicago/')
-
+        elif 'jlg1657' in user_path:
+            git_dir = os.path.join('C:/Users/jlg1657', 'Documents/covid-chicago/')
+            # user_path = 'E:/'
+            home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
+            data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
             project_path = os.path.join(home_path, 'covid_chicago')
             wdir = os.path.join(project_path, 'cms_sim')
             exe_dir = os.path.join(home_path, 'binaries', 'compartments')
+
+        elif 'mrung' in user_path or 'mrm9534' in user_path:
+            user_path = user_path
+            home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
+            data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
+            git_dir = os.path.join(user_path, 'gitrepos', 'covid-chicago/')
+            project_path = os.path.join(home_path, 'covid_chicago')
+            wdir = os.path.join(project_path, 'cms_sim')
+            exe_dir = os.path.join(home_path, 'binaries', 'compartments')
+
+        elif 'Ibis' in user_path:
+            # user_path = r'\~/'
+            git_dir = os.path.join(user_path, 'Documents', 'GitHub', 'covid-chicago')
+            home_path = os.path.join(user_path, 'Box')
+            data_path = os.path.join(user_path, 'Box')
+            project_path = os.path.join(home_path, 'covid_chicago')
+            wdir = os.path.join(project_path, 'cms_sim')
+            exe_dir = os.path.join(home_path, 'binaries', 'compartments')
+
+        elif 'HP1' in user_path:
+            # user_path = r'\~/'
+            git_dir = os.path.join(user_path, 'Documents', 'covid-chicago')
+            home_path = os.path.join(user_path, 'Box')
+            data_path = os.path.join(user_path, 'Box')
+            project_path = os.path.join(home_path, 'covid_chicago')
+            wdir = os.path.join(project_path, 'cms_sim')
+            exe_dir = os.path.join(home_path, 'binaries', 'compartments')
+
+        elif 'aec7248' in user_path:
+            user_path = user_path
+            home_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'projects')
+            data_path = os.path.join(user_path, 'Box', 'NU-malaria-team', 'data')
+            git_dir = os.path.join(user_path, 'Documents', 'covid-chicago/')
+            project_path = os.path.join(home_path, 'covid_chicago')
+            wdir = os.path.join(project_path, 'cms_sim')
+            exe_dir = os.path.join(home_path, 'binaries', 'compartments')
+
+        else:
+            from dotenv import load_dotenv
+            load_dotenv()
+            home_path = os.getenv("HOME_PATH")
+            data_path = os.getenv("DATA_PATH")
+            project_path = os.getenv("PROJECT_PATH")
+            wdir = os.getenv("WDIR")
+            exe_dir = os.getenv("EXE_DIR")
+            git_dir = os.getenv("GIT_DIR")
 
     return data_path, project_path, wdir, exe_dir, git_dir
 

--- a/load_paths.py
+++ b/load_paths.py
@@ -11,6 +11,8 @@ def load_box_paths(user_path=None, Location='Local'):
         exe_dir = os.path.join(user_path,'covidproject', 'binaries', 'compartments')
 
     else:
+        from dotenv import load_dotenv
+        load_dotenv()
         home_path = os.getenv("HOME_PATH")
         data_path = os.getenv("DATA_PATH")
         project_path = os.getenv("PROJECT_PATH")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-python-dotenv>=0.12
+#required
 PyYAML>=5.3
-yamlordereddictloader>0.4
 epyestim
-
 matplotlib==3.1.3
 more-itertools==8.2.0
 numpy==1.18.1
 pandas==1.0.1
 seaborn==0.10.0
+
+#optional for save yaml loading and loading environment variables
+yamlordereddictloader>0.4
+python-dotenv>=0.12

--- a/runScenarios.py
+++ b/runScenarios.py
@@ -9,10 +9,7 @@ import matplotlib as mpl
 import numpy as np
 import pandas as pd
 import yaml
-import yamlordereddictloader
 
-from dotenv import load_dotenv
-load_dotenv()
 
 from load_paths import load_box_paths
 from simulation_helpers import (DateToTimestep, cleanup, write_emodl,
@@ -391,7 +388,11 @@ def generateScenarios(simulation_population, Kivalues, duration, monitoring_samp
 
 
 def get_experiment_config(experiment_config_file):
-    config = yaml.load(open(os.path.join('./experiment_configs', args.masterconfig)), Loader=yamlordereddictloader.Loader)
+    try:
+        import yamlordereddictloader
+        config = yaml.load(open(os.path.join('./experiment_configs', args.masterconfig)), Loader=yamlordereddictloader.Loader)
+    except:
+        config = yaml.load(open(os.path.join('./experiment_configs', args.masterconfig)))
     yaml_file = open(os.path.join('./experiment_configs',experiment_config_file))
     expt_config = yaml.safe_load(yaml_file)
     for param_type, updated_params in expt_config.items():
@@ -400,7 +401,6 @@ def get_experiment_config(experiment_config_file):
         if updated_params:
             config[param_type].update(updated_params)
     return config
-
 
 def get_experiment_setup_parameters(experiment_config):
     return experiment_config['experiment_setup_parameters']


### PR DESCRIPTION
as described in this [issue ](https://app.zenhub.com/workspaces/covid-19-modeling-5e8b85bb090561fddfdc48ec/issues/numalariamodeling/covid-chicago/712) the `yamlorderredditloader `caused issue in some installations,
 in addition the `dotenv `module was difficult to install as well. `Dotenv `is only needed  in load_paths.py if no username specified  (or on specific systems?)

-> cleaned up load_paths.py
->added `try except `in runScenarios.py when loading yaml file, if   `yamlorderredditloader ` does not work, yaml files is loaded without a specified yaml loader.

Note  `yamlorderredditloader ` is disabled and better would be yamlloader, however since a virtual environment is being used on NUCLUSTER, no package change is made. 