### PR TITLE
Cleanup postprocessing_combine and NUcivis filecopy

### DIFF
--- a/plotters/Ki_plotter.py
+++ b/plotters/Ki_plotter.py
@@ -49,17 +49,18 @@ def plot_Ki(exp_name,first_day,last_day):
     grp_list, grp_suffix, grp_numbers = get_group_names(exp_path=sim_output_path)
     grp_list = [grp for grp in grp_list if grp !="All"]
 
-    column_list = base_list + [f'Ki_t_{grp}' for grp in grp_list ]
-    df = load_sim_data(exp_name, region_suffix=None, column_list=column_list)
-    df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
-
     fig = plt.figure(figsize=(16, 8))
     fig.subplots_adjust(right=0.97, left=0.05, hspace=0.4, wspace=0.2, top=0.95, bottom=0.05)
     palette = sns.color_palette('Set1', 12)
 
     for c, grp in enumerate(grp_list):
+        column_list = base_list + [f'Ki_t_{grp}']
+        df = load_sim_data(exp_name, region_suffix=f'_{grp}', column_list=column_list)
+        df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
+
+
         ax = fig.add_subplot(3, 4, c + 1)
-        mdf = df.groupby('date')[f'Ki_t_{grp}'].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
+        mdf = df.groupby('date')[f'Ki_t'].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
 
         ax.set_title(grp.replace('_EMS-', 'COVID-19 Region '))
         ax.plot(mdf['date'], mdf['CI_50'], color=palette[0])
@@ -89,12 +90,14 @@ def plot_Ki_compare(exp_names, labels, first_day, last_day):
 
     palette = sns.color_palette('Set1', 12)
 
-    column_list = base_list + [f'Ki_t_{grp}' for grp in grp_list]
+
     for e, exp_name in enumerate(exp_names):
-        df = load_sim_data(exp_name, region_suffix=None, column_list=column_list)
-        df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
 
         for c, grp in enumerate(grp_list):
+            column_list = base_list +[ f'Ki_t_{grp}']
+            df = load_sim_data(exp_name, region_suffix=f'_{grp}', column_list=column_list)
+            df = df[df['date'].between(pd.Timestamp(first_day), pd.Timestamp(last_day))]
+
             ax = axes[c]
             mdf = df.groupby('date')[f'Ki_t_{grp}'].agg([CI_50, CI_2pt5, CI_97pt5, CI_25, CI_75]).reset_index()
 

--- a/plotters/NUcivis_filecopy.py
+++ b/plotters/NUcivis_filecopy.py
@@ -33,18 +33,12 @@ def createFolder(output_dir):
         os.makedirs(output_dir)
     if not os.path.exists(os.path.join(output_dir, "plots")):
         os.makedirs(os.path.join(output_dir, "plots"))
-    if not os.path.exists(os.path.join(output_dir, "csv")):
-        os.makedirs(os.path.join(output_dir, "csv"))
-    if not os.path.exists(os.path.join(output_dir, "trajectories")):
-        os.makedirs(os.path.join(output_dir, "trajectories"))
 
 def copyFiles(output_dir):
     fname1 = f'nu_{simdate}.csv'
     fname2 = f'nu_hospitaloverflow_{simdate}.csv'
-    fname3 = f'trajectoriesDat_{exp_scenario}.csv'
-    shutil.copyfile(os.path.join(exp_dir, fname1), os.path.join(output_dir,'csv', fname1))
-    shutil.copyfile(os.path.join(exp_dir, fname2), os.path.join(output_dir,'csv', fname2))
-    shutil.copyfile(os.path.join(exp_dir, 'trajectoriesDat.csv'), os.path.join(output_dir,'trajectories', fname3))
+    shutil.copyfile(os.path.join(exp_dir, fname1), os.path.join(output_dir, fname1))
+    shutil.copyfile(os.path.join(exp_dir, fname2), os.path.join(output_dir, fname2))
 
     filelist= [file for file in os.listdir(os.path.join(exp_dir, '_plots')) if file.endswith('.png')]
     for file in filelist :
@@ -64,7 +58,7 @@ def subset_df(fname, regions_to_keep, output_dir,save_dir=None):
     df.to_csv(os.path.join(save_dir, fname))
 
 
-def writeChangelog(output_dir,A1=None,A2=None, A3=None, A4=None, A5=None, A6=None):
+def writeChangelog(output_dir,A1=None,A2=None, A3=None, A4=None, A5=None, A6=None, A7=None, A8=None):
     Q1 = "1) How has the date range of data used changed since your last update?"
     Q2 = "2) How have data sources changed since your last update?"
     Q3 = "3) What important changes have you made in your methodology since the last update?"
