### PR TITLE
added bvariant2 to emodl_generator

### DIFF
--- a/emodl_generators/emodl_generator_locale.py
+++ b/emodl_generators/emodl_generator_locale.py
@@ -656,6 +656,58 @@ class covidModel:
             reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (* Kv_{grp} S::{grp}))\n'
             reaction_str_I = reaction_str_I + reaction_str_Ia + reaction_str_Ib
 
+        if 'bvariant2' in self.add_interventions:
+
+            reaction_str_Ic = f'\n(reaction exposure_{grp}   (S::{grp}) (E::{grp}) (* Ki_{grp} S::{grp} ' \
+                              f'(/ (+ (* infectious_undet_symp_{grp} (- 1 bvariant_fracinfect) )' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As (- 1 bvariant_fracinfect) ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_undet_symp_{grp} bvariant_fracinfect @bvariant_infectivity@ )  ' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@)  ) N_{grp} )))\n'
+
+            reaction_str_Id = f'\n(reaction exposure_{grp}   (S::{grp}) (E::{grp}) (* Ki_{grp} S::{grp} ' \
+                              f'(/ (+ (* infectious_undet_symp_{grp} (- 1 bvariant_fracinfect) )' \
+                              f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V (- 1 bvariant_fracinfect) ) ' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As (- 1 bvariant_fracinfect) ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases (- 1 bvariant_fracinfect))' \
+                              f'(* infectious_undet_symp_{grp} bvariant_fracinfect @bvariant_infectivity@ )  ' \
+                              f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@) ' \
+                              f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases bvariant_fracinfect  @bvariant_infectivity@) ' \
+                              f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@)) N_{grp} )))\n'
+
+            reaction_str_Ie = f'\n(reaction exposure_{grp}   (S_V::{grp}) (E_V::{grp}) (* Ki_{grp} S_V::{grp} ' \
+                              f'(/ (+ (* infectious_undet_symp_{grp} (- 1 bvariant_fracinfect) )' \
+                              f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V (- 1 bvariant_fracinfect) ) ' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As (- 1 bvariant_fracinfect) ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases (- 1 bvariant_fracinfect)) ' \
+                              f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases (- 1 bvariant_fracinfect))' \
+                              f'(* infectious_undet_symp_{grp} bvariant_fracinfect @bvariant_infectivity@ )  ' \
+                              f'(* (+ infectious_undet_symp_V_{grp} infectious_undet_As_V_{grp} ) reduced_infectious_V bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_undet_As_{grp} reduced_infectious_As bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_symp_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@ ) ' \
+                              f'(* infectious_det_AsP_{grp} reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@) ' \
+                              f'(* infectious_det_symp_V_{grp} reduced_infectious_V reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@) ' \
+                              f'(* infectious_det_AsP_V_{grp} reduced_infectious_V reduced_inf_of_det_cases bvariant_fracinfect @bvariant_infectivity@)) N_{grp} )))\n'
+
+            if 'vaccine' not in self.add_interventions:
+                reaction_str_I = reaction_str_Ic
+
+            if 'vaccine' in self.add_interventions:
+                reaction_str_I = f'(reaction vaccination_{grp}  (S::{grp}) (S_V::{grp}) (* Kv_{grp} S::{grp}))\n'
+                reaction_str_I = reaction_str_I + reaction_str_Id + reaction_str_Ie
+
+
         reaction_str_III = f'(reaction recovery_H1_{grp} (H1::{grp}) (RH1::{grp}) (* Kr_h{grp} H1::{grp}))\n' \
                            f'(reaction recovery_C2_{grp} (C2::{grp}) (H2post::{grp}) (* Kr_c{grp} C2::{grp}))\n' \
                            f'(reaction recovery_H2post_{grp} (H2post::{grp}) (RC2::{grp}) (* Kr_hc H2post::{grp}))\n' \
@@ -1122,6 +1174,74 @@ class covidModel:
 
             return emodl_str
 
