### PR TITLE
save_ranked_sample_parameters per region, added nsamples to runScenarios.py

### DIFF
--- a/plotters/extract_sample_param.py
+++ b/plotters/extract_sample_param.py
@@ -251,6 +251,6 @@ if __name__ == '__main__':
         ## Save samples ranked in order of trace selection (fitting performance)
         save_ranked_samples_per_region(sim_output_path,git_dir, grp_list, n_traces_to_keep=None,save_to_git=False)
 
-        ### Plot samples (all)
-        #extract_samples(grp_numbers,save_dir=None, plot_dists=True, include_grp_param=True)
-        #extract_mean_of_samples(grp_numbers, save_dir=None, plot_dists=False, include_grp_param=True)
+        grp_numbers = [nr for nr in grp_numbers if nr != 0]
+        extract_samples(grp_numbers,save_dir=None, plot_dists=True, include_grp_param=True)
+        extract_mean_of_samples(grp_numbers, save_dir=None, plot_dists=False, include_grp_param=True)

--- a/plotters/extract_sample_param.py
+++ b/plotters/extract_sample_param.py
@@ -249,7 +249,7 @@ if __name__ == '__main__':
         #grp_numbers = [x for x in grp_numbers if x !=0]
 
         ## Save samples ranked in order of trace selection (fitting performance)
-        save_ranked_samples_per_region(sim_output_path,git_dir, grp_list, n_traces_to_keep=3,save_to_git=False)
+        save_ranked_samples_per_region(sim_output_path,git_dir, grp_list, n_traces_to_keep=None,save_to_git=False)
 
         ### Plot samples (all)
         #extract_samples(grp_numbers,save_dir=None, plot_dists=True, include_grp_param=True)


### PR DESCRIPTION
 - added `save_ranked_samples_per_region `function, repurposed the `extract_sample_param.py` script (histograms can still be generated and mean parameter value extracted using `extract_samples `and `extract_mean_of_samples`, but in most instances not needed
 - added `nsamples `to runScenarios when reading in a csv and wanting to select a subset of samples

Note, sample parameter csv files per region are too large to be added to the experiment_config/input_csv folder , hence added to Box under `\covid_chicago\cms_sim\input_csv` and can be copied from there (not done automatically)