@@ -73,26 +67,23 @@ def writeChangelog(output_dir,A1=None,A2=None, A3=None, A4=None, A5=None, A6=Non
     Q5 = "5) Relevant time events in the simulations"
     Q6 = "6) Bvariant: "
     Q7 = "7) Vaccinations: "
-    Q7 = "8) Future scenarios: "
+    Q8 = "8) Future scenarios: "
 
     if A1 == None :A1 = "- another week of EMResource and LL data"
     if A2 == None :A2 = "- same as last week, also using CLI admissions for validation"
-    if A3 == None :A3 = "- updated fitting "
+    if A3 == None :A3 = "- updated fitting, , included bvariant (see 6)), adjusted latest transmission rate multiplier to account for the stagnating trend in data "
     if A4 == None :A4 = "..."
     if os.path.exists(os.path.join(exp_dir, f'traces_ranked_region_11.csv')):
         A4 = A4 + "\n Note: using the 25% if the simulation trajectories that best fit the data"
     if A5 == None :  A5 = "- Reduction in transmission rate due to 'shelter in place policies': " \
                           "2020-03-12, 2020-03-17, 2020-03-21, 2020-04-21" \
-                          "\n- Change in transmission rate during reopening period : " \
-                          "2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20 " \
-                           "2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20," \
-                            "2021-02-15 ,2021-03-15  "\
+                          "\n- Change in transmission rate during reopening period : 2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20 2020-06-21 ,2020-07-25, 2020-08-25 , 2020-09-17, 2020-10-10, 2020-11-07, 2020-12-20, 2021-01-20, 2021-02-15 ,2021-03-07, 2021-04-07  "\
                           "\n- Increase in detection rates/ decrease in fraction dead: monthly between March to Oct/Dec 2020"
-    if A6 == None : A6 = \ "- bvariant not included in historical fit but in future projections with higher infectiousness and severity for a fraction of the population, reaching 25% by May"
-    if A7 == None : A7 = \ "- added vaccination, assuming current trend in daily vaccinations to continue until end of 2021 " \
-                          "\n- assume that vaccinations reduce mild infections by 20% severe symptoms by 95%, and infectiousness by 90% for the vaccinated population (all ages)" \
-                          "\n- added a 85% reduction in severe infections for those not vaccinated,  time-varying and depending on the fraction of pop aged > 65 vaccinated (1st dose)" \
-    if A8 == None : A8 = "- No additional scenarios"
+    if A6 == None : A6 = "\n- bvariant not included in historical fit but in future projections with higher infectiousness and severity for a fraction of the population, reaching 25% by May"
+    if A7 == None : A7 = "\n- added vaccination, assuming current trend in daily vaccinations to continue until end of 2021 " \
+                         "\n- assume that vaccinations reduce mild infections by 20% severe symptoms by 95%, and infectiousness by 90% for the vaccinated population (all ages)" \
+                         "\n- added a 85% reduction in severe infections for those not vaccinated,  time-varying and depending on the fraction of pop aged > 65 vaccinated (1st dose)"
+    A8 = "- No additional scenarios"
 
     file = open(os.path.join(output_dir, 'changelog.txt'), 'w')
     file.write(f'Northwestern University COVID-19 Modelling Team \n\n Date: {simdate} \n\n '

--- a/plotters/NUcivis_filecopy.py
+++ b/plotters/NUcivis_filecopy.py
@@ -33,12 +33,14 @@ def createFolder(output_dir):
         os.makedirs(output_dir)
     if not os.path.exists(os.path.join(output_dir, "plots")):
         os.makedirs(os.path.join(output_dir, "plots"))
+    if not os.path.exists(os.path.join(output_dir, "csv")):
+        os.makedirs(os.path.join(output_dir, "csv"))
 
 def copyFiles(output_dir):
     fname1 = f'nu_{simdate}.csv'
     fname2 = f'nu_hospitaloverflow_{simdate}.csv'
-    shutil.copyfile(os.path.join(exp_dir, fname1), os.path.join(output_dir, fname1))
-    shutil.copyfile(os.path.join(exp_dir, fname2), os.path.join(output_dir, fname2))
+    shutil.copyfile(os.path.join(exp_dir, fname1), os.path.join(output_dir,'csv', fname1))
+    shutil.copyfile(os.path.join(exp_dir, fname2), os.path.join(output_dir,'csv', fname2))
 
     filelist= [file for file in os.listdir(os.path.join(exp_dir, '_plots')) if file.endswith('.png')]
     for file in filelist :

--- a/plotters/estimate_Rt_forCivisOutputs.py
+++ b/plotters/estimate_Rt_forCivisOutputs.py
@@ -15,10 +15,10 @@ import epyestim
 import epyestim.covid19 as covid19
 import seaborn as sns
 
+from estimate_Rt_trajectores import *
 sys.path.append('../')
 from load_paths import load_box_paths
 from processing_helpers import *
-from estimate_Rt_trajectores import *
 
 mpl.rcParams['pdf.fonttype'] = 42
 

--- a/plotters/postprocessing_combine_regions.py
+++ b/plotters/postprocessing_combine_regions.py
@@ -196,17 +196,26 @@ def copy_regional_plots(exp_names):
         plot_path = os.path.join(wdir, 'simulation_output', exp_name, '_plots')
 
         filelist = [f for f in os.listdir(os.path.join(plot_path)) if f.endswith('.png')]
-        # filelist = [f for f in filelist if "covidregion" in f]
+        filelist = [f for f in filelist if "covidregion_" in f or  "EMS-" in f]
         for file in filelist:
             shutil.copyfile(os.path.join(plot_path, file), os.path.join(plot_path_new, file))
 
+
+def replace_stem(submission_file):
+    fin = open(submission_file, "rt")
+    txt = fin.read()
+    fin.close()
+    txt = txt.replace(f'{exp_names[0]}', f'{exp_name_new}')
+    fin = open(submission_file, "w")
+    fin.write(txt)
+    fin.close()
 
 if __name__ == '__main__':
 
     args = parse_args()
     custom_exp_names = False
     if custom_exp_names:
-        exp_name_new = '20210429_IL_ae_v8_MRtest'
+        exp_name_new = '20210428_IL_ae_combined_bvariant_vaccine'
         exp_names = ['20210428_IL_localeEMS_1_ae_v3_bvariant_vaccine',
                      '20210429_IL_localeEMS_2_ae_v5_bvariant_vaccine',
                      '20210429_IL_localeEMS_3_ae_v6_bvariant_vaccine',
@@ -236,15 +245,18 @@ if __name__ == '__main__':
         os.makedirs(os.path.join(sim_output_path_new, 'sh'))
         os.makedirs(os.path.join(sim_output_path_new, 'bat'))
 
+    """Move sh or bat files"""
     filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh')) if f.endswith('.sh')]
     for file in filelist:
         shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh', file),
                         os.path.join(sim_output_path_new, 'sh', file))
-    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat')) if
-                f.endswith('.bat')]
+        replace_stem(submission_file= os.path.join(sim_output_path_new, 'sh', file) )
+
+    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat')) if f.endswith('.bat')]
     for file in filelist:
         shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat', file),
                         os.path.join(sim_output_path_new, 'bat', file))