+        def write_bvariant2():
+            emodl_str = ';COVID-19 bvariant scenario\n'
+
+            csvfile = intervention_param['bvariant_csv']
+            if csvfile != "":
+                df = pd.read_csv(os.path.join("./experiment_configs", 'input_csv', csvfile))
+
+                fracinfect_timevent = ''
+                fracinfect_str = ''
+
+                intervention_dates = list(df['Date'].values)
+                fracinfect = list(df['variant_freq'].values)
+                if len(intervention_dates) != len(fracinfect):
+                    raise ValueError("intervention_dates not same lengths as fracinfect")
+
+                fracinfect_str = f'(param bvariant_fracinfect 0)\n(observe bvariant_fracinfect_t bvariant_fracinfect)\n'
+
+                fracinfect_timevent = ''.join([f'(time-event bvariant_fracinfect_change {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} '
+                                                 f'((bvariant_fracinfect {fracinfect[i - 1]})))\n'
+                                                 for i, date in enumerate(intervention_dates, 1)])
+
+                fracinfect_str = fracinfect_str + fracinfect_timevent
+
+            else:
+                n_gradual_steps, intervention_dates = covidModel.get_intervention_dates(intervention_param,scen='bvariant')
+
+                fracinfect_timevent = ''.join([f'(time-event bvariant_fracinfect {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)}'
+                                               f' ((bvariant_fracinfect (* @bvariant_fracinfect@ '
+                                               f'{(1 / (len(intervention_dates)) * i)})))'
+                                               f')\n' for i, date in enumerate(intervention_dates, 1)])
+
+                fracinfect_str = '(param bvariant_fracinfect 0)\n' \
+                                 '(observe bvariant_fracinfect_t bvariant_fracinfect)\n' + fracinfect_timevent
+
+            """fraction severe adjustment over time"""
+            frac_severe_timevent = ''.join([f'(time-event fraction_severe_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} '
+                                            f'('
+                                            f'(fraction_severe (+ '
+                                            f'(* @fraction_severe@ (- 1 bvariant_fracinfect)) '
+                                            f'(* fraction_severeB  bvariant_fracinfect )  '
+                                            f')) '
+                                            f'(Ksys ( * fraction_severe (/ 1 time_to_symptoms))) '
+                                            f'(Ksym ( * (- 1 fraction_severe)(/ 1 time_to_symptoms)))'
+                                            f')'
+                                            f')\n' for i, date in enumerate(intervention_dates, 1)])
+
+            frac_severe_str = '(param fraction_severeB (* @fraction_severe@ @bvariant_severity@))\n' + frac_severe_timevent
+            if 'vaccine' in self.add_interventions:
+                """fraction severe adjustment over time"""
+                frac_severeV_timevent = ''.join([f'(time-event fraction_severe_V_change{i} {covidModel.DateToTimestep(pd.Timestamp(date), self.startdate)} '
+                                                 f'('
+                                                 f'(fraction_severe_V (+ '
+                                                 f'(* @fraction_severe@ @reduced_fraction_Sys@ (- 1 bvariant_fracinfect)) '
+                                                 f'(* fraction_severeB @reduced_fraction_Sys@ bvariant_fracinfect )  '
+                                                 f')) '
+                                                 f'(KsysV ( * fraction_severe_V (/ 1 time_to_symptoms))) '
+                                                 f'(KsymV ( * (- 1 fraction_severe_V)(/ 1 time_to_symptoms)))'
+                                                 f')'
+                                                 f')\n' for i, date in enumerate(intervention_dates, 1)])
+
+                frac_severeV_str = '(observe fraction_severe_V_t fraction_severe_V)\n' + frac_severeV_timevent
+                frac_severe_str = frac_severe_str + frac_severeV_str
+
+
+            emodl_str = emodl_str +  fracinfect_str + frac_severe_str
+
+            return emodl_str
+
         def write_rollback():
             emodl_str = ';COVID-19 rollback scenario\n'
             rollback_regionspecific = intervention_param['rollback_regionspecific']