+        replace_stem(submission_file= os.path.join(sim_output_path_new, 'bat', file))
 
     print("Running copy_traces")
     copy_traces(exp_names)

--- a/plotters/postprocessing_combine_regions.py
+++ b/plotters/postprocessing_combine_regions.py
@@ -197,6 +197,7 @@ def copy_regional_plots(exp_names):
 
         filelist = [f for f in os.listdir(os.path.join(plot_path)) if f.endswith('.png')]
         filelist = [f for f in filelist if "covidregion_" in f or  "EMS-" in f]
+        filelist = [f for f in filelist if "rt_" not in f ]
         for file in filelist:
             shutil.copyfile(os.path.join(plot_path, file), os.path.join(plot_path_new, file))
 
@@ -209,6 +210,22 @@ def replace_stem(submission_file):
     fin = open(submission_file, "w")
     fin.write(txt)
     fin.close()
+
+def copy_submission_files():
+    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh')) if f.endswith('.sh')]
+    for file in filelist:
+        shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh', file), os.path.join(sim_output_path_new, 'sh', file))
+        replace_stem(submission_file=os.path.join(sim_output_path_new, 'sh', file))
+
+    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0])) if f.endswith('.sh')]
+    for file in filelist:
+        shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], file), os.path.join(sim_output_path_new, file))
+        replace_stem(submission_file=os.path.join(sim_output_path_new, file))
+
+    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat')) if  f.endswith('.bat')]
+    for file in filelist:
+        shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat', file), os.path.join(sim_output_path_new, 'bat', file))
+        replace_stem(submission_file=os.path.join(sim_output_path_new, 'bat', file))
 
 if __name__ == '__main__':
 
@@ -246,17 +263,8 @@ if __name__ == '__main__':
         os.makedirs(os.path.join(sim_output_path_new, 'bat'))
 
     """Move sh or bat files"""
-    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh')) if f.endswith('.sh')]
-    for file in filelist:
-        shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'sh', file),
-                        os.path.join(sim_output_path_new, 'sh', file))
-        replace_stem(submission_file= os.path.join(sim_output_path_new, 'sh', file) )
-
-    filelist = [f for f in os.listdir(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat')) if f.endswith('.bat')]
-    for file in filelist:
-        shutil.copyfile(os.path.join(wdir, 'simulation_output', exp_names[0], 'bat', file),
-                        os.path.join(sim_output_path_new, 'bat', file))
-        replace_stem(submission_file= os.path.join(sim_output_path_new, 'bat', file))
+    print("Running copy_submission_files")
+    copy_submission_files()
 
     print("Running copy_traces")
     copy_traces(exp_names)


### PR DESCRIPTION
- postprocessing_combine_regions requires 11 separate region experiments, (combining grouped regional experiments would need further adjustments)
- all postprocessing submission (sh or bat) are copied into the new folder and experiment name (or stem) replaced with the new name to facilitate re-running postprocessing on the combined folder
- note most postprocessing and plotters all can run with regional trajectories csvs, trajectoriesDat.csv not needed (except in some less frequently used plotters)
-  trajectoriesDat_region_0.csv sums over  trajectoriesDat_region_1.csv to trajectoriesDat_region_11.csv , already using trace selection, as for each regional experiment the scen_num and sample_num will differ! (reset to count from 1 to n selected traces)
- cleanup of NUcivis filecopy