@@ -1217,8 +1337,10 @@ class covidModel:
 
         """Select intervention to add to emodl"""
         intervention_str = ""
-        if "bvariant" in self.add_interventions:
+        if "bvariant" in self.add_interventions and not "bvariant2" in self.add_interventions:
             intervention_str = intervention_str + write_bvariant()
+        if "bvariant2" in self.add_interventions:
+            intervention_str = intervention_str + write_bvariant2()
         if "rollback" in self.add_interventions and not "triggeredrollback" in self.add_interventions:
             intervention_str = intervention_str + write_rollback()
         if "triggeredrollback" in self.add_interventions:

--- a/experiment_configs/extendedcobey_200428.yaml
+++ b/experiment_configs/extendedcobey_200428.yaml
@@ -304,6 +304,7 @@ intervention_parameters:
   'bvariant_infectivity':
     np: linspace
     function_kwargs: {'start':0.5, 'stop':0.5}
+    #function_kwargs: {'start':1.5, 'stop':1.5}  #bvariant2
   ### Fraction of the population infected with COVID-19 B variant  
   'bvariant_fracinfect':
     np: linspace

--- a/runScenarios.py
+++ b/runScenarios.py
@@ -511,13 +511,15 @@ def parse_args():
         "--scenario",
         type=str,
         help=("Intervention scenario to use, default = baseline"
-              'Any combination of "baseline", "rollback","triggeredrollback", "reopen","bvariant", "vaccine"'
+              'Any combination of "baseline", "rollback","triggeredrollback", "reopen","bvariant","bvariant2", "vaccine"'
               'Separated by underscore, example: reopen_rollback '
               "For a full list please visit the GitHub readme"),
         choices=['baseline', 'rollback', 'reopen', 'triggeredrollback','rollback_reopen', 'triggeredrollback_reopen',
                  'vaccine', 'rollback_vaccine', 'reopen_vaccine', 'triggeredrollback_vaccine','rollback_reopen_vaccine', 'triggeredrollback_reopen_vaccine',
                  'bvariant', 'rollback_bvariant', 'reopen_bvariant', 'triggeredrollback_bvariant','rollback_reopen_bvariant', 'triggeredrollback_reopen_bvariant',
-                 'bvariant_vaccine', 'rollback_bvariant_vaccine', 'reopen_bvariant_vaccine', 'triggeredrollback_bvariant_vaccine','rollback_reopen_bvariant_vaccine', 'triggeredrollback_reopen_bvariant_vaccine'],
+                 'bvariant_vaccine', 'rollback_bvariant_vaccine', 'reopen_bvariant_vaccine', 'triggeredrollback_bvariant_vaccine','rollback_reopen_bvariant_vaccine', 'triggeredrollback_reopen_bvariant_vaccine',
+                 'bvariant2', 'rollback_bvariant2', 'reopen_bvariant2', 'triggeredrollback_bvariant2','rollback_reopen_bvariant2', 'triggeredrollback_reopen_bvariant2',
+                 'bvariant2_vaccine', 'rollback_bvariant2_vaccine', 'reopen_bvariant2_vaccine', 'triggeredrollback_bvariant2_vaccine','rollback_reopen_bvariant2_vaccine', 'triggeredrollback_reopen_bvariant2_vaccine'],
         default="baseline"
     )
     parser.add_argument(


### PR DESCRIPTION
- moved modified bvariant inetrvention from 'bvariant_prev' branch into emodl_generator, called bvariant2 
-  'bvariant_prev' branch deleted and reduced having different versions of the emodl_generator_locale
- `bvariant2  `differs from `bvariant` as it does not modify the Ki parameter, hence does not intervene with the monthly `ki_multiplier`, and is integrated directly in the exposure reaction
- however `bvariant2 `results in slightly different predictions and has not been fitted